### PR TITLE
Properly generate DataChannel streamId

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -86,7 +86,7 @@ func (api *API) newDataChannel(params *DataChannelParameters, log logging.Levele
 		label:             params.Label,
 		protocol:          params.Protocol,
 		negotiated:        params.Negotiated,
-		id:                &params.ID,
+		id:                params.ID,
 		ordered:           params.Ordered,
 		maxPacketLifeTime: params.MaxPacketLifeTime,
 		maxRetransmits:    params.MaxRetransmits,
@@ -146,6 +146,15 @@ func (d *DataChannel) open(sctpTransport *SCTPTransport) error {
 		Protocol:             d.protocol,
 		Negotiated:           d.negotiated,
 		LoggerFactory:        d.api.settingEngine.LoggerFactory,
+	}
+
+	if d.id == nil {
+		generatedID, err := d.sctpTransport.generateDataChannelID(d.sctpTransport.dtlsTransport.role())
+		if err != nil {
+			return err
+		}
+
+		d.id = &generatedID
 	}
 
 	dc, err := datachannel.Dial(d.sctpTransport.association, *d.id, cfg)

--- a/datachannel_go_test.go
+++ b/datachannel_go_test.go
@@ -19,38 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateDataChannelID(t *testing.T) {
-	api := NewAPI()
-
-	testCases := []struct {
-		client bool
-		c      *PeerConnection
-		result uint16
-	}{
-		{true, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{}, api: api}, 0},
-		{true, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{1: nil}, api: api}, 0},
-		{true, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{0: nil}, api: api}, 2},
-		{true, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{0: nil, 2: nil}, api: api}, 4},
-		{true, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{0: nil, 4: nil}, api: api}, 2},
-		{false, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{}, api: api}, 1},
-		{false, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{0: nil}, api: api}, 1},
-		{false, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{1: nil}, api: api}, 3},
-		{false, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{1: nil, 3: nil}, api: api}, 5},
-		{false, &PeerConnection{sctpTransport: api.NewSCTPTransport(nil), dataChannels: map[uint16]*DataChannel{1: nil, 5: nil}, api: api}, 3},
-	}
-
-	for _, testCase := range testCases {
-		id, err := testCase.c.generateDataChannelID(testCase.client)
-		if err != nil {
-			t.Errorf("failed to generate id: %v", err)
-			return
-		}
-		if id != testCase.result {
-			t.Errorf("Wrong id: %d expected %d", id, testCase.result)
-		}
-	}
-}
-
 func TestDataChannel_EventHandlers(t *testing.T) {
 	to := test.TimeOut(time.Second * 20)
 	defer to.Stop()

--- a/datachannel_ortc_test.go
+++ b/datachannel_ortc_test.go
@@ -43,9 +43,10 @@ func TestDataChannel_ORTCE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var id uint16 = 1
 	dcParams := &DataChannelParameters{
 		Label: "Foo",
-		ID:    1,
+		ID:    &id,
 	}
 	channelA, err := stackA.api.NewDataChannel(stackA.sctp, dcParams)
 	if err != nil {

--- a/datachannelparameters.go
+++ b/datachannelparameters.go
@@ -4,7 +4,7 @@ package webrtc
 type DataChannelParameters struct {
 	Label             string  `json:"label"`
 	Protocol          string  `json:"protocol"`
-	ID                uint16  `json:"id"`
+	ID                *uint16 `json:"id"`
 	Ordered           bool    `json:"ordered"`
 	MaxPacketLifeTime *uint16 `json:"maxPacketLifeTime"`
 	MaxRetransmits    *uint16 `json:"maxRetransmits"`

--- a/examples/ortc/main.go
+++ b/examples/ortc/main.go
@@ -120,9 +120,11 @@ func main() {
 
 	// Construct the data channel as the offerer
 	if *isOffer {
+		var id uint16 = 1
+
 		dcParams := &webrtc.DataChannelParameters{
 			Label: "Foo",
-			ID:    1,
+			ID:    &id,
 		}
 		var channel *webrtc.DataChannel
 		channel, err = api.NewDataChannel(sctp, dcParams)

--- a/icetransport.go
+++ b/icetransport.go
@@ -81,6 +81,10 @@ func (t *ICETransport) Start(gatherer *ICEGatherer, params ICEParameters, role *
 	}
 
 	agent := t.gatherer.agent
+	if agent == nil {
+		return errors.New("ICEAgent does not exist, unable to start ICETransport")
+	}
+
 	if err := agent.OnConnectionStateChange(func(iceState ice.ConnectionState) {
 		state := newICETransportStateFromICE(iceState)
 		t.lock.Lock()

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -544,15 +544,6 @@ func TestOfferRejectionMissingCodec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	iceComplete := make(chan bool)
-	noCodecPC.OnICEConnectionStateChange(func(iceState ICEConnectionState) {
-		if iceState == ICEConnectionStateConnected {
-			go func() {
-				close(iceComplete)
-			}()
-		}
-	})
-
 	track, err := pc.NewTrack(DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
 	if err != nil {
 		t.Fatal(err)
@@ -580,7 +571,6 @@ func TestOfferRejectionMissingCodec(t *testing.T) {
 		t.Fatalf("rejecting unknown codec: sdp m=%s, want trailing 0", *videoDesc.MediaName.String())
 	}
 
-	<-iceComplete
 	assert.NoError(t, noCodecPC.Close())
 	assert.NoError(t, pc.Close())
 }

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -1,0 +1,45 @@
+// +build !js
+
+package webrtc
+
+import "testing"
+
+func TestGenerateDataChannelID(t *testing.T) {
+	sctpTransportWithChannels := func(ids []uint16) *SCTPTransport {
+		ret := &SCTPTransport{dataChannels: []*DataChannel{}}
+
+		for i := range ids {
+			id := ids[i]
+			ret.dataChannels = append(ret.dataChannels, &DataChannel{id: &id})
+		}
+
+		return ret
+	}
+
+	testCases := []struct {
+		role   DTLSRole
+		s      *SCTPTransport
+		result uint16
+	}{
+		{DTLSRoleClient, sctpTransportWithChannels([]uint16{}), 0},
+		{DTLSRoleClient, sctpTransportWithChannels([]uint16{1}), 0},
+		{DTLSRoleClient, sctpTransportWithChannels([]uint16{0}), 2},
+		{DTLSRoleClient, sctpTransportWithChannels([]uint16{0, 2}), 4},
+		{DTLSRoleClient, sctpTransportWithChannels([]uint16{0, 4}), 2},
+		{DTLSRoleServer, sctpTransportWithChannels([]uint16{}), 1},
+		{DTLSRoleServer, sctpTransportWithChannels([]uint16{0}), 1},
+		{DTLSRoleServer, sctpTransportWithChannels([]uint16{1}), 3},
+		{DTLSRoleServer, sctpTransportWithChannels([]uint16{1, 3}), 5},
+		{DTLSRoleServer, sctpTransportWithChannels([]uint16{1, 5}), 3},
+	}
+	for _, testCase := range testCases {
+		id, err := testCase.s.generateDataChannelID(testCase.role)
+		if err != nil {
+			t.Errorf("failed to generate id: %v", err)
+			return
+		}
+		if id != testCase.result {
+			t.Errorf("Wrong id: %d expected %d", id, testCase.result)
+		}
+	}
+}


### PR DESCRIPTION
Before we computed DataChannel IDs before signaling, this
is incorrect because IDs must take into account if we are
running an DTLS Client or Server.

This updates the DataChannel ID generation code to take this
into account before generating a streamId.

Resolves #908
