### PR TITLE
GenerateMulticastDNSCandidates in SettingEngine

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -78,6 +78,11 @@ func (g *ICEGatherer) createAgent() error {
 		nat1To1CandiTyp = ice.CandidateTypeUnspecified
 	}
 
+	var multicastDNSMode ice.MulticastDNSMode
+	if g.api.settingEngine.candidates.GenerateMulticastDNSCandidates {
+		multicastDNSMode = ice.MulticastDNSModeQueryAndGather
+	}
+
 	config := &ice.AgentConfig{
 		Trickle:                   g.api.settingEngine.candidates.ICETrickle,
 		Lite:                      g.api.settingEngine.candidates.ICELite,
@@ -97,6 +102,7 @@ func (g *ICEGatherer) createAgent() error {
 		NAT1To1IPs:                g.api.settingEngine.candidates.NAT1To1IPs,
 		NAT1To1IPCandidateType:    nat1To1CandiTyp,
 		Net:                       g.api.settingEngine.vnet,
+		MulticastDNSMode:          multicastDNSMode,
 	}
 
 	requestedNetworkTypes := g.api.settingEngine.candidates.ICENetworkTypes

--- a/settingengine.go
+++ b/settingengine.go
@@ -32,12 +32,13 @@ type SettingEngine struct {
 		ICERelayAcceptanceMinWait    *time.Duration
 	}
 	candidates struct {
-		ICELite                bool
-		ICETrickle             bool
-		ICENetworkTypes        []NetworkType
-		InterfaceFilter        func(string) bool
-		NAT1To1IPs             []string
-		NAT1To1IPCandidateType ICECandidateType
+		ICELite                        bool
+		ICETrickle                     bool
+		ICENetworkTypes                []NetworkType
+		InterfaceFilter                func(string) bool
+		NAT1To1IPs                     []string
+		NAT1To1IPCandidateType         ICECandidateType
+		GenerateMulticastDNSCandidates bool
 	}
 	answeringDTLSRole DTLSRole
 	vnet              *vnet.Net
@@ -173,4 +174,9 @@ func (e *SettingEngine) SetAnsweringDTLSRole(role DTLSRole) error {
 // learning WebRTC concepts or testing your application in a lab environment
 func (e *SettingEngine) SetVNet(vnet *vnet.Net) {
 	e.vnet = vnet
+}
+
+// GenerateMulticastDNSCandidates pion/ice to generate host candidates with mDNS names instead of IP Addresses
+func (e *SettingEngine) GenerateMulticastDNSCandidates(generateMulticastDNSCandidates bool) {
+	e.candidates.GenerateMulticastDNSCandidates = generateMulticastDNSCandidates
 }


### PR DESCRIPTION
Users can now generate MulticastDNS candidates by enabling this option
in the SettingEngine.