### PR TITLE
Close ICEGatherer if mux isn't ready

### DIFF
--- a/icetransport.go
+++ b/icetransport.go
@@ -148,7 +148,10 @@ func (t *ICETransport) Stop() error {
 
 	if t.mux != nil {
 		return t.mux.Close()
+	} else if t.gatherer != nil {
+		return t.gatherer.Close()
 	}
+
 	return nil
 }
 

--- a/peerconnection_close_test.go
+++ b/peerconnection_close_test.go
@@ -55,3 +55,37 @@ func TestPeerConnection_Close(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Assert that a PeerConnection that is shutdown before ICE starts doesn't leak
+func TestPeerConnection_Close_PreICE(t *testing.T) {
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	pcOffer, pcAnswer, err := newPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	answer, err := pcOffer.CreateOffer(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = pcOffer.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = pcAnswer.SetRemoteDescription(answer); err != nil {
+		t.Fatal(err)
+	}
+
+	err = pcAnswer.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
When ICE is completely connected closing the mux is the proper way to
shut everything down. The Close is communicated down each transport.

The ICETransport mux is only available once ICE has completed however.
When shutting down the ICETransport if the mux isn't set close the
ICEGatherer if it has been set.

Resolves #608