### PR TITLE
Fix flaky test TestPeerConnection_Close_PreICE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+language: c
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod
 env:
   - GO111MODULE=on
 


### PR DESCRIPTION
Test success depend on a condition that happens in a detached thread.
Update test to take the lock and assert the behavior explicitly.

Resolves #626