### PR TITLE
Handle undeclared SSRCes

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -5,6 +5,7 @@ const (
 	// comparisons when no value was defined.
 	Unknown    = iota
 	unknownStr = "unknown"
+	ssrcStr    = "ssrc"
 
 	receiveMTU = 8192
 )

--- a/sdpsemantics_test.go
+++ b/sdpsemantics_test.go
@@ -45,7 +45,7 @@ func getMdNames(sdp *sdp.SessionDescription) []string {
 func extractSsrcList(md *sdp.MediaDescription) []string {
 	ssrcMap := map[string]struct{}{}
 	for _, attr := range md.Attributes {
-		if attr.Key == "ssrc" {
+		if attr.Key == ssrcStr {
 			ssrc := strings.Fields(attr.Value)[0]
 			ssrcMap[ssrc] = struct{}{}
 		}
@@ -286,7 +286,7 @@ func TestSDPSemantics_UnifiedPlanWithFallback(t *testing.T) {
 	extractSsrcList := func(md *sdp.MediaDescription) []string {
 		ssrcMap := map[string]struct{}{}
 		for _, attr := range md.Attributes {
-			if attr.Key == "ssrc" {
+			if attr.Key == ssrcStr {
 				ssrc := strings.Fields(attr.Value)[0]
 				ssrcMap[ssrc] = struct{}{}
 			}


### PR DESCRIPTION
If we receive an unknown SSRC and we have a single
media section with no SSRCes declared fire an OnTrack
with that stream

Resolves #880
