### PR TITLE
Don't error when no candidate pairs

### DIFF
--- a/internal/mux/endpoint.go
+++ b/internal/mux/endpoint.go
@@ -1,9 +1,11 @@
 package mux
 
 import (
+	"io"
 	"net"
 	"time"
 
+	"github.com/pion/ice"
 	"github.com/pion/transport/packetio"
 )
 
@@ -35,8 +37,15 @@ func (e *Endpoint) Read(p []byte) (int, error) {
 }
 
 // Write writes len(p) bytes to the underlying conn
-func (e *Endpoint) Write(p []byte) (n int, err error) {
-	return e.mux.nextConn.Write(p)
+func (e *Endpoint) Write(p []byte) (int, error) {
+	n, err := e.mux.nextConn.Write(p)
+	if err == ice.ErrNoCandidatePairs {
+		return 0, nil
+	} else if err == ice.ErrClosed {
+		return 0, io.ErrClosedPipe
+	}
+
+	return n, err
 }
 
 // LocalAddr is a stub

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -8,7 +8,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
-	"io"
 	mathRand "math/rand"
 	"net"
 	"regexp"
@@ -1544,13 +1543,7 @@ func (pc *PeerConnection) WriteRTCP(pkts []rtcp.Packet) error {
 	}
 
 	if _, err := writeStream.Write(raw); err != nil {
-		if err == ice.ErrNoCandidatePairs {
-			return nil
-		} else if err == ice.ErrClosed {
-			return io.ErrClosedPipe
-		}
-
-		return fmt.Errorf("WriteRTCP failed to write: %v", err)
+		return err
 	}
 	return nil
 }

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/pion/ice"
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 	"github.com/pion/srtp"
@@ -149,11 +148,7 @@ func (r *RTPSender) sendRTP(header *rtp.Header, payload []byte) (int, error) {
 			return 0, err
 		}
 
-		n, err := writeStream.WriteRTP(header, payload)
-		if err == ice.ErrNoCandidatePairs {
-			err = nil
-		}
-		return n, err
+		return writeStream.WriteRTP(header, payload)
 	}
 }
 


### PR DESCRIPTION
Fix inconsistency with error handling when we have no candidate pairs.
Before we had custom code in RTP handling that would discard errors
if it was because we had no candidate pairs. Move this logic into the
mux so we have consistent behavior with Datachannels

This can be expected and is a soft failure. Every subsystem is expected
to handle lossy communication.

Resolves #706