### PR TITLE
fix: decrease receiveMTU down to 1200 bytes for less memory bloat

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -7,5 +7,6 @@ const (
 	unknownStr = "unknown"
 	ssrcStr    = "ssrc"
 
-	receiveMTU = 1200
+	// Equal to UDP MTU
+	receiveMTU = 1460
 )

--- a/constants.go
+++ b/constants.go
@@ -7,5 +7,5 @@ const (
 	unknownStr = "unknown"
 	ssrcStr    = "ssrc"
 
-	receiveMTU = 8192
+	receiveMTU = 1200
 )


### PR DESCRIPTION
#### Description
From the discussion in slack channel I suggest here to decrease buffer size to 1200 as standard for chrome (https://groups.google.com/forum/#!topic/discuss-webrtc/gH5ysR3SoZI)

