### PR TITLE
Fix DC open

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -154,8 +154,6 @@ func (d *DataChannel) open(sctpTransport *SCTPTransport) error {
 	// bufferedAmountLowThreshold and onBufferedAmountLow might be set earlier
 	dc.SetBufferedAmountLowThreshold(d.bufferedAmountLowThreshold)
 	dc.OnBufferedAmountLow(d.onBufferedAmountLow)
-
-	d.readyState = DataChannelStateOpen
 	d.mu.Unlock()
 
 	d.handleOpen(dc)
@@ -273,6 +271,7 @@ func (d *DataChannel) onMessage(msg DataChannelMessage) {
 
 func (d *DataChannel) handleOpen(dc *datachannel.DataChannel) {
 	d.mu.Lock()
+	d.readyState = DataChannelStateOpen
 	d.dataChannel = dc
 	d.mu.Unlock()
 

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -187,8 +187,6 @@ func (r *SCTPTransport) acceptDataChannels() {
 			return
 		}
 
-		rtcDC.readyState = DataChannelStateOpen
-
 		<-r.onDataChannel(rtcDC)
 		rtcDC.handleOpen(dc)
 	}


### PR DESCRIPTION
it's expected for a open Datachannel to have an associated datachannel.Datachannel. Handling everything under the same lock guarantee that

I'm currently random getting this error (which this PR fixes), when trying to detach a channel in the open handler `datachannel not opened yet, try calling Detach from OnOpen`