### PR TITLE
Migrate SDP generation to Unified Plan

### DIFF
--- a/examples/gstreamer-receive/README.md
+++ b/examples/gstreamer-receive/README.md
@@ -14,7 +14,7 @@ go get github.com/pions/webrtc/examples/gstreamer-receive
 ```
 
 ### Open gstreamer-receive example page
-[jsfiddle.net](https://jsfiddle.net/pdm7bqfr/) you should see your Webcam, two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/8t2g5Lar/) you should see your Webcam, two text-areas and a 'Start Session' button
 
 ### Run gstreamer-receive with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/gstreamer-receive/jsfiddle/demo.html
+++ b/examples/gstreamer-receive/jsfiddle/demo.html
@@ -4,12 +4,14 @@ Browser base64 Session Description<br />
 
 Golang base64 Session Description<br />
 <textarea id="remoteSessionDescription"></textarea> <br/>
-<button onclick="window.startSession()"> Start Session </button><br />
+<button onclick="window.startSession()"> Start Session </button>
+<button onclick="window.addDisplayCapture()" id="displayCapture"> Display Capture </button><br />
 
 <br />
 
 Video<br />
-<video id="video1" width="160" height="120" autoplay muted></video> <br />
+<div id="localVideos"></div> <br />
+
 
 Logs<br />
 <div id="logs"></div>

--- a/examples/gstreamer-receive/jsfiddle/demo.js
+++ b/examples/gstreamer-receive/jsfiddle/demo.js
@@ -7,13 +7,24 @@ let pc = new RTCPeerConnection({
     }
   ]
 })
-var log = msg => {
+let log = msg => {
   document.getElementById('logs').innerHTML += msg + '<br>'
+}
+let displayVideo = video => {
+  var el = document.createElement('video')
+  el.srcObject = video
+  el.autoplay = true
+  el.muted = true
+  el.width = 160
+  el.height = 120
+
+  document.getElementById('localVideos').appendChild(el)
+  return video
 }
 
 navigator.mediaDevices.getUserMedia({ video: true, audio: true })
   .then(stream => {
-    pc.addStream(document.getElementById('video1').srcObject = stream)
+    pc.addStream(displayVideo(stream))
     pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
   }).catch(log)
 
@@ -35,4 +46,12 @@ window.startSession = () => {
   } catch (e) {
     alert(e)
   }
+}
+
+window.addDisplayCapture = () => {
+  navigator.mediaDevices.getDisplayMedia().then(stream => {
+    document.getElementById('displayCapture').disabled = true
+    pc.addStream(displayVideo(stream))
+    pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
+  })
 }

--- a/examples/gstreamer-receive/main.go
+++ b/examples/gstreamer-receive/main.go
@@ -32,6 +32,15 @@ func gstreamerReceiveMain() {
 		panic(err)
 	}
 
+	// Allow us to receive 1 audio track, and 2 video tracks
+	if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeAudio); err != nil {
+		panic(err)
+	} else if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeVideo); err != nil {
+		panic(err)
+	} else if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeVideo); err != nil {
+		panic(err)
+	}
+
 	// Set a handler for when a new remote track starts, this handler creates a gstreamer pipeline
 	// for the given codec
 	peerConnection.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {

--- a/examples/gstreamer-send-offer/main.go
+++ b/examples/gstreamer-send-offer/main.go
@@ -85,8 +85,8 @@ func main() {
 	}
 
 	// Start pushing buffers on these tracks
-	gst.CreatePipeline(webrtc.Opus, opusTrack, *audioSrc).Start()
-	gst.CreatePipeline(webrtc.VP8, vp8Track, *videoSrc).Start()
+	gst.CreatePipeline(webrtc.Opus, []*webrtc.Track{opusTrack}, *audioSrc).Start()
+	gst.CreatePipeline(webrtc.VP8, []*webrtc.Track{vp8Track}, *videoSrc).Start()
 
 	// Block forever
 	select {}

--- a/examples/gstreamer-send/README.md
+++ b/examples/gstreamer-send/README.md
@@ -14,7 +14,7 @@ go get github.com/pions/webrtc/examples/gstreamer-send
 ```
 
 ### Open gstreamer-send example page
-[jsfiddle.net](https://jsfiddle.net/Laf7ujeo/164/) you should see two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/z7ms3u5r/) you should see two text-areas and a 'Start Session' button
 
 ### Run gstreamer-send with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/gstreamer-send/jsfiddle/demo.js
+++ b/examples/gstreamer-send/jsfiddle/demo.js
@@ -27,7 +27,11 @@ pc.onicecandidate = event => {
   }
 }
 
