### PR TITLE
Issue 754

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Guilherme Souza](https://github.com/gqgs)
 * [Andrew N. Shalaev](https://github.com/isqad)
 * [David Hamilton](https://github.com/dihamilton)
+* [Ilya Mayorov](https://github.com/faroyam)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
Add SCTPTransport.OnError() func to handle errors in a new goroutine.

#### Description
Add SCTPTransport.OnError() func to handle errors in a new goroutine.
#### Reference issue
https://github.com/pion/webrtc/issues/754

This PR is copy of https://github.com/pion/webrtc/pull/926, got some troubles with fixing commit author name :(