### PR TITLE
Add codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2
+    patch:
+      default:
+        against: parent
+        target: 70%
+
+ignore:
+  - "examples/*"
+  - "examples/**/*"


### PR DESCRIPTION
Coverage value on CI is noisy and often causes false-positive error unrelated to the code change.
This sets tolerance of project coverage error to 2% and diff coverage target to 70%.