### PR TITLE
Check buffer length is 0 or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Gareth Hayes](https://github.com/gazhayes)
 * [Sebastian Waisbrot](https://github.com/seppo0010)
 * [Masataka Hisasue](https://github.com/sylba2050) - *Fix Docs*
+* [Hongchao Ma(马洪超)](https://github.com/hcm007) - *Fix Issues*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -127,7 +127,11 @@ func (m *Mux) dispatch(buf []byte) error {
 	m.lock.Unlock()
 
 	if endpoint == nil {
-		m.log.Warnf("Warning: mux: no endpoint for packet starting with %d\n", buf[0])
+		if len(buf) > 0 {
+			m.log.Warnf("Warning: mux: no endpoint for packet starting with %d\n", buf[0])
+		} else {
+			m.log.Warnf("Warning: mux: no endpoint")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
#### Buffer index out of range
```
goroutine 102716 [running]:
github.com/pion/webrtc/v2/internal/mux.(*Mux).dispatch(0xc0313608c0, 0xc0235b2000, 0x0, 0x2000, 0x0, 0x0)
    /go/pkg/mod/github.com/pion/webrtc/v2@v2.1.3/internal/mux/mux.go:130 +0x270
github.com/pion/webrtc/v2/internal/mux.(*Mux).readLoop(0xc0313608c0)
    /go/pkg/mod/github.com/pion/webrtc/v2@v2.1.3/internal/mux/mux.go:110 +0xf6
```
#### Reference issue
```
https://github.com/pion/webrtc/issues/820
```
