### PR TITLE
Fix race in checkDetachAfterOpen

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -200,8 +200,11 @@ func (d *DataChannel) Transport() *SCTPTransport {
 // After onOpen is complete check that the user called detach
 // and provide an error message if the call was missed
 func (d *DataChannel) checkDetachAfterOpen() {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	if d.api.settingEngine.detach.DataChannels && !d.detachCalled {
-		d.log.Error("webrtc.DetachDataChannels() enabled but didn't Detach, call Detach from OnOpen")
+		d.log.Warn("webrtc.DetachDataChannels() enabled but didn't Detach, call Detach from OnOpen")
 	}
 }
 


### PR DESCRIPTION
checkDetachAfterOpen incorrectly accesses detachCalled without holding the lock

Relates to #838
