### PR TITLE
Properly sanitize STUN urls

### DIFF
--- a/configuration_common.go
+++ b/configuration_common.go
@@ -2,28 +2,22 @@ package webrtc
 
 import (
 	"strings"
-
-	"github.com/pion/ice"
 )
 
 // getICEServers side-steps the strict parsing mode of the ice package
 // (as defined in https://tools.ietf.org/html/rfc7064) by stripping any
 // erroneous queries from "stun(s):" URLs before parsing.
-func (c Configuration) getICEServers() (*[]*ice.URL, error) {
-	var iceServers []*ice.URL
-	for _, server := range c.ICEServers {
-		for _, rawURL := range server.URLs {
+func (c Configuration) getICEServers() []ICEServer {
+	iceServers := append([]ICEServer{}, c.ICEServers...)
+	for _, server := range iceServers {
+		for i, rawURL := range server.URLs {
 			if strings.HasPrefix(rawURL, "stun") {
 				// strip the query from "stun(s):" if present
 				parts := strings.Split(rawURL, "?")
 				rawURL = parts[0]
 			}
-			url, err := ice.ParseURL(rawURL)
-			if err != nil {
-				return nil, err
-			}
-			iceServers = append(iceServers, url)
+			server.URLs[i] = rawURL
 		}
 	}
-	return &iceServers, nil
+	return iceServers
 }

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -17,23 +17,8 @@ func TestConfiguration_getICEServers(t *testing.T) {
 			},
 		}
 
-		parsedURLs, err := cfg.getICEServers()
-		assert.Nil(t, err)
-		assert.Equal(t, expectedServerStr, (*parsedURLs)[0].String())
-	})
-
-	t.Run("Failure", func(t *testing.T) {
-		expectedServerStr := "stun.l.google.com:19302"
-		cfg := Configuration{
-			ICEServers: []ICEServer{
-				{
-					URLs: []string{expectedServerStr},
-				},
-			},
-		}
-
-		_, err := cfg.getICEServers()
-		assert.NotNil(t, err)
+		parsedURLs := cfg.getICEServers()
+		assert.Equal(t, expectedServerStr, parsedURLs[0].URLs[0])
 	})
 
 	t.Run("Success", func(t *testing.T) {
@@ -48,8 +33,7 @@ func TestConfiguration_getICEServers(t *testing.T) {
 			},
 		}
 
-		parsedURLs, err := cfg.getICEServers()
-		assert.Nil(t, err)
-		assert.Equal(t, expectedServerStr, (*parsedURLs)[0].String())
+		parsedURLs := cfg.getICEServers()
+		assert.Equal(t, expectedServerStr, parsedURLs[0].URLs[0])
 	})
 }

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -196,13 +196,14 @@ func (pc *PeerConnection) initConfiguration(configuration Configuration) error {
 		pc.configuration.SDPSemantics = configuration.SDPSemantics
 	}
 
-	if len(configuration.ICEServers) > 0 {
-		for _, server := range configuration.ICEServers {
+	sanitizedICEServers := configuration.getICEServers()
+	if len(sanitizedICEServers) > 0 {
+		for _, server := range sanitizedICEServers {
 			if err := server.validate(); err != nil {
 				return err
 			}
 		}
-		pc.configuration.ICEServers = configuration.ICEServers
+		pc.configuration.ICEServers = sanitizedICEServers
 	}
 
 	return nil
@@ -479,7 +480,7 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 
 func (pc *PeerConnection) createICEGatherer() (*ICEGatherer, error) {
 	g, err := pc.api.NewICEGatherer(ICEGatherOptions{
-		ICEServers:      pc.configuration.ICEServers,
+		ICEServers:      pc.configuration.getICEServers(),
 		ICEGatherPolicy: pc.configuration.ICETransportPolicy,
 	})
 	if err != nil {


### PR DESCRIPTION
Currently we error if a STUN URL passed to Configuration.ICEServers
contained a query parameter. Fix this by using the getICEServers
function that sanitizes these for us.