### PR TITLE
Fix all routine leaks in tests

### DIFF
--- a/datachannel_go_test.go
+++ b/datachannel_go_test.go
@@ -351,6 +351,9 @@ func TestDataChannelBufferedAmount(t *testing.T) {
 }
 
 func TestEOF(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
 	log := logging.NewDefaultLoggerFactory().NewLogger("test")
 	label := "test-channel"
 	testData := []byte("this is some test data")

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -16,19 +16,12 @@ import (
 const expectedLabel = "data"
 
 func closePair(t *testing.T, pc1, pc2 io.Closer, done chan bool) {
-	var err error
 	select {
 	case <-time.After(10 * time.Second):
 		t.Fatalf("closePair timed out waiting for done signal")
 	case <-done:
-		err = pc1.Close()
-		if err != nil {
-			t.Fatalf("Failed to close offer PC")
-		}
-		err = pc2.Close()
-		if err != nil {
-			t.Fatalf("Failed to close answer PC")
-		}
+		assert.NoError(t, pc1.Close())
+		assert.NoError(t, pc2.Close())
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/pion/datachannel v1.4.12
 	github.com/pion/dtls v1.5.2
-	github.com/pion/ice v0.7.0
+	github.com/pion/ice v0.7.1
 	github.com/pion/logging v0.2.2
 	github.com/pion/quic v0.1.1
 	github.com/pion/rtcp v1.2.1
@@ -13,8 +13,9 @@ require (
 	github.com/pion/sctp v1.7.2
 	github.com/pion/sdp/v2 v2.3.1
 	github.com/pion/srtp v1.2.6
-	github.com/pion/transport v0.8.9
+	github.com/pion/transport v0.8.10
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0 // indirect
+	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
+	golang.org/x/sys v0.0.0-20191023151326-f89234f9a2c2 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/pion/datachannel v1.4.12 h1:fFdt26Ppkk9US5mpa/G+9QvYDoYXRIWipj0YUhxSB
 github.com/pion/datachannel v1.4.12/go.mod h1:Ulrx2j4r8c0Za5ltWFv/hZvSpc3ZpvOvcz46tvnt+PY=
 github.com/pion/dtls v1.5.2 h1:cIVSR1GPGfUAnRS1nl7jSdpoB63WOLANSu4ewpwRHzg=
 github.com/pion/dtls v1.5.2/go.mod h1:v4ULmyyV65geAZQBBckCjgMhmngTqz7HQVsQVYnfkGo=
-github.com/pion/ice v0.7.0 h1:hR+aOsdqAiVO95CgarQkzOUzmIC687/RU31epOSFM7o=
-github.com/pion/ice v0.7.0/go.mod h1:fPnWLWO3B83fJmO6Sci5Mv3ypN4Vd956Py4JlbJfVwU=
+github.com/pion/ice v0.7.1 h1:Leyv/AO/mSPeevlvKuUEgNkfYNZgETONNXTVTYCzMbk=
+github.com/pion/ice v0.7.1/go.mod h1:fPnWLWO3B83fJmO6Sci5Mv3ypN4Vd956Py4JlbJfVwU=
 github.com/pion/logging v0.2.1/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=
 github.com/pion/logging v0.2.2/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
@@ -53,8 +53,9 @@ github.com/pion/srtp v1.2.6/go.mod h1:rd8imc5htjfs99XiEoOjLMEOcVjME63UHx9Ek9IGst
 github.com/pion/stun v0.3.3 h1:brYuPl9bN9w/VM7OdNzRSLoqsnwlyNvD9MVeJrHjDQw=
 github.com/pion/stun v0.3.3/go.mod h1:xrCld6XM+6GWDZdvjPlLMsTU21rNxnO6UO8XsAvHr/M=
 github.com/pion/transport v0.6.0/go.mod h1:iWZ07doqOosSLMhZ+FXUTq+TamDoXSllxpbGcfkCmbE=
-github.com/pion/transport v0.8.9 h1:3PUZULb0WZd/QNfXKKMwcUHzLR+XfNem6lF2M9UrxSU=
 github.com/pion/transport v0.8.9/go.mod h1:lpeSM6KJFejVtZf8k0fgeN7zE73APQpTF83WvA1FVP8=
+github.com/pion/transport v0.8.10 h1:lTiobMEw2PG6BH/mgIVqTV2mBp/mPT+IJLaN8ZxgdHk=
+github.com/pion/transport v0.8.10/go.mod h1:tBmha/UCjpum5hqTWhfAEs3CO4/tHSg0MYRhSzR+CZ8=
 github.com/pion/turn v1.4.0 h1:7NUMRehQz4fIo53Qv9ui1kJ0Kr1CA82I81RHKHCeM80=
 github.com/pion/turn v1.4.0/go.mod h1:aDSi6hWX/hd1+gKia9cExZOR0MU95O7zX9p3Gw/P2aU=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -75,8 +76,8 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190930134127-c5a3c61f89f3/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191002035440-2ec189313ef0 h1:2mqDk8w/o6UmeUCu5Qiq2y7iMf6anbx+YA8d1JFoFrs=
-golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094 h1:5O4U9trLjNpuhpynaDsqwCk+Tw6seqJz1EbqbnzHrc8=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -85,6 +86,8 @@ golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24 h1:R8bzl0244nw47n1xKs1MUMAaTNgjavKcN/aX2Ss3+Fo=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191023151326-f89234f9a2c2 h1:I7efaDQAsIQmkTF+WSdcydwVWzK07Yuz8IFF8rNkDe0=
+golang.org/x/sys v0.0.0-20191023151326-f89234f9a2c2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/icegatherer_test.go
+++ b/icegatherer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pion/ice"
 	"github.com/pion/logging"
 	"github.com/pion/transport/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewICEGatherer_Success(t *testing.T) {
@@ -56,16 +57,16 @@ func TestNewICEGatherer_Success(t *testing.T) {
 		t.Fatalf("No candidates gathered")
 	}
 
-	err = gatherer.Close()
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, gatherer.Close())
 }
 
 func TestICEGather_LocalCandidateOrder(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 20)
 	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
 
 	opts := ICEGatherOptions{
 		ICEServers: []ICEServer{{URLs: []string{"stun:stun.l.google.com:19302"}}},
@@ -111,12 +112,13 @@ func TestICEGather_LocalCandidateOrder(t *testing.T) {
 		}
 	}
 
-	if err := gatherer.Close(); err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, gatherer.Close())
 }
 
 func TestNewICEGatherer_NAT1To1IP(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
 	t.Run("1:1 NAT with host", func(t *testing.T) {
 		opts := ICEGatherOptions{
 			ICEServers: []ICEServer{},
@@ -142,10 +144,7 @@ func TestNewICEGatherer_NAT1To1IP(t *testing.T) {
 			t.Fatal("unexpected nat1To1IPs value")
 		}
 
-		err = gatherer.Close()
-		if err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, gatherer.Close())
 	})
 
 	t.Run("1:1 NAT with srflx", func(t *testing.T) {
@@ -173,10 +172,7 @@ func TestNewICEGatherer_NAT1To1IP(t *testing.T) {
 			t.Fatal("unexpected nat1To1IPs value")
 		}
 
-		err = gatherer.Close()
-		if err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, gatherer.Close())
 	})
 
 	t.Run("1:1 NAT with invalid candidate type", func(t *testing.T) {
@@ -204,9 +200,6 @@ func TestNewICEGatherer_NAT1To1IP(t *testing.T) {
 			t.Fatal("unexpected nat1To1IPs value")
 		}
 
-		err = gatherer.Close()
-		if err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, gatherer.Close())
 	})
 }

