### PR TITLE
SDP: reject media tracks without matching codec

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1640,12 +1640,17 @@ func (pc *PeerConnection) addTransceiverSDP(d *sdp.SessionDescription, midValue 
 		WithPropertyAttribute(sdp.AttrKeyRTCPMux).  // TODO: support RTCP fallback
 		WithPropertyAttribute(sdp.AttrKeyRTCPRsize) // TODO: Support Reduced-Size RTCP?
 
-	for _, codec := range pc.api.mediaEngine.getCodecsByKind(t.kind) {
+	codecs := pc.api.mediaEngine.getCodecsByKind(t.kind)
+	for _, codec := range codecs {
 		media.WithCodec(codec.PayloadType, codec.Name, codec.ClockRate, codec.Channels, codec.SDPFmtpLine)
 
 		for _, feedback := range codec.RTPCodecCapability.RTCPFeedback {
 			media.WithValueAttribute("rtcp-fb", fmt.Sprintf("%d %s %s", codec.PayloadType, feedback.Type, feedback.Parameter))
 		}
+	}
+	if len(codecs) == 0 {
+		// Explicitly reject track if we don't have the codec
+		media.MediaName.Formats = []string{"0"}
 	}
 
 	for _, mt := range transceivers {

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -2,13 +2,11 @@ package webrtc
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/pion/sdp/v2"
 	"github.com/pion/webrtc/v2/pkg/rtcerr"
 	"github.com/stretchr/testify/assert"
 )
@@ -315,48 +313,6 @@ func TestCreateOfferAnswer(t *testing.T) {
 	err = offerPeerConn.SetRemoteDescription(answer)
 	if err != nil {
 		t.Errorf("SetRemoteDescription (Originator): got error: %v", err)
-	}
-}
-
-func TestOfferRejectionMissingCodec(t *testing.T) {
-	api := NewAPI()
-	api.mediaEngine.RegisterDefaultCodecs()
-	pc, err := api.NewPeerConnection(Configuration{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	noCodecAPI := NewAPI()
-	noCodecPC, err := noCodecAPI.NewPeerConnection(Configuration{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	track, err := pc.NewTrack(DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := pc.AddTrack(track); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := signalPair(pc, noCodecPC); err != nil {
-		t.Fatal(err)
-	}
-
-	var sdes sdp.SessionDescription
-	if err := sdes.Unmarshal([]byte(pc.RemoteDescription().SDP)); err != nil {
-		t.Fatal(err)
-	}
-	var videoDesc sdp.MediaDescription
-	for _, m := range sdes.MediaDescriptions {
-		if m.MediaName.Media == "video" {
-			videoDesc = *m
-		}
-	}
-
-	if got, want := videoDesc.MediaName.Formats, []string{"0"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("rejecting unknown codec: sdp m=%s, want trailing 0", *videoDesc.MediaName.String())
 	}
 }
 

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -2,11 +2,13 @@ package webrtc
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/pion/sdp/v2"
 	"github.com/pion/webrtc/v2/pkg/rtcerr"
 	"github.com/stretchr/testify/assert"
 )
@@ -313,6 +315,48 @@ func TestCreateOfferAnswer(t *testing.T) {
 	err = offerPeerConn.SetRemoteDescription(answer)
 	if err != nil {
 		t.Errorf("SetRemoteDescription (Originator): got error: %v", err)
+	}
+}
+
+func TestOfferRejectionMissingCodec(t *testing.T) {
+	api := NewAPI()
+	api.mediaEngine.RegisterDefaultCodecs()
+	pc, err := api.NewPeerConnection(Configuration{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noCodecAPI := NewAPI()
+	noCodecPC, err := noCodecAPI.NewPeerConnection(Configuration{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	track, err := pc.NewTrack(DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pc.AddTrack(track); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := signalPair(pc, noCodecPC); err != nil {
+		t.Fatal(err)
+	}
+
+	var sdes sdp.SessionDescription
+	if err := sdes.Unmarshal([]byte(pc.RemoteDescription().SDP)); err != nil {
+		t.Fatal(err)
+	}
+	var videoDesc sdp.MediaDescription
+	for _, m := range sdes.MediaDescriptions {
+		if m.MediaName.Media == "video" {
+			videoDesc = *m
+		}
+	}
+
+	if got, want := videoDesc.MediaName.Formats, []string{"0"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("rejecting unknown codec: sdp m=%s, want trailing 0", *videoDesc.MediaName.String())
 	}
 }
 


### PR DESCRIPTION
Fixes regression in issue #449 caused by recent unified plan
changes.

Previously the PeerConnection would create invalid SDPs
when answering an offer that contained codecs it didn't
know about. Now it rejects them by setting the media format
to 0.

Related to #449