### PR TITLE
Properly set DataChannel readyState on Close

### DIFF
--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -211,6 +211,23 @@ func TestDataChannel_Send(t *testing.T) {
 	})
 }
 
+func TestDataChannel_Close(t *testing.T) {
+	t.Run("Close after PeerConnection Closed", func(t *testing.T) {
+		report := test.CheckRoutines(t)
+		defer report()
+
+		offerPC, answerPC, err := newPair()
+		assert.NoError(t, err)
+
+		dc, err := offerPC.CreateDataChannel(expectedLabel, nil)
+		assert.NoError(t, err)
+
+		assert.NoError(t, offerPC.Close())
+		assert.NoError(t, answerPC.Close())
+		assert.NoError(t, dc.Close())
+	})
+}
+
 func TestDataChannelParameters(t *testing.T) {
 	report := test.CheckRoutines(t)
 	defer report()

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1555,7 +1555,16 @@ func (pc *PeerConnection) Close() error {
 		}
 	}
 
-	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #6,#7)
+	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #6)
+	if pc.sctpTransport != nil {
+		pc.sctpTransport.lock.Lock()
+		for _, d := range pc.sctpTransport.dataChannels {
+			d.setReadyState(DataChannelStateClosed)
+		}
+		pc.sctpTransport.lock.Unlock()
+	}
+
+	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #7)
 	if pc.sctpTransport != nil {
 		if err := pc.sctpTransport.Stop(); err != nil {
 			closeErrs = append(closeErrs, err)


### PR DESCRIPTION
DataChannel readyState should be set to Closed on PeerConnection
shutdown. If not properly set it would attempt to interact with
state that doesn't exist after the PeerConnection has been Closed.

Setting the readyState is also clearly defined in the W3C webrtc-pc

Resolves #915