### PR TITLE
matching the video MTU from chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Rafael Viscarra](https://github.com/rviscarra)
 * [Mike Coleman](https://github.com/fivebats)
 * [Suhas Gaddam](https://github.com/suhasgaddam)
+* [Robert Eperjesi](https://github.com/epes)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/track.go
+++ b/track.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	rtpOutboundMTU          = 1400
+	rtpOutboundMTU          = 1200
 	trackDefaultIDLength    = 16
 	trackDefaultLabelLength = 16
 )


### PR DESCRIPTION
#### Description
Setting the MTU to be the same as the video MTU from Chromium. This should fix issues where certain networks would fragment RTP packets from Pion but not from Chromium.

Discussion: https://groups.google.com/forum/#!topic/discuss-webrtc/gH5ysR3SoZI
Chromium constant: https://codesearch.chromium.org/chromium/src/third_party/webrtc/media/engine/constants.cc?type=cs&q=1200+file:webrtc&sq=package:chromium&l=16

