### PR TITLE
mediaengine: Case-insensitive media subtype check

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Lukas Herman](https://github.com/lherman-cs)
 * [Konstantin Chugalinskiy](https://github.com/kchugalinskiy)
 * [Bao Nguyen](https://github.com/sysbot)
+* [Luke S](https://github.com/encounter)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -77,7 +77,8 @@ func (m *MediaEngine) PopulateFromSDP(sd SessionDescription) error {
 			var codec *RTPCodec
 			clockRate := payloadCodec.ClockRate
 			parameters := payloadCodec.Fmtp
-			switch payloadCodec.Name {
+			codecName := strings.ToUpper(payloadCodec.Name)
+			switch codecName {
 			case PCMU:
 				codec = NewRTPPCMUCodec(payloadType, clockRate)
 			case PCMA:
@@ -143,7 +144,7 @@ const (
 	PCMU = "PCMU"
 	PCMA = "PCMA"
 	G722 = "G722"
-	Opus = "opus"
+	Opus = "OPUS"
 	VP8  = "VP8"
 	VP9  = "VP9"
 	H264 = "H264"

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -87,8 +87,8 @@ a=sctpmap:5000 webrtc-datachannel 1024
 	m.RegisterDefaultCodecs()
 	assert.NoError(t, m.PopulateFromSDP(SessionDescription{SDP: sdpValue}))
 
-	assertCodecWithPayloadType("opus", 111)
-	assertCodecWithPayloadType("VP8", 105)
-	assertCodecWithPayloadType("H264", 115)
-	assertCodecWithPayloadType("VP9", 135)
+	assertCodecWithPayloadType(Opus, 111)
+	assertCodecWithPayloadType(VP8, 105)
+	assertCodecWithPayloadType(H264, 115)
+	assertCodecWithPayloadType(VP9, 135)
 }


### PR DESCRIPTION
As defined in: https://tools.ietf.org/html/rfc4855#section-3

```
Media subtype names are commonly shown in lower case.
These names are case-insensitive in both places.
```

As well as: https://tools.ietf.org/html/rfc4288#section-4.2

```
Both type and subtype names are case-insensitive.
```