-pc.createOffer({ offerToReceiveVideo: true, offerToReceiveAudio: true }).then(d => pc.setLocalDescription(d)).catch(log)
+// Offer to receive 1 audio, and 2 video tracks
+pc.addTransceiver('audio', {'direction': 'recvonly'})
+pc.addTransceiver('video', {'direction': 'recvonly'})
+pc.addTransceiver('video', {'direction': 'recvonly'})
+pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
 
 window.startSession = () => {
   let sd = document.getElementById('remoteSessionDescription').value

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -85,8 +85,8 @@ func main() {
 	fmt.Println(signal.Encode(answer))
 
 	// Start pushing buffers on these tracks
-	gst.CreatePipeline(webrtc.Opus, opusTrack, *audioSrc).Start()
-	gst.CreatePipeline(webrtc.VP8, vp8Track, *videoSrc).Start()
+	gst.CreatePipeline(webrtc.Opus, []*webrtc.Track{opusTrack}, *audioSrc).Start()
+	gst.CreatePipeline(webrtc.VP8, []*webrtc.Track{vp8Track}, *videoSrc).Start()
 
 	// Block forever
 	select {}

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -40,21 +40,31 @@ func main() {
 	})
 
 	// Create a audio track
-	opusTrack, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeOpus, rand.Uint32(), "audio", "pion1")
+	audioTrack, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeOpus, rand.Uint32(), "audio", "pion1")
 	if err != nil {
 		panic(err)
 	}
-	_, err = peerConnection.AddTrack(opusTrack)
+	_, err = peerConnection.AddTrack(audioTrack)
 	if err != nil {
 		panic(err)
 	}
 
 	// Create a video track
-	vp8Track, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
+	firstVideoTrack, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
 	if err != nil {
 		panic(err)
 	}
-	_, err = peerConnection.AddTrack(vp8Track)
+	_, err = peerConnection.AddTrack(firstVideoTrack)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a second video track
+	secondVideoTrack, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion3")
+	if err != nil {
+		panic(err)
+	}
+	_, err = peerConnection.AddTrack(secondVideoTrack)
 	if err != nil {
 		panic(err)
 	}
@@ -85,8 +95,8 @@ func main() {
 	fmt.Println(signal.Encode(answer))
 
 	// Start pushing buffers on these tracks
-	gst.CreatePipeline(webrtc.Opus, []*webrtc.Track{opusTrack}, *audioSrc).Start()
-	gst.CreatePipeline(webrtc.VP8, []*webrtc.Track{vp8Track}, *videoSrc).Start()
+	gst.CreatePipeline(webrtc.Opus, []*webrtc.Track{audioTrack}, *audioSrc).Start()
+	gst.CreatePipeline(webrtc.VP8, []*webrtc.Track{firstVideoTrack, secondVideoTrack}, *videoSrc).Start()
 
 	// Block forever
 	select {}

--- a/examples/janus-gateway/streaming/main.go
+++ b/examples/janus-gateway/streaming/main.go
@@ -68,6 +68,13 @@ func main() {
 		panic(err)
 	}
 
+	// Allow us to receive 1 audio track, and 1 video track
+	if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeAudio); err != nil {
+		panic(err)
+	} else if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeVideo); err != nil {
+		panic(err)
+	}
+
 	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
 	})

--- a/examples/janus-gateway/video-room/main.go
+++ b/examples/janus-gateway/video-room/main.go
@@ -146,8 +146,8 @@ func main() {
 		}
 
 		// Start pushing buffers on these tracks
-		gst.CreatePipeline(webrtc.Opus, opusTrack, "audiotestsrc").Start()
-		gst.CreatePipeline(webrtc.VP8, vp8Track, "videotestsrc").Start()
+		gst.CreatePipeline(webrtc.Opus, []*webrtc.Track{opusTrack}, "audiotestsrc").Start()
+		gst.CreatePipeline(webrtc.VP8, []*webrtc.Track{vp8Track}, "videotestsrc").Start()
 	}
 
 	select {}

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -61,6 +61,13 @@ func main() {
 		panic(err)
 	}
 
