### PR TITLE
Add error when DataChannel isn't detached but DetachDataChannels() is used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Andrew N. Shalaev](https://github.com/isqad)
 * [David Hamilton](https://github.com/dihamilton)
 * [Ilya Mayorov](https://github.com/faroyam)
+* [Patrick Lange](https://github.com/langep)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
#### Description

Added `detached` property to `webrtc.DataChannel` to check at the end of `open()` if `Detach()` was called when `DetachDataChannels()` setting is used.

#### Reference issue
Fixes #838
