### PR TITLE
Fix description of IVF headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Aaron France](https://github.com/AeroNotix)
 * [Chris Hiszpanski](https://github.com/thinkski) - *Fix Answer bundle generation*
 * [Vicken Simonian](https://github.com/vsimon)
+* [Guilherme Souza](https://github.com/gqgs)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -50,12 +50,12 @@ func (i *IVFWriter) writeHeader() error {
 	header := make([]byte, 32)
 	copy(header[0:], []byte("DKIF"))                // DKIF
 	binary.LittleEndian.PutUint16(header[4:], 0)    // Version
-	binary.LittleEndian.PutUint16(header[6:], 32)   // Header Size
+	binary.LittleEndian.PutUint16(header[6:], 32)   // Header size
 	copy(header[8:], []byte("VP80"))                // FOURCC
-	binary.LittleEndian.PutUint16(header[12:], 640) // Version
-	binary.LittleEndian.PutUint16(header[14:], 480) // Header Size
-	binary.LittleEndian.PutUint32(header[16:], 30)  // Framerate numerator
-	binary.LittleEndian.PutUint32(header[20:], 1)   // Framerate Denominator
+	binary.LittleEndian.PutUint16(header[12:], 640) // Width in pixels
+	binary.LittleEndian.PutUint16(header[14:], 480) // Height in pixels
+	binary.LittleEndian.PutUint32(header[16:], 30)  // Framerate denominator
+	binary.LittleEndian.PutUint32(header[20:], 1)   // Framerate numerator
 	binary.LittleEndian.PutUint32(header[24:], 900) // Frame count, will be updated on first Close() call
 	binary.LittleEndian.PutUint32(header[28:], 0)   // Unused
 


### PR DESCRIPTION
#### Description
Comments were incorrectly describing fields of IVF's header.

Reference:
https://chromium.googlesource.com/chromium/src/media/+/master/filters/ivf_parser.h#22
https://wiki.multimedia.cx/index.php/IVF