### PR TITLE
Update H264 default payload type to match Chromium

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -17,7 +17,7 @@ const (
 	DefaultPayloadTypeOpus = 111
 	DefaultPayloadTypeVP8  = 96
 	DefaultPayloadTypeVP9  = 98
-	DefaultPayloadTypeH264 = 100
+	DefaultPayloadTypeH264 = 102
 )
 
 // MediaEngine defines the codecs supported by a PeerConnection


### PR DESCRIPTION
This will fix answers with H264 in the short term.

In the long term we need to update our examples and show how you need to probe this.