### PR TITLE
Allow user to Close DataChannel before signaling

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -383,7 +383,8 @@ func (d *DataChannel) Detach() (datachannel.ReadWriteCloser, error) {
 // the DataChannel object was created by this peer or the remote peer.
 func (d *DataChannel) Close() error {
 	d.mu.Lock()
-	isClosed := d.readyState == DataChannelStateClosing || d.readyState == DataChannelStateClosed
+	isClosed := d.readyState == DataChannelStateClosed
+	haveSctpTransport := d.dataChannel != nil
 	d.mu.Unlock()
 
 	if isClosed {
@@ -391,6 +392,10 @@ func (d *DataChannel) Close() error {
 	}
 
 	d.setReadyState(DataChannelStateClosing)
+	if !haveSctpTransport {
+		return nil
+	}
+
 	return d.dataChannel.Close()
 }
 

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -212,10 +212,10 @@ func TestDataChannel_Send(t *testing.T) {
 }
 
 func TestDataChannel_Close(t *testing.T) {
-	t.Run("Close after PeerConnection Closed", func(t *testing.T) {
-		report := test.CheckRoutines(t)
-		defer report()
+	report := test.CheckRoutines(t)
+	defer report()
 
+	t.Run("Close after PeerConnection Closed", func(t *testing.T) {
 		offerPC, answerPC, err := newPair()
 		assert.NoError(t, err)
 
@@ -225,6 +225,18 @@ func TestDataChannel_Close(t *testing.T) {
 		assert.NoError(t, offerPC.Close())
 		assert.NoError(t, answerPC.Close())
 		assert.NoError(t, dc.Close())
+	})
+
+	t.Run("Close before connected", func(t *testing.T) {
+		offerPC, answerPC, err := newPair()
+		assert.NoError(t, err)
+
+		dc, err := offerPC.CreateDataChannel(expectedLabel, nil)
+		assert.NoError(t, err)
+
+		assert.NoError(t, dc.Close())
+		assert.NoError(t, offerPC.Close())
+		assert.NoError(t, answerPC.Close())
 	})
 }
 

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1915,12 +1915,14 @@ func (pc *PeerConnection) startTransports(iceRole ICERole, dtlsRole DTLSRole, re
 
 	var openedDCCount uint32
 	for _, d := range dataChannels {
-		err := d.open(pc.sctpTransport)
-		if err != nil {
-			pc.log.Warnf("failed to open data channel: %s", err)
-			continue
+		if d.readyState == DataChannelStateConnecting {
+			err := d.open(pc.sctpTransport)
+			if err != nil {
+				pc.log.Warnf("failed to open data channel: %s", err)
+				continue
+			}
+			openedDCCount++
 		}
-		openedDCCount++
 	}
 
 	pc.sctpTransport.lock.Lock()


### PR DESCRIPTION
Match W3C WebRTC and allow a DataChannel to close even before
signaling happens. When SCTPTransport opens make sure
to check the readyState first.