### PR TITLE
Return error on certificate fingerprint failure

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -93,7 +93,7 @@ func (c Certificate) Expires() time.Time {
 
 // GetFingerprints returns the list of certificate fingerprints, one of which
 // is computed with the digest algorithm used in the certificate signature.
-func (c Certificate) GetFingerprints() []DTLSFingerprint {
+func (c Certificate) GetFingerprints() ([]DTLSFingerprint, error) {
 	fingerprintAlgorithms := []dtls.HashAlgorithm{dtls.HashAlgorithmSHA256}
 	res := make([]DTLSFingerprint, len(fingerprintAlgorithms))
 
@@ -101,8 +101,7 @@ func (c Certificate) GetFingerprints() []DTLSFingerprint {
 	for _, algo := range fingerprintAlgorithms {
 		value, err := dtls.Fingerprint(c.x509Cert, algo)
 		if err != nil {
-			fmt.Printf("Failed to create fingerprint: %v\n", err)
-			continue
+			return nil, fmt.Errorf("failed to create fingerprint: %v", err)
 		}
 		res[i] = DTLSFingerprint{
 			Algorithm: algo.String(),
@@ -110,7 +109,7 @@ func (c Certificate) GetFingerprints() []DTLSFingerprint {
 		}
 	}
 
-	return res[:i+1]
+	return res[:i+1], nil
 }
 
 // GenerateCertificate causes the creation of an X.509 certificate and

--- a/datachannel_ortc_test.go
+++ b/datachannel_ortc_test.go
@@ -133,7 +133,10 @@ func (s *testORTCStack) getSignal() (*testORTCSignal, error) {
 		return nil, err
 	}
 
-	dtlsParams := s.dtls.GetLocalParameters()
+	dtlsParams, err := s.dtls.GetLocalParameters()
+	if err != nil {
+		return nil, err
+	}
 
 	sctpCapabilities := s.sctp.GetCapabilities()
 

--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -82,18 +82,22 @@ func (t *DTLSTransport) ICETransport() *ICETransport {
 }
 
 // GetLocalParameters returns the DTLS parameters of the local DTLSTransport upon construction.
-func (t *DTLSTransport) GetLocalParameters() DTLSParameters {
+func (t *DTLSTransport) GetLocalParameters() (DTLSParameters, error) {
 	fingerprints := []DTLSFingerprint{}
 
 	for _, c := range t.certificates {
-		prints := c.GetFingerprints() // TODO: Should be only one?
+		prints, err := c.GetFingerprints() // TODO: Should be only one?
+		if err != nil {
+			return DTLSParameters{}, err
+		}
+
 		fingerprints = append(fingerprints, prints...)
 	}
 
 	return DTLSParameters{
 		Role:         DTLSRoleAuto, // always returns the default role
 		Fingerprints: fingerprints,
-	}
+	}, nil
 }
 
 // GetRemoteCertificate returns the certificate chain in use by the remote side

--- a/examples/ortc-quic/main.go
+++ b/examples/ortc-quic/main.go
@@ -73,7 +73,10 @@ func main() {
 		panic(err)
 	}
 
-	quicParams := qt.GetLocalParameters()
+	quicParams, err := qt.GetLocalParameters()
+	if err != nil {
+		panic(err)
+	}
 
 	s := Signal{
 		ICECandidates:  iceCandidates,

--- a/examples/ortc/main.go
+++ b/examples/ortc/main.go
@@ -71,7 +71,10 @@ func main() {
 		panic(err)
 	}
 
-	dtlsParams := dtls.GetLocalParameters()
+	dtlsParams, err := dtls.GetLocalParameters()
+	if err != nil {
+		panic(err)
+	}
 
 	sctpCapabilities := sctp.GetCapabilities()
 

--- a/quictransport.go
+++ b/quictransport.go
@@ -63,18 +63,22 @@ func (api *API) NewQUICTransport(transport *ICETransport, certificates []Certifi
 }
 
 // GetLocalParameters returns the Quic parameters of the local QUICParameters upon construction.
-func (t *QUICTransport) GetLocalParameters() QUICParameters {
+func (t *QUICTransport) GetLocalParameters() (QUICParameters, error) {
 	fingerprints := []DTLSFingerprint{}
 
 	for _, c := range t.certificates {
-		prints := c.GetFingerprints() // TODO: Should be only one?
+		prints, err := c.GetFingerprints() // TODO: Should be only one?
+		if err != nil {
+			return QUICParameters{}, err
+
+		}
 		fingerprints = append(fingerprints, prints...)
 	}
 
 	return QUICParameters{
 		Role:         QUICRoleAuto, // always returns the default role
 		Fingerprints: fingerprints,
-	}
+	}, nil
 }
 
 // Start Quic transport with the parameters of the remote

--- a/quictransport_test.go
+++ b/quictransport_test.go
@@ -126,7 +126,10 @@ func (s *testQuicStack) getSignal() (*testQuicSignal, error) {
 		return nil, err
 	}
 
-	quicParams := s.quic.GetLocalParameters()
+	quicParams, err := s.quic.GetLocalParameters()
+	if err != nil {
+		return nil, err
+	}
 
 	return &testQuicSignal{
 		ICECandidates:  iceCandidates,


### PR DESCRIPTION
Instead of printing the error to stdout return the error to the user.
This may not be a hard error (as later certificates would have passed)
but it never is good to be in a state where you have certificates in a
broken state.

Resolves #586
