### PR TITLE
Expose an API to get Packetizer of the Track.

### DIFF
--- a/track.go
+++ b/track.go
@@ -77,6 +77,13 @@ func (t *Track) Codec() *RTPCodec {
 	return t.codec
 }
 
+// Packetizer gets the Packetizer of the track
+func (t *Track) Packetizer() rtp.Packetizer {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.packetizer
+}
+
 // Read reads data from the track. If this is a local track this will error
 func (t *Track) Read(b []byte) (n int, err error) {
 	t.mu.RLock()


### PR DESCRIPTION
#### Description
Add a new public method, Packetizer, under Track to allow access
to get corresponding Packetizer to allow developers configure it.
At the current moment Packetizer allows user to use abs time as a timestamp, as [described here](https://webrtc.org/experiments/rtp-hdrext/abs-send-time), but there is no way in pion webrtc to use this feature.

#### Reference issue
No issues found
