### PR TITLE
Parse DTLS setup in SetRemoteDescription

### DIFF
--- a/dtlsrole_test.go
+++ b/dtlsrole_test.go
@@ -1,8 +1,10 @@
 package webrtc
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/pion/sdp/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,6 +24,59 @@ func TestDTLSRole_String(t *testing.T) {
 			testCase.expectedString,
 			testCase.role.String(),
 			"testCase: %d %v", i, testCase,
+		)
+	}
+}
+
+func TestDTLSRoleFromRemoteSDP(t *testing.T) {
+	parseSDP := func(raw string) *sdp.SessionDescription {
+		parsed := &sdp.SessionDescription{}
+		if err := parsed.Unmarshal([]byte(raw)); err != nil {
+			panic(err)
+		}
+		return parsed
+	}
+
+	const noMedia = `v=0
+o=- 4596489990601351948 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+`
+
+	const mediaNoSetup = `v=0
+o=- 4596489990601351948 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=application 47299 DTLS/SCTP 5000
+c=IN IP4 192.168.20.129
+`
+
+	const mediaSetupDeclared = `v=0
+o=- 4596489990601351948 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=application 47299 DTLS/SCTP 5000
+c=IN IP4 192.168.20.129
+a=setup:%s
+`
+
+	testCases := []struct {
+		test               string
+		sessionDescription *sdp.SessionDescription
+		expectedRole       DTLSRole
+	}{
+		{"nil SessionDescription", nil, DTLSRoleAuto},
+		{"No MediaDescriptions", parseSDP(noMedia), DTLSRoleAuto},
+		{"MediaDescription, no setup", parseSDP(mediaNoSetup), DTLSRoleAuto},
+		{"MediaDescription, setup:actpass", parseSDP(fmt.Sprintf(mediaSetupDeclared, "actpass")), DTLSRoleAuto},
+		{"MediaDescription, setup:passive", parseSDP(fmt.Sprintf(mediaSetupDeclared, "passive")), DTLSRoleClient},
+		{"MediaDescription, setup:active", parseSDP(fmt.Sprintf(mediaSetupDeclared, "active")), DTLSRoleServer},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedRole,
+			dtlsRoleFromRemoteSDP(testCase.sessionDescription),
+			"TestDTLSRoleFromSDP (%s)", testCase.test,
 		)
 	}
 }

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -464,13 +464,13 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 	if pc.configuration.SDPSemantics == SDPSemanticsPlanB {
 		midValue = "data"
 	}
-	pc.addDataMediaSection(d, midValue, iceParams, candidates, sdp.ConnectionRoleActive)
+	pc.addDataMediaSection(d, midValue, iceParams, candidates, sdp.ConnectionRoleActpass)
 	appendBundle(midValue)
 
 	d = d.WithValueAttribute(sdp.AttrKeyGroup, bundleValue)
 
 	for _, m := range d.MediaDescriptions {
-		m.WithPropertyAttribute("setup:actpass")
+		m.WithValueAttribute(sdp.AttrKeyConnectionSetup, "actpass")
 	}
 
 	sdpBytes, err := d.Marshal()
@@ -968,7 +968,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 
 		// Start the dtls transport
 		err = pc.dtlsTransport.Start(DTLSParameters{
-			Role:         DTLSRoleAuto,
+			Role:         dtlsRoleFromRemoteSDP(desc.parsed),
 			Fingerprints: []DTLSFingerprint{{Algorithm: fingerprintHash, Value: fingerprint}},
 		})
 		if err != nil {
@@ -1656,7 +1656,7 @@ func (pc *PeerConnection) addTransceiverSDP(d *sdp.SessionDescription, midValue 
 	// Use the first transceiver to generate the section attributes
 	t := transceivers[0]
 	media := sdp.NewJSEPMediaDescription(t.kind.String(), []string{}).
-		WithValueAttribute(sdp.AttrKeyConnectionSetup, dtlsRole.String()). // pion/webrtc#494
+		WithValueAttribute(sdp.AttrKeyConnectionSetup, dtlsRole.String()).
 		WithValueAttribute(sdp.AttrKeyMID, midValue).
 		WithICECredentials(iceParams.UsernameFragment, iceParams.Password).
 		WithPropertyAttribute(sdp.AttrKeyRTCPMux).
@@ -1718,7 +1718,7 @@ func (pc *PeerConnection) addDataMediaSection(d *sdp.SessionDescription, midValu
 			},
 		},
 	}).
-		WithValueAttribute(sdp.AttrKeyConnectionSetup, dtlsRole.String()). // pion/webrtc#494
+		WithValueAttribute(sdp.AttrKeyConnectionSetup, dtlsRole.String()).
 		WithValueAttribute(sdp.AttrKeyMID, midValue).
 		WithPropertyAttribute(RTPTransceiverDirectionSendrecv.String()).
 		WithPropertyAttribute("sctpmap:5000 webrtc-datachannel 1024").


### PR DESCRIPTION
Take into consideration if remote is running DTLS as a
client/server. Before we ignored this value and we could
enter cases where DTLS would never connect.

Resolves #494