+	// Allow us to receive 1 audio track, and 1 video track
+	if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeAudio); err != nil {
+		panic(err)
+	} else if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeVideo); err != nil {
+		panic(err)
+	}
+
 	opusFile, err := opuswriter.New("output.opus", 48000, 2)
 	if err != nil {
 		panic(err)

--- a/examples/sfu-minimal/README.md
+++ b/examples/sfu-minimal/README.md
@@ -10,7 +10,7 @@ go get github.com/pions/webrtc/examples/sfu-minimal
 ```
 
 ### Open sfu-minimal example page
-[jsfiddle.net](https://jsfiddle.net/4g03uqrx/) You should see two buttons 'Publish a Broadcast' and 'Join a Broadcast'
+[jsfiddle.net](https://jsfiddle.net/zhpya3n9/) You should see two buttons 'Publish a Broadcast' and 'Join a Broadcast'
 
 ### Run SFU Minimal
 #### Linux/macOS

--- a/examples/sfu-minimal/jsfiddle/demo.js
+++ b/examples/sfu-minimal/jsfiddle/demo.js
@@ -27,7 +27,8 @@ window.createSession = isPublisher => {
           .catch(log)
       }).catch(log)
   } else {
-    pc.createOffer({ offerToReceiveVideo: true })
+    pc.addTransceiver('video', {'direction': 'recvonly'})
+    pc.createOffer()
       .then(d => pc.setLocalDescription(d))
       .catch(log)
 

--- a/examples/sfu-ws/sfu.html
+++ b/examples/sfu-ws/sfu.html
@@ -66,7 +66,7 @@ window.sendMessage = element => {
             return alert('Message must not be empty')
         }
         dataChannel.send(message)
-        element.value = '' 
+        element.value = ''
     }
 }
 
@@ -103,7 +103,10 @@ window.createSession = isPublisher => {
         document.getElementById('msginput').style = 'display: none'
         dataChannel = pc.createDataChannel('data')
         dataChannel.onmessage = e => log(`receive data from '${dataChannel.label}' payload '${e.data}'`)
-        pc.createOffer({ offerToReceiveVideo: true , offerToReceiveAudio: true})
+        pc.addTransceiver('audio', {'direction': 'recvonly'})
+        pc.addTransceiver('video', {'direction': 'recvonly'})
+
+        pc.createOffer()
             .then(d => pc.setLocalDescription(d))
             .catch(log)
 

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -4,6 +4,7 @@ package webrtc
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/pions/rtp"
 	"github.com/pions/rtp/codecs"
@@ -161,6 +162,18 @@ func (t RTPCodecType) String() string {
 		return "video"
 	default:
 		return ErrUnknownType.Error()
+	}
+}
+
+// NewRTPCodecType creates a RTPCodecType from a string
+func NewRTPCodecType(r string) RTPCodecType {
+	switch {
+	case strings.EqualFold(r, "audio"):
+		return RTPCodecTypeAudio
+	case strings.EqualFold(r, "video"):
+		return RTPCodecTypeVideo
+	default:
+		return RTPCodecType(0)
 	}
 }
 

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -37,6 +37,11 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = pcAnswer.AddTransceiver(RTPCodecTypeVideo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	awaitRTPRecv := make(chan bool)
 	awaitRTPRecvClosed := make(chan bool)
 	awaitRTPSend := make(chan bool)
@@ -187,6 +192,16 @@ func TestPeerConnection_Media_Shutdown(t *testing.T) {
 	api := NewAPI()
 	api.mediaEngine.RegisterDefaultCodecs()
 	pcOffer, pcAnswer, err := api.newPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = pcOffer.AddTransceiver(RTPCodecTypeVideo, RtpTransceiverInit{Direction: RTPTransceiverDirectionRecvonly})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = pcAnswer.AddTransceiver(RTPCodecTypeVideo, RtpTransceiverInit{Direction: RTPTransceiverDirectionRecvonly})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,6 +377,11 @@ func TestPeerConnection_Media_Closed(t *testing.T) {
 	api := NewAPI()
 	api.mediaEngine.RegisterDefaultCodecs()
 	pcOffer, pcAnswer, err := api.newPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = pcAnswer.AddTransceiver(RTPCodecTypeVideo)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -2,7 +2,9 @@
 
 package webrtc
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // RTPTransceiver represents a combination of an RTPSender and an RTPReceiver that share a common mid.
 type RTPTransceiver struct {
@@ -14,6 +16,7 @@ type RTPTransceiver struct {
 	// firedDirection   RTPTransceiverDirection
 	// receptive bool
 	stopped bool
+	kind    RTPCodecType
 }
 
 func (t *RTPTransceiver) setSendingTrack(track *Track) error {

--- a/rtptransceiverinit.go
+++ b/rtptransceiverinit.go
@@ -1,0 +1,8 @@
+package webrtc
+
+// RtpTransceiverInit dictionary is used when calling the WebRTC function addTransceiver() to provide configuration options for the new transceiver.
+type RtpTransceiverInit struct {
+	Direction     RTPTransceiverDirection
+	SendEncodings []RTPEncodingParameters
+	// Streams       []*Track
+}

--- a/track.go
+++ b/track.go
@@ -11,7 +11,11 @@ import (
 	"github.com/pions/webrtc/pkg/media"
 )
 
-const rtpOutboundMTU = 1400
+const (
+	rtpOutboundMTU          = 1400
+	trackDefaultIDLength    = 16
+	trackDefaultLabelLength = 16
+)
 
 // Track represents a single media track
 type Track struct {


### PR DESCRIPTION
This commit does cause some breaking changes. This API change means we
can no longer support an arbitrary number of receivers. For every track
you want to receive you MUST call PeerConnection.AddTransceiver

We do now support sending an multiple audio/video feeds. You can see
this behavior via gstreamer-receive and gstreamer-send currently.
