### PR TITLE
Fix answer bundle for rejected media

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Masataka Hisasue](https://github.com/sylba2050) - *Fix Docs*
 * [Hongchao Ma(马洪超)](https://github.com/hcm007)
 * [Aaron France](https://github.com/AeroNotix)
+* [Chris Hiszpanski](https://github.com/thinkski) - *Fix Answer bundle generation*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
#### Description

When rejecting media, the identification-tag (i.e. media ID) must
be removed from the bundle in addition to setting the m-line port
to zero.

See https://tools.ietf.org/html/draft-ietf-mmusic-sdp-bundle-negotiation-39#section-8.3.4

#### Reference issue
Fixes #840 