### PR TITLE
Modified sfu-minimal to work with heterogeneous clients

### DIFF
--- a/examples/sfu-minimal/README.md
+++ b/examples/sfu-minimal/README.md
@@ -29,4 +29,9 @@ You can change the listening port using `-port 8011`
 
 You can `Join the broadcast` as many times as you want. The `sfu-minimal` Golang application is relaying all traffic, so your browser only has to upload once.
 
+When using `curl` Instead of pasting the SDP into the terminal, you may prefer using a paste-from-clipboard command:
+
+* Linux: `xclip -o | curl http://localhost:8080/sdp -d @-`
+* macOS: `pbpaste | curl http://localhost:8080/sdp -d @-`
+
 Congrats, you have used Pion WebRTC! Now start building something cool

--- a/examples/sfu-minimal/jsfiddle/demo.js
+++ b/examples/sfu-minimal/jsfiddle/demo.js
@@ -21,7 +21,8 @@ window.createSession = isPublisher => {
   if (isPublisher) {
     navigator.mediaDevices.getUserMedia({ video: true, audio: false })
       .then(stream => {
-        pc.addStream(document.getElementById('video1').srcObject = stream)
+        stream.getTracks().forEach(track => pc.addTrack(track, stream));
+        document.getElementById('video1').srcObject = stream;
         pc.createOffer()
           .then(d => pc.setLocalDescription(d))
           .catch(log)

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -130,6 +130,17 @@ const (
 	H264 = "H264"
 )
 
+// GetCodecsByName returns all codecs of a chosen name in the codecs list
+func (m *MediaEngine) GetCodecsByName(codecName string) []*RTPCodec {
+	var codecs []*RTPCodec
+	for _, codec := range m.codecs {
+		if codec.Name == codecName {
+			codecs = append(codecs, codec)
+		}
+	}
+	return codecs
+}
+
 // NewRTPG722Codec is a helper to create a G722 codec
 func NewRTPG722Codec(payloadType uint8, clockrate uint32) *RTPCodec {
 	c := NewRTPCodec(RTPCodecTypeAudio,

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -160,7 +160,7 @@ func (r *RTPSender) sendRTP(header *rtp.Header, payload []byte) (int, error) {
 			// this setup should only happen on the first call to sendRTP
 			codecs := r.api.mediaEngine.GetCodecsByName(r.track.codec.Name)
 			if len(codecs) == 0 {
-				return 0, fmt.Errorf("no %d codecs in media engine", r.track.codec.Name)
+				return 0, fmt.Errorf("no %s codecs in media engine", r.track.codec.Name)
 			}
 			payloadType := codecs[0].PayloadType
 			r.payloadType = &payloadType


### PR DESCRIPTION
#### Description

The original code only worked with Chrome as sender and receiver. This
change permits the sender and receivers to all be different types of
clients, such as Chrome, Safari, and Firefox.

* Changed local track so it always gets VP8 from remote client using
their dynamic payload type instead of assuming 96, enabling interop
with Safari and recent Firefox.

* Changed remote tracks so they also negotiate the correct VP8 payload
  type.

* Added MediaEngine.GetCodecsByName() to assist the above.

* Changed RTPSender so it writes its MediaEngine's VP8 payload type
  into the RTP header, rather than using the sender's VP8 payload type
  when the packets are written to the remote track.

#### Compatibility

This change to RTPSender will affect all code that
currently uses RTPSender.sendRTP(). That method has not written into
the RTP header until now.
