### PR TITLE
Remove direct usage of unexported fields in ICETransport

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -200,10 +200,9 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 		return err
 	}
 
-	mx := t.iceTransport.mux
-	dtlsEndpoint := mx.NewEndpoint(mux.MatchDTLS)
-	t.srtpEndpoint = mx.NewEndpoint(mux.MatchSRTP)
-	t.srtcpEndpoint = mx.NewEndpoint(mux.MatchSRTCP)
+	dtlsEndpoint := t.iceTransport.NewEndpoint(mux.MatchDTLS)
+	t.srtpEndpoint = t.iceTransport.NewEndpoint(mux.MatchSRTP)
+	t.srtcpEndpoint = t.iceTransport.NewEndpoint(mux.MatchSRTCP)
 
 	// TODO: handle multiple certs
 	cert := t.certificates[0]
@@ -291,8 +290,7 @@ func (t *DTLSTransport) validateFingerPrint(remoteParameters DTLSParameters, rem
 
 func (t *DTLSTransport) ensureICEConn() error {
 	if t.iceTransport == nil ||
-		t.iceTransport.conn == nil ||
-		t.iceTransport.mux == nil {
+		t.iceTransport.State() == ICETransportStateNew {
 		return errors.New("ICE connection not started")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/pion/datachannel v1.4.3
 	github.com/pion/dtls v1.3.4
-	github.com/pion/ice v0.2.6
+	github.com/pion/ice v0.2.7
 	github.com/pion/logging v0.2.1
 	github.com/pion/quic v0.1.1
 	github.com/pion/rtcp v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/pion/datachannel v1.4.3 h1:tqS6YiqqAiFCxGGhvn1K7fHEzemK9Aov025dE/isGF
 github.com/pion/datachannel v1.4.3/go.mod h1:SpMJbuu8v+qbA94m6lWQwSdCf8JKQvgmdSHDNtcbe+w=
 github.com/pion/dtls v1.3.4 h1:MdOMsCfd44m2iTrxtkzA6UndvYVjLWWjua7hxU8EXEA=
 github.com/pion/dtls v1.3.4/go.mod h1:CjlPLfQdsTg3G4AEXjJp8FY5bRweBlxHrgoFrN+fQsk=
-github.com/pion/ice v0.2.6 h1:N/xhQtO6WfWlyMvIZgE+cqG5AHJnKL+aEboade72qno=
-github.com/pion/ice v0.2.6/go.mod h1:igvbO76UeYthbSu0UsUTqjyWpFT3diUmM+x2vt4p4fw=
+github.com/pion/ice v0.2.7 h1:dmjqaGoC+/QIOv9j9lHnFmaECm2YOir25ivLbSN4kF4=
+github.com/pion/ice v0.2.7/go.mod h1:igvbO76UeYthbSu0UsUTqjyWpFT3diUmM+x2vt4p4fw=
 github.com/pion/logging v0.2.1 h1:LwASkBKZ+2ysGJ+jLv1E/9H1ge0k1nTfi1X+5zirkDk=
 github.com/pion/logging v0.2.1/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/quic v0.1.1 h1:D951FV+TOqI9A0rTF7tHx0Loooqz+nyzjEyj8o3PuMA=

--- a/peerconnection_close_test.go
+++ b/peerconnection_close_test.go
@@ -86,22 +86,24 @@ func TestPeerConnection_Close_PreICE(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	for {
+		if pcAnswer.iceTransport.State() == ICETransportStateChecking {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
 	err = pcAnswer.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Assert that ICEGatherer is shutdown, test timeout will prevent deadlock
-	pcAnswer.iceTransport.lock.Lock()
-	gatherer := pcAnswer.iceTransport.gatherer
-	pcAnswer.iceTransport.lock.Unlock()
+	// Assert that ICETransport is shutdown, test timeout will prevent deadlock
 	for {
-		gatherer.lock.RLock()
-		if gatherer.agent == nil {
+		if pcAnswer.iceTransport.State() == ICETransportStateClosed {
 			time.Sleep(time.Second * 3)
 			return
 		}
-		gatherer.lock.RUnlock()
 
 		time.Sleep(time.Second)
 	}

--- a/quictransport.go
+++ b/quictransport.go
@@ -118,7 +118,7 @@ func (t *QUICTransport) Start(remoteParameters QUICParameters) error {
 		Certificate: cert.x509Cert,
 		PrivateKey:  cert.privateKey,
 	}
-	endpoint := t.iceTransport.mux.NewEndpoint(mux.MatchAll)
+	endpoint := t.iceTransport.NewEndpoint(mux.MatchAll)
 	err := t.TransportBase.StartBase(endpoint, cfg)
 	if err != nil {
 		return err
@@ -161,8 +161,7 @@ func (t *QUICTransport) validateFingerPrint(remoteParameters QUICParameters, rem
 
 func (t *QUICTransport) ensureICEConn() error {
 	if t.iceTransport == nil ||
-		t.iceTransport.conn == nil ||
-		t.iceTransport.mux == nil {
+		t.iceTransport.State() == ICETransportStateNew {
 		return errors.New("ICE connection not started")
 	}
 


### PR DESCRIPTION
There are some direct usages of unexported fields of ICETransport
from non ice-related methods. This would be problematic when ice
once ice related code is moved to a separate packet. Added proxy
methods to ICETransport to avoid this.

#### Reference issue
Rel #646 
