### PR TITLE
Fix ICECandidateInit ToJSON

### DIFF
--- a/icecandidate.go
+++ b/icecandidate.go
@@ -157,5 +157,8 @@ func iceCandidateToSDP(c ICECandidate) sdp.ICECandidate {
 // as indicated by the spec https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson
 func (c ICECandidate) ToJSON() ICECandidateInit {
 	var sdpmLineIndex uint16
-	return ICECandidateInit{Candidate: iceCandidateToSDP(c).Marshal(), SDPMLineIndex: &sdpmLineIndex}
+	return ICECandidateInit{
+		Candidate:     fmt.Sprintf("candidate:%s", iceCandidateToSDP(c).Marshal()),
+		SDPMLineIndex: &sdpmLineIndex,
+	}
 }

--- a/icecandidate_test.go
+++ b/icecandidate_test.go
@@ -158,3 +158,20 @@ func TestConvertTypeFromICE(t *testing.T) {
 		}
 	})
 }
+
+func TestICECandidate_ToJSON(t *testing.T) {
+	candidate := ICECandidate{
+		Foundation: "foundation",
+		Priority:   128,
+		Address:    "1.0.0.1",
+		Protocol:   ICEProtocolUDP,
+		Port:       1234,
+		Typ:        ICECandidateTypeHost,
+		Component:  1,
+	}
+
+	candidateInit := candidate.ToJSON()
+
+	assert.Equal(t, uint16(0), *candidateInit.SDPMLineIndex)
+	assert.Equal(t, "candidate:foundation 1 udp 128 1.0.0.1 1234 typ host", candidateInit.Candidate)
+}


### PR DESCRIPTION
Candidate field should always start with "candidate:" prefix
