### PR TITLE
Update framerate using frame count and time duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Adam Kiss](https://github.com/masterada)
 * [xsbchen](https://github.com/xsbchen)
 * [Alex Harford](https://github.com/alexjh)
+* [Raphael Derosso Pereira](https://github.com/raphaelpereira)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
Instead of keeping fixed 30fps, get current timestamp
on frame count zero and update framerate using full
video duration upon closing file
