### PR TITLE
Only create ICEGather via API

### DIFF
--- a/ice_go.go
+++ b/ice_go.go
@@ -4,31 +4,6 @@ package webrtc
 
 import "github.com/pion/sdp/v2"
 
-// NewICEGatherer creates a new NewICEGatherer.
-// This constructor is part of the ORTC API. It is not
-// meant to be used together with the basic WebRTC API.
-func (api *API) NewICEGatherer(opts ICEGatherOptions) (*ICEGatherer, error) {
-	return NewICEGatherer(
-		api.settingEngine.ephemeralUDP.PortMin,
-		api.settingEngine.ephemeralUDP.PortMax,
-		api.settingEngine.timeout.ICEConnection,
-		api.settingEngine.timeout.ICEKeepalive,
-		api.settingEngine.timeout.ICECandidateSelectionTimeout,
-		api.settingEngine.timeout.ICEHostAcceptanceMinWait,
-		api.settingEngine.timeout.ICESrflxAcceptanceMinWait,
-		api.settingEngine.timeout.ICEPrflxAcceptanceMinWait,
-		api.settingEngine.timeout.ICERelayAcceptanceMinWait,
-		api.settingEngine.LoggerFactory,
-		api.settingEngine.candidates.ICETrickle,
-		api.settingEngine.candidates.ICELite,
-		api.settingEngine.candidates.ICENetworkTypes,
-		api.settingEngine.candidates.InterfaceFilter,
-		api.settingEngine.candidates.NAT1To1IPs,
-		api.settingEngine.candidates.NAT1To1IPCandidateType,
-		opts,
-	)
-}
-
 // NewICETransport creates a new NewICETransport.
 // This constructor is part of the ORTC API. It is not
 // meant to be used together with the basic WebRTC API.

--- a/icetransport.go
+++ b/icetransport.go
@@ -267,7 +267,7 @@ func (t *ICETransport) NewEndpoint(f mux.MatchFunc) *mux.Endpoint {
 func (t *ICETransport) ensureGatherer() error {
 	if t.gatherer == nil {
 		return errors.New("gatherer not started")
-	} else if t.gatherer.getAgent() == nil && t.gatherer.agentIsTrickle {
+	} else if t.gatherer.getAgent() == nil && t.gatherer.api.settingEngine.candidates.ICETrickle {
 		// Special case for trickle=true. (issue-707)
 		if err := t.gatherer.createAgent(); err != nil {
 			return err

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -112,7 +112,7 @@ func (api *API) NewPeerConnection(configuration Configuration) (*PeerConnection,
 		return nil, err
 	}
 
-	if !pc.iceGatherer.agentIsTrickle {
+	if !pc.api.settingEngine.candidates.ICETrickle {
 		if err = pc.iceGatherer.Gather(); err != nil {
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 		}
 	}
 
-	if pc.iceGatherer.lite {
+	if pc.api.settingEngine.candidates.ICELite {
 		// RFC 5245 S15.3
 		d = d.WithValueAttribute(sdp.AttrKeyICELite, sdp.AttrKeyICELite)
 	}
@@ -869,7 +869,7 @@ func (pc *PeerConnection) SetLocalDescription(desc SessionDescription) error {
 	// setup while also support the old trickle=false synchronous gathering
 	// process this is necessary to avoid calling Gather() in multiple
 	// places; which causes race conditions. (issue-707)
-	if !pc.iceGatherer.agentIsTrickle {
+	if !pc.api.settingEngine.candidates.ICETrickle {
 		if err := pc.iceGatherer.SignalCandidates(); err != nil {
 			return err
 		}
@@ -963,7 +963,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 	// If one of the agents is lite and the other one is not, the lite agent must be the controlling agent.
 	// If both or neither agents are lite the offering agent is controlling.
 	// RFC 8445 S6.1.1
-	if (weOffer && remoteIsLite == pc.iceGatherer.lite) || (remoteIsLite && !pc.iceGatherer.lite) {
+	if (weOffer && remoteIsLite == pc.api.settingEngine.candidates.ICELite) || (remoteIsLite && !pc.api.settingEngine.candidates.ICELite) {
 		iceRole = ICERoleControlling
 	}
 


### PR DESCRIPTION
Use values directly from SettingValues instead of just copying
when calling NewICEGatherer. This greatly reduces the LoC and makes
the public API a little cleaner.

Resolves #872
