### PR TITLE
Disable quic by default; enable with build tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ before_script:
   - go get github.com/mattn/goveralls
 
 script:
-  - golangci-lint run ./...
-  - cd examples && golangci-lint run ./... -D gochecknoinits
+  - golangci-lint run --build-tags quic ./...
+  - cd examples && golangci-lint run --build-tags quic ./... -D gochecknoinits
   - cd ..
   - rm -rf examples # Remove examples, no test coverage for them
-  - go test -coverpkg=$(go list ./... | tr '\n' ',') -coverprofile=cover.out -v -race -covermode=atomic ./...
+  - go test -tags quic -coverpkg=$(go list ./... | tr '\n' ',') -coverprofile=cover.out -v -race -covermode=atomic ./...
   - GOOS=js GOARCH=wasm go test -exec="./test-wasm/go_js_wasm_exec" -v .
   - goveralls -coverprofile=cover.out -service=travis-ci
   - bash .github/assert-contributors.sh

--- a/examples/ortc-quic/main.go
+++ b/examples/ortc-quic/main.go
@@ -1,3 +1,5 @@
+// +build quic
+
 package main
 
 import (

--- a/quicparameters.go
+++ b/quicparameters.go
@@ -1,3 +1,5 @@
+// +build quic
+
 package webrtc
 
 // QUICParameters holds information relating to QUIC configuration.

--- a/quicrole.go
+++ b/quicrole.go
@@ -1,3 +1,5 @@
+// +build quic
+
 package webrtc
 
 // QUICRole indicates the role of the Quic transport.

--- a/quicrole_test.go
+++ b/quicrole_test.go
@@ -1,3 +1,5 @@
+// +build quic
+
 package webrtc
 
 import (

--- a/quictransport.go
+++ b/quictransport.go
@@ -1,4 +1,5 @@
 // +build !js
+// +build quic
 
 package webrtc
 

--- a/quictransport_test.go
+++ b/quictransport_test.go
@@ -1,4 +1,5 @@
 // +build !js
+// +build quic
 
 package webrtc
 


### PR DESCRIPTION
Taking a more extreme approach than #588... This patch
disables quic by default. The advantage here would be
that webrtc builds with older versions of go than
quic-go supports (currently 1.12+).