### PR TITLE
Guard against SCTPTransport being closed during start

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -94,7 +94,7 @@ func (r *SCTPTransport) Start(remoteCaps SCTPCapabilities) error {
 	}
 	r.association = sctpAssociation
 
-	go r.acceptDataChannels()
+	go r.acceptDataChannels(sctpAssociation)
 
 	return nil
 }
@@ -126,10 +126,7 @@ func (r *SCTPTransport) ensureDTLS() error {
 	return nil
 }
 
-func (r *SCTPTransport) acceptDataChannels() {
-	r.lock.RLock()
-	a := r.association
-	r.lock.RUnlock()
+func (r *SCTPTransport) acceptDataChannels(a *sctp.Association) {
 	for {
 		dc, err := datachannel.Accept(a, &datachannel.Config{
 			LoggerFactory: r.api.settingEngine.LoggerFactory,


### PR DESCRIPTION
Pass association to readLoop instead of accessing SCTPTransport
inside readloop. It is possible that before the read loop starts
the SCTPTransport assocation could be cleared, this would cause
us to pass a  nil assocation to pion/datachannel

Resolves #571
