### PR TITLE
Reduce blocking in datachannel handler

### DIFF
--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -70,7 +70,11 @@ func TestDataChannel_Open(t *testing.T) {
 				openCalls <- true
 			})
 			d.OnMessage(func(msg DataChannelMessage) {
-				done <- true
+				go func() {
+					// Wait a little bit to ensure all messages are processed.
+					time.Sleep(100 * time.Millisecond)
+					done <- true
+				}()
 			})
 		})
 


### PR DESCRIPTION
OnOpen handler is sometimes called with a huge delay in TestDataChannel_Open and causes handler_should_be_called_once failure.
This commit minimizes mutex lock scope around handler registration and removes redundant mutex.

Also, add sleep before closing PeerConnections in TestDataChannel_Open to ensure all messages are processed.

```
--- FAIL: TestDataChannel_Open (0.54s)
    --- FAIL: TestDataChannel_Open/handler_should_be_called_once (0.54s)
        datachannel_test.go:91: 
            	Error Trace:	datachannel_test.go:91
            	Error:      	"%!s(chan bool=0x81c310)" should have 1 item(s), but has 0
            	Test:       	TestDataChannel_Open/handler_should_be_called_once
```
This error should be fixed by this PR.

#### Reference issue
~might reduce #938~ and errors shown in #943
