### PR TITLE
Fix panic in openSRTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [xsbchen](https://github.com/xsbchen)
 * [Alex Harford](https://github.com/alexjh)
 * [Aleksandr Razumov](https://github.com/ernado)
+* [mchlrhw](https://github.com/mchlrhw)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1102,6 +1102,11 @@ func (pc *PeerConnection) openSRTP() {
 		pc.mu.RLock()
 		defer pc.mu.RUnlock()
 
+		if pc.currentLocalDescription == nil {
+			pc.log.Warnf("SetLocalDescription not called, unable to handle incoming media streams")
+			return
+		}
+
 		sdpCodec, err := pc.currentLocalDescription.parsed.GetCodecForPayloadType(receiver.Track().PayloadType())
 		if err != nil {
 			pc.log.Warnf("no codec could be found in RemoteDescription for payloadType %d", receiver.Track().PayloadType())

--- a/peerconnection_setlocaldescription_test.go
+++ b/peerconnection_setlocaldescription_test.go
@@ -1,0 +1,127 @@
+// +build !js
+
+package webrtc
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/pion/webrtc/v2/pkg/media"
+)
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func runOfferingPeer(offerChan chan<- SessionDescription, answerChan <-chan SessionDescription) {
+	config := Configuration{}
+	peerConnection, err := NewPeerConnection(config)
+	check(err)
+
+	track, err := peerConnection.NewTrack(DefaultPayloadTypeOpus, rand.Uint32(), "audio", "pion1")
+	check(err)
+	_, err = peerConnection.AddTrack(track)
+	check(err)
+
+	offer, err := peerConnection.CreateOffer(nil)
+	check(err)
+	err = peerConnection.SetLocalDescription(offer)
+	check(err)
+	offerChan <- offer
+
+	answer := <-answerChan
+	err = peerConnection.SetRemoteDescription(answer)
+	check(err)
+
+	for {
+		// send bogus data
+		sample := media.Sample{
+			Data:    []byte{0x00},
+			Samples: 1,
+		}
+		err = track.WriteSample(sample)
+		check(err)
+	}
+}
+
+func runAnsweringPeer(offerChan <-chan SessionDescription, answerChan chan<- SessionDescription, resultChan chan<- error) {
+	config := Configuration{}
+	peerConnection, err := NewPeerConnection(config)
+	check(err)
+
+	initLogWatcher(peerConnection, resultChan)
+
+	_, err = peerConnection.AddTransceiver(RTPCodecTypeAudio)
+	check(err)
+
+	peerConnection.OnTrack(func(track *Track, receiver *RTPReceiver) {
+		buf := make([]byte, 1400)
+		_, err = track.Read(buf)
+		check(err)
+		resultChan <- errors.New("Data erroneously received")
+	})
+
+	offer := <-offerChan
+	err = peerConnection.SetRemoteDescription(offer)
+	check(err)
+
+	answer, err := peerConnection.CreateAnswer(nil)
+	check(err)
+	answerChan <- answer
+}
+
+func initLogWatcher(peerConnection *PeerConnection, resultChan chan<- error) {
+	expectedLogging := "SetLocalDescription not called"
+
+	r, w := io.Pipe()
+
+	// replace the existing logger with one we can slurp from
+	loggerFactory := &logging.DefaultLoggerFactory{
+		Writer:          w,
+		DefaultLogLevel: logging.LogLevelWarn,
+	}
+	peerConnection.log = loggerFactory.NewLogger("pc")
+
+	scanner := bufio.NewScanner(r)
+	go func() {
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, expectedLogging) {
+				// we found what we were looking for
+				resultChan <- nil
+				break
+			}
+		}
+		check(scanner.Err())
+	}()
+}
+
+func TestNoPanicIfSetLocalDescriptionNotCalledByAnsweringPeer(t *testing.T) {
+	offerChan := make(chan SessionDescription)
+	answerChan := make(chan SessionDescription)
+	resultChan := make(chan error)
+
+	go runOfferingPeer(offerChan, answerChan)
+	go runAnsweringPeer(offerChan, answerChan, resultChan)
+
+	// wait for either:
+	// - the expected logging (success!)
+	// - the read to succeed (which is actually a bad thing)
+	// - or a timeout (also bad)
+	select {
+	case err := <-resultChan:
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+	case <-time.After(140 * time.Second):
+		t.Fatalf("Timed out waiting for expected logging")
+	}
+}


### PR DESCRIPTION
#### Description

The fact that SetLocalDescription isn't called is erroneous, but should not result in a panic. It may be that we shouldn't even be processing incoming tracks until the local description has been set.

**Edit**: The approach taken to fix the panic is to just log and bail as is done in the rest of the function, rather than moving around the code to handle incoming tracks. I would appreciate suggestions for alternatives.

#### Reference issue
Fixes #563 
