### PR TITLE
Reduce syscall/js calls needed to load Uint8Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [mchlrhw](https://github.com/mchlrhw)
 * [AlexWoo(武杰)](https://github.com/AlexWoo) *Fix RemoteDescription parsing for certificate fingerprint*
 * [Cecylia Bocovich](https://github.com/cohosh)
+* [Slugalisk](https://github.com/slugalisk)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/js_utils.go
+++ b/js_utils.go
@@ -162,8 +162,7 @@ func recoveryToError(e interface{}) error {
 
 func uint8ArrayValueToBytes(val js.Value) []byte {
 	result := make([]byte, val.Length())
-	for i := 0; i < val.Length(); i++ {
-		result[i] = byte(val.Index(i).Int())
-	}
+	jsResult := js.TypedArrayOf(result)
+	jsResult.Call("set", val)
 	return result
 }


### PR DESCRIPTION
#### Description
With the result buffer wrapped in a js.TypedArray js will do the copy for us. See: https://github.com/WebAssembly/design/issues/1231#issuecomment-420466909