### PR TITLE
Fix763

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -832,10 +832,7 @@ func (pc *PeerConnection) SetLocalDescription(desc SessionDescription) error {
 		return nil
 	}
 
-	if desc.Type == SDPTypeAnswer {
-		return pc.iceGatherer.Gather()
-	}
-	return nil
+	return pc.iceGatherer.Gather()
 }
 
 // LocalDescription returns pendingLocalDescription if it is not null and
@@ -1027,9 +1024,6 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 		pc.mu.Unlock()
 	}()
 
-	if (desc.Type == SDPTypeAnswer || desc.Type == SDPTypePranswer) && pc.iceGatherer.agentIsTrickle {
-		return pc.iceGatherer.Gather()
-	}
 	return nil
 }
 


### PR DESCRIPTION
#### Description

This patch reverts the breaking changes made to the core WebRTC API in https://github.com/pion/webrtc/pull/763/ and modifies the pion-to-pion-trickle example to work properly with the WebRTC API as specified in https://w3c.github.io/webrtc-pc/ and following the specification of trickle ICE in https://tools.ietf.org/html/draft-ietf-mmusic-trickle-ice-02

