### PR TITLE
problem: instructions are outdated and broken

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ We've made it easy to run the browser based examples on your local machine.
 
 1. Build and run the example server:
     ``` sh
-    go get github.com/pion/webrtc
+    go get github.com/pion/webrtc/v2
     cd $GOPATH/src/github.com/pion/webrtc/examples
     go run examples.go
     ```


### PR DESCRIPTION
solution: append `v2` to the import path.
See #795 for context.

#### Description

#### Reference issue
Fixes #...
