### PR TITLE
Remove doubling of connection setup in SDP creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Ato Araki](https://github.com/atotto)
 * [Rafael Viscarra](https://github.com/rviscarra)
 * [Mike Coleman](https://github.com/fivebats)
+* [Suhas Gaddam](https://github.com/suhasgaddam)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -469,10 +469,6 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 
 	d = d.WithValueAttribute(sdp.AttrKeyGroup, bundleValue)
 
-	for _, m := range d.MediaDescriptions {
-		m.WithValueAttribute(sdp.AttrKeyConnectionSetup, "actpass")
-	}
-
 	sdpBytes, err := d.Marshal()
 	if err != nil {
 		return SessionDescription{}, err

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 
@@ -458,4 +459,31 @@ func TestPeerConnection_satisfyTypeAndDirection(t *testing.T) {
 		}
 	}
 
+}
+
+func TestOneAttrKeyConnectionSetupPerMediaDescriptionInSDP(t *testing.T) {
+	pc, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	_, err = pc.AddTransceiver(RTPCodecTypeVideo)
+	assert.NoError(t, err)
+
+	_, err = pc.AddTransceiver(RTPCodecTypeAudio)
+	assert.NoError(t, err)
+
+	_, err = pc.AddTransceiver(RTPCodecTypeAudio)
+	assert.NoError(t, err)
+
+	_, err = pc.AddTransceiver(RTPCodecTypeVideo)
+	assert.NoError(t, err)
+
+	sdp, err := pc.CreateOffer(nil)
+	assert.NoError(t, err)
+
+	re := regexp.MustCompile(`a=setup:[[:alpha:]]+`)
+
+	matches := re.FindAllStringIndex(sdp.SDP, -1)
+
+	// 5 because a datachannel is always added
+	assert.Len(t, matches, 5)
 }


### PR DESCRIPTION
#### Description
I noticed `a:setup=actpass` showing up twice in each media description in an SDP. It is already being added in the `addTransceiverSDP` and `addDataMediaSection` methods.

#### Reference issue
