### PR TITLE
Expose an API to get a list of registered RTPCodec from PeerConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Ilya Mayorov](https://github.com/faroyam)
 * [Patrick Lange](https://github.com/langep)
 * [cyannuk](https://github.com/cyannuk)
+* [Lukas Herman](https://github.com/lherman-cs)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1945,3 +1945,8 @@ func addCandidatesToMediaDescriptions(candidates []ICECandidate, m *sdp.MediaDes
 		m.WithPropertyAttribute("end-of-candidates")
 	}
 }
+
+// GetRegisteredRTPCodecs gets a list of registered RTPCodec from the underlying constructed MediaEngine
+func (pc *PeerConnection) GetRegisteredRTPCodecs(kind RTPCodecType) []*RTPCodec {
+	return pc.api.mediaEngine.GetCodecsByKind(kind)
+}

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -900,3 +900,25 @@ a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f
 	}
 	assert.NoError(t, pc.Close())
 }
+
+func TestGetRegisteredRTPCodecs(t *testing.T) {
+	mediaEngine := MediaEngine{}
+	expectedCodec := NewRTPH264Codec(DefaultPayloadTypeH264, 90000)
+	mediaEngine.RegisterCodec(expectedCodec)
+
+	api := NewAPI(WithMediaEngine(mediaEngine))
+	pc, err := api.NewPeerConnection(Configuration{})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	codecs := pc.GetRegisteredRTPCodecs(RTPCodecTypeVideo)
+	if len(codecs) != 1 {
+		t.Errorf("expected to get only 1 codec but got %d codecs", len(codecs))
+	}
+
+	actualCodec := codecs[0]
+	if actualCodec != expectedCodec {
+		t.Errorf("expected to get %v but got %v", expectedCodec, actualCodec)
+	}
+}


### PR DESCRIPTION
Add a new public method, GetRegisteredRTPCodecs, under PeerConnection to allow access to get the registered list of RTPCodec from the underlying MediaEngine for developers who want to build libraries on top of pion.

Resolves #966