### PR TITLE
Check for dc.id in stats

### DIFF
--- a/stats_go_test.go
+++ b/stats_go_test.go
@@ -281,7 +281,7 @@ func TestPeerConnection_GetStats(t *testing.T) {
 	assert.Equal(t, uint32(1), connStatsAnswer.DataChannelsClosed)
 	assert.Equal(t, uint32(0), connStatsAnswer.DataChannelsRequested)
 	assert.Equal(t, uint32(1), connStatsAnswer.DataChannelsAccepted)
-	dcStatsAnswer = getDataChannelStats(t, reportPCOffer, answerDC)
+	dcStatsAnswer = getDataChannelStats(t, reportPCAnswer, answerDC)
 	assert.Equal(t, DataChannelStateClosed, dcStatsAnswer.State)
 
 	answerICETransportStats := getTransportStats(t, reportPCAnswer, "iceTransport")


### PR DESCRIPTION
Recent changes allow a dc to have a nil id before it's actually open, but stats used to require the id.

