### PR TITLE
Fix possible ill-order of OnLocalCandidate call

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Rafael Viscarra](https://github.com/rviscarra)
 * [Mike Coleman](https://github.com/fivebats)
 * [Suhas Gaddam](https://github.com/suhasgaddam)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/icegatherer.go
+++ b/icegatherer.go
@@ -274,12 +274,14 @@ func (g *ICEGatherer) SignalCandidates() error {
 	g.lock.Unlock()
 
 	if onLocalCandidateHdlr != nil {
-		for i := range candidates {
-			go onLocalCandidateHdlr(&candidates[i])
-		}
-		// Call the handler one last time with nil. This is a signal that candidate
-		// gathering is complete.
-		go onLocalCandidateHdlr(nil)
+		go func() {
+			for i := range candidates {
+				onLocalCandidateHdlr(&candidates[i])
+			}
+			// Call the handler one last time with nil. This is a signal that candidate
+			// gathering is complete.
+			onLocalCandidateHdlr(nil)
+		}()
 	}
 	return nil
 }

--- a/icegatherer_test.go
+++ b/icegatherer_test.go
@@ -60,3 +60,57 @@ func TestNewICEGatherer_Success(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestICEGather_LocalCandidateOrder(t *testing.T) {
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	opts := ICEGatherOptions{
+		ICEServers: []ICEServer{{URLs: []string{"stun:stun.l.google.com:19302"}}},
+	}
+
+	to := time.Second
+	gatherer, err := NewICEGatherer(10000, 10010, &to, &to, &to, &to, &to, &to, &to, logging.NewDefaultLoggerFactory(), false, []NetworkType{NetworkTypeUDP4}, opts)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if gatherer.State() != ICEGathererStateNew {
+		t.Fatalf("Expected gathering state new")
+	}
+
+	for i := 0; i < 10; i++ {
+		candidate := make(chan *ICECandidate)
+		gatherer.OnLocalCandidate(func(c *ICECandidate) {
+			candidate <- c
+		})
+
+		if err := gatherer.SignalCandidates(); err != nil {
+			t.Error(err)
+		}
+		endGathering := false
+
+	L:
+		for {
+			select {
+			case c := <-candidate:
+				if c == nil {
+					endGathering = true
+				} else if endGathering {
+					t.Error("Received a candidate after the last candidate")
+					break L
+				}
+			case <-time.After(100 * time.Millisecond):
+				if !endGathering {
+					t.Error("Timed out before receiving the last candidate")
+				}
+				break L
+			}
+		}
+	}
+
+	if err := gatherer.Close(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
#### Description

onLocalCandidateHdlr was called in one candidate per one goroutine.
It is not guaranteed to be called in-order, and nil can be sent before the final candidate.
Before this fix, nil is sent before sending all candidates 8-10 times per 10 tries on my local environment.
