### PR TITLE
Allow remote Sendrecv to be used with Recvonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Žiga Željko](https://github.com/zigazeljko)
 * [Simonacca Fotokite](https://github.com/simonacca-fotokite)
 * [Marouane](https://github.com/nindolabs) *Fix Offer bundle generation*
+* [Christopher Fry](https://github.com/christopherfry)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection_close_test.go
+++ b/peerconnection_close_test.go
@@ -61,7 +61,7 @@ func TestPeerConnection_Close(t *testing.T) {
 // Assert that a PeerConnection that is shutdown before ICE starts doesn't leak
 func TestPeerConnection_Close_PreICE(t *testing.T) {
 	// Limit runtime in case of deadlocks
-	lim := test.TimeOut(time.Second * 10)
+	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()
 
 	report := test.CheckRoutines(t)


### PR DESCRIPTION
Before our RTPTransceiver logic would only allow Sendrecv to
match with another Sendrecv. Instead allow a SendRecv to be used
with a local Recvonly
