### PR TITLE
Allow the build tag "noquic" to exclude quic

### DIFF
--- a/quictransport.go
+++ b/quictransport.go
@@ -1,4 +1,5 @@
 // +build !js
+// +build !noquic
 
 package webrtc
 


### PR DESCRIPTION
Running go build -tags noquic will prevent the dependencies for
quictransport.go from being pulled in.

The underlying dependencies of this feature are in flux and currently
require go1.12+ due to some runtime struct matching nonsense. Being
able to disable it via build tag should be useful to most users.