--- a/peerconnection_close_test.go
+++ b/peerconnection_close_test.go
@@ -7,10 +7,8 @@ import (
 	"time"
 
 	"github.com/pion/transport/test"
+	"github.com/stretchr/testify/assert"
 )
-
-// TestPeerConnection_Close is moved to it's own file because the tests
-// in rtcpeerconnection_test.go are leaky, making the goroutine report useless.
 
 func TestPeerConnection_Close(t *testing.T) {
 	// Limit runtime in case of deadlocks
@@ -54,15 +52,8 @@ func TestPeerConnection_Close(t *testing.T) {
 
 	<-awaitSetup
 
-	err = pcOffer.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = pcAnswer.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, pcOffer.Close())
+	assert.NoError(t, pcAnswer.Close())
 
 	<-awaitICEClosed
 }
@@ -86,10 +77,7 @@ func TestPeerConnection_Close_PreICE(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = pcOffer.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, pcOffer.Close())
 
 	if err = pcAnswer.SetRemoteDescription(answer); err != nil {
 		t.Fatal(err)
@@ -102,10 +90,7 @@ func TestPeerConnection_Close_PreICE(t *testing.T) {
 		time.Sleep(time.Second)
 	}
 
-	err = pcAnswer.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, pcAnswer.Close())
 
 	// Assert that ICETransport is shutdown, test timeout will prevent deadlock
 	for {


### PR DESCRIPTION
Fix tests that didn't properly close and add
test.CheckRoutines everywhere. No changes in pion/webrtc
but we did catch hanging thread in pion/ice