### PR TITLE
Add test for multi-track PlanB signaling

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -423,8 +423,13 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 			}
 		}
 
-		mediaSections = append(mediaSections, mediaSection{id: "video", transceivers: video})
-		mediaSections = append(mediaSections, mediaSection{id: "audio", transceivers: audio})
+		if len(video) > 1 {
+			mediaSections = append(mediaSections, mediaSection{id: "video", transceivers: video})
+		}
+
+		if len(audio) > 1 {
+			mediaSections = append(mediaSections, mediaSection{id: "audio", transceivers: audio})
+		}
 		mediaSections = append(mediaSections, mediaSection{id: "data", data: true})
 	} else {
 		for _, t := range pc.GetTransceivers() {

--- a/sdp.go
+++ b/sdp.go
@@ -37,6 +37,9 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) m
 					log.Warnf("Failed to parse SSRC: %v", err)
 					continue
 				}
+				if existingValues, ok := incomingTracks[uint32(ssrc)]; ok && existingValues.label != "" && existingValues.id != "" {
+					continue // This ssrc is already fully defined
+				}
 
 				trackID := ""
 				trackLabel := ""
@@ -46,9 +49,6 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) m
 				}
 
 				incomingTracks[uint32(ssrc)] = trackDetails{codecType, trackLabel, trackID, uint32(ssrc)}
-				if trackID != "" && trackLabel != "" {
-					break // Remote provided Label+ID, we have all the information we need
-				}
 			}
 		}
 	}


### PR DESCRIPTION
SDP parsing only supported one ssrc per media section.
Now we properly can handle multiple.

Resolves #1014