### PR TITLE
Fix echo for Safari and Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Agugua Kenechukwu](https://github.com/spaceCh1mp)
 * [Ato Araki](https://github.com/atotto)
 * [Rafael Viscarra](https://github.com/rviscarra)
+* [Mike Coleman](https://github.com/fivebats)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/examples/echo/jsfiddle/demo.js
+++ b/examples/echo/jsfiddle/demo.js
@@ -13,7 +13,7 @@ var log = msg => {
 
 navigator.mediaDevices.getUserMedia({ video: true, audio: true })
   .then(stream => {
-    pc.addStream(stream)
+    stream.getTracks().forEach(track => pc.addTrack(track, stream));
     pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
   }).catch(log)
 

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -7,12 +7,35 @@ import (
 
 	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v2"
-
 	"github.com/pion/webrtc/v2/examples/internal/signal"
 )
 
 func main() {
 	// Everything below is the Pion WebRTC API! Thanks for using it ❤️.
+
+	// Wait for the offer to be pasted
+	offer := webrtc.SessionDescription{}
+	signal.Decode(signal.MustReadStdin(), &offer)
+
+	// We make our own mediaEngine so we can place the sender's codecs in it. Since we are echoing their RTP packet
+	// back to them we are actually codec agnostic - we can accept all their codecs. This also ensures that we use the
+	// dynamic media type from the sender in our answer.
+	mediaEngine := webrtc.MediaEngine{}
+
+	// Add codecs to the mediaEngine. Note that even though we are only going to echo back the sender's video we also
+	// add audio codecs. This is because createAnswer will create an audioTransceiver and associated SDP and we currently
+	// cannot tell it not to. The audio SDP must match the sender's codecs too...
+	err := mediaEngine.PopulateFromSDP(offer)
+	if err != nil {
+		panic(err)
+	}
+
+	preferredCodec, err := mediaEngine.FirstCodecOfKind(webrtc.RTPCodecTypeVideo)
+	if err != nil {
+		panic("no video codec in offer sdp")
+	}
+
+	api := webrtc.NewAPI(webrtc.WithMediaEngine(mediaEngine))
 
 	// Prepare the configuration
 	config := webrtc.Configuration{
@@ -22,15 +45,19 @@ func main() {
 			},
 		},
 	}
-
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.NewPeerConnection(config)
+	peerConnection, err := api.NewPeerConnection(config)
+	if err != nil {
+		panic(err)
+	}
+	// Set the remote SessionDescription
+	err = peerConnection.SetRemoteDescription(offer)
 	if err != nil {
 		panic(err)
 	}
 
 	// Create Track that we send video back to browser on
-	outputTrack, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion")
+	outputTrack, err := peerConnection.NewTrack(preferredCodec.PayloadType, rand.Uint32(), "video", "pion")
 	if err != nil {
 		panic(err)
 	}
@@ -66,7 +93,6 @@ func main() {
 			// Replace the SSRC with the SSRC of the outbound track.
 			// The only change we are making replacing the SSRC, the RTP packets are unchanged otherwise
 			rtp.SSRC = outputTrack.SSRC()
-			rtp.PayloadType = webrtc.DefaultPayloadTypeVP8
 
 			if writeErr := outputTrack.WriteRTP(rtp); writeErr != nil {
 				panic(writeErr)
@@ -78,16 +104,6 @@ func main() {
 	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
 	})
-
-	// Wait for the offer to be pasted
-	offer := webrtc.SessionDescription{}
-	signal.Decode(signal.MustReadStdin(), &offer)
-
-	// Set the remote SessionDescription
-	err = peerConnection.SetRemoteDescription(offer)
-	if err != nil {
-		panic(err)
-	}
 
 	// Create an answer
 	answer, err := peerConnection.CreateAnswer(nil)

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -3,6 +3,7 @@
 package webrtc
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -39,6 +40,61 @@ func (m *MediaEngine) RegisterDefaultCodecs() {
 	m.RegisterCodec(NewRTPVP8Codec(DefaultPayloadTypeVP8, 90000))
 	m.RegisterCodec(NewRTPH264Codec(DefaultPayloadTypeH264, 90000))
 	m.RegisterCodec(NewRTPVP9Codec(DefaultPayloadTypeVP9, 90000))
+}
+
+// PopulateFromSDP finds all codecs in a session description and adds them to a MediaEngine, using dynamic
+// payload types and parameters from the sdp.
+func (m *MediaEngine) PopulateFromSDP(sd SessionDescription) error {
+	sdpsd := sdp.SessionDescription{}
+	err := sdpsd.Unmarshal([]byte(sd.SDP))
+	if err != nil {
+		return err
+	}
+	for _, md := range sdpsd.MediaDescriptions {
+		for _, format := range md.MediaName.Formats {
+			pt, err := strconv.Atoi(format)
+			if err != nil {
+				return fmt.Errorf("format parse error")
+			}
+			payloadType := uint8(pt)
+			payloadCodec, err := sdpsd.GetCodecForPayloadType(payloadType)
+			if err != nil {
+				return fmt.Errorf("could not find codec for payload type %d", payloadType)
+			}
+			var codec *RTPCodec
+			clockRate := payloadCodec.ClockRate
+			parameters := payloadCodec.Fmtp
+			switch payloadCodec.Name {
+			case G722:
+				codec = NewRTPG722Codec(payloadType, clockRate)
+			case Opus:
+				codec = NewRTPOpusCodec(payloadType, clockRate)
+			case VP8:
+				codec = NewRTPVP8Codec(payloadType, clockRate)
+				codec.SDPFmtpLine = parameters
+			case VP9:
+				codec = NewRTPVP9Codec(payloadType, clockRate)
+				codec.SDPFmtpLine = parameters
+			case H264:
+				codec = NewRTPH264Codec(payloadType, clockRate)
+				codec.SDPFmtpLine = parameters
+			default:
+				// ignoring other codecs
+				continue
+			}
+			m.RegisterCodec(codec)
+		}
+	}
+	return nil
+}
+
+// FirstCodecOfKind returns the first codec of a chosen kind in the codecs list
+func (m *MediaEngine) FirstCodecOfKind(kind RTPCodecType) (*RTPCodec, error) {
+	foundCodecs := m.getCodecsByKind(kind)
+	if len(foundCodecs) == 0 {
+		return nil, fmt.Errorf("none found")
+	}
+	return foundCodecs[0], nil
 }
 
 func (m *MediaEngine) getCodec(payloadType uint8) (*RTPCodec, error) {

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1364,12 +1364,12 @@ func (pc *PeerConnection) AddTransceiverFromKind(kind RTPCodecType, init ...RtpT
 			return nil, err
 		}
 
-		payloadType := DefaultPayloadTypeOpus
-		if kind == RTPCodecTypeVideo {
-			payloadType = DefaultPayloadTypeVP8
+		codecs := pc.api.mediaEngine.getCodecsByKind(kind)
+		if len(codecs) == 0 {
+			return nil, fmt.Errorf("no %s codecs found", kind.String())
 		}
 
-		track, err := pc.NewTrack(uint8(payloadType), mathRand.Uint32(), util.RandSeq(trackDefaultIDLength), util.RandSeq(trackDefaultLabelLength))
+		track, err := pc.NewTrack(codecs[0].PayloadType, mathRand.Uint32(), util.RandSeq(trackDefaultIDLength), util.RandSeq(trackDefaultLabelLength))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### Description

This fixes the echo program so it works properly on Safari
and Firefox, where the preferred offered dynamic media type
is not 96/VP8. It loads MediaEngine with codecs found in the
offer and then uses the payload type of the offer's preferred
video codec in the answer.
