### PR TITLE
Default ICECredentialType to password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/pion/datachannel v1.4.3
 	github.com/pion/dtls v1.3.5
-	github.com/pion/ice v0.3.0
+	github.com/pion/ice v0.3.1
 	github.com/pion/logging v0.2.1
 	github.com/pion/quic v0.1.1
 	github.com/pion/rtcp v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/pion/datachannel v1.4.3 h1:tqS6YiqqAiFCxGGhvn1K7fHEzemK9Aov025dE/isGF
 github.com/pion/datachannel v1.4.3/go.mod h1:SpMJbuu8v+qbA94m6lWQwSdCf8JKQvgmdSHDNtcbe+w=
 github.com/pion/dtls v1.3.5 h1:mBioifvh6JSE9pD4FtJh5WoizygoqkOJNJyS5Ns+y1U=
 github.com/pion/dtls v1.3.5/go.mod h1:CjlPLfQdsTg3G4AEXjJp8FY5bRweBlxHrgoFrN+fQsk=
-github.com/pion/ice v0.3.0 h1:ueaLHTrXr3Npqia3dktIVYsRpPY6UnLSdi0/LCPygag=
-github.com/pion/ice v0.3.0/go.mod h1:fKZO8+Rl0St8LwsKR1q0K9olEGUrGMDW6QnrpJmFkJM=
+github.com/pion/ice v0.3.1 h1:+VfScgpjzf2wnGY5s4IF8UJOqQTKOxmfigyRVjDcmus=
+github.com/pion/ice v0.3.1/go.mod h1:fKZO8+Rl0St8LwsKR1q0K9olEGUrGMDW6QnrpJmFkJM=
 github.com/pion/logging v0.2.1 h1:LwASkBKZ+2ysGJ+jLv1E/9H1ge0k1nTfi1X+5zirkDk=
 github.com/pion/logging v0.2.1/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/quic v0.1.1 h1:D951FV+TOqI9A0rTF7tHx0Loooqz+nyzjEyj8o3PuMA=

--- a/icecredentialtype.go
+++ b/icecredentialtype.go
@@ -7,7 +7,7 @@ type ICECredentialType int
 const (
 	// ICECredentialTypePassword describes username and pasword based
 	// credentials as described in https://tools.ietf.org/html/rfc5389.
-	ICECredentialTypePassword ICECredentialType = iota + 1
+	ICECredentialTypePassword ICECredentialType = iota
 
 	// ICECredentialTypeOauth describes token based credential as described
 	// in https://tools.ietf.org/html/rfc7635.

--- a/icecredentialtype_test.go
+++ b/icecredentialtype_test.go
@@ -11,7 +11,6 @@ func TestNewICECredentialType(t *testing.T) {
 		credentialTypeString   string
 		expectedCredentialType ICECredentialType
 	}{
-		{unknownStr, ICECredentialType(Unknown)},
 		{"password", ICECredentialTypePassword},
 		{"oauth", ICECredentialTypeOauth},
 	}
@@ -30,7 +29,6 @@ func TestICECredentialType_String(t *testing.T) {
 		credentialType ICECredentialType
 		expectedString string
 	}{
-		{ICECredentialType(Unknown), unknownStr},
 		{ICECredentialTypePassword, "password"},
 		{ICECredentialTypeOauth, "oauth"},
 	}

--- a/iceserver.go
+++ b/iceserver.go
@@ -34,13 +34,16 @@ func (s ICEServer) validate() ([]*ice.URL, error) {
 			if s.Username == "" || s.Credential == nil {
 				return nil, &rtcerr.InvalidAccessError{Err: ErrNoTurnCredencials}
 			}
+			url.Username = s.Username
 
 			switch s.CredentialType {
 			case ICECredentialTypePassword:
 				// https://www.w3.org/TR/webrtc/#set-the-configuration (step #11.3.3)
-				if _, ok := s.Credential.(string); !ok {
+				password, ok := s.Credential.(string)
+				if !ok {
 					return nil, &rtcerr.InvalidAccessError{Err: ErrTurnCredencials}
 				}
+				url.Password = password
 
 			case ICECredentialTypeOauth:
 				// https://www.w3.org/TR/webrtc/#set-the-configuration (step #11.3.4)


### PR DESCRIPTION
https://www.w3.org/TR/webrtc/#dom-rtciceserver has the following default
```
credentialType = "password";
```

Update our enum to match that, currently we require users to specify
password

