### PR TITLE
Allow formatting parameters for all codecs

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -92,17 +92,16 @@ func (m *MediaEngine) PopulateFromSDP(sd SessionDescription) error {
 				codec = NewRTPOpusCodec(payloadType, clockRate)
 			case VP8:
 				codec = NewRTPVP8Codec(payloadType, clockRate)
-				codec.SDPFmtpLine = parameters
 			case VP9:
 				codec = NewRTPVP9Codec(payloadType, clockRate)
-				codec.SDPFmtpLine = parameters
 			case H264:
 				codec = NewRTPH264Codec(payloadType, clockRate)
-				codec.SDPFmtpLine = parameters
 			default:
 				// ignoring other codecs
 				continue
 			}
+			codec.SDPFmtpLine = parameters
+
 			m.RegisterCodec(codec)
 		}
 	}


### PR DESCRIPTION
#### Description

Formatting parameters are not only allowed on video codecs but also on most audio codecs.

Without this change, custom parameters of audio codecs would be dropped when parsing SDPs (e.g. opus parameters)