### PR TITLE
Guard against nil OnLocalCandidate handler

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -147,6 +147,10 @@ func (g *ICEGatherer) Gather() error {
 
 	g.lock.Lock()
 	onLocalCandidateHdlr := g.onLocalCandidateHdlr
+	if onLocalCandidateHdlr == nil {
+		onLocalCandidateHdlr = func(*ICECandidate) {}
+	}
+
 	isTrickle := g.agentIsTrickle
 	agent := g.agent
 	g.lock.Unlock()


### PR DESCRIPTION
Currently the ICEGather will crash if trickle is enabled and
OnLocalCandidate hasn't been defined. This adds a simple nil check
to make sure we don't crash if the user doesn't set a OnLocalCandidate
callback.
