### PR TITLE
Ivf reader live stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Bao Nguyen](https://github.com/sysbot)
 * [Luke S](https://github.com/encounter)
 * [Hendrik Hofstadt](https://github.com/hendrikhofstadt)
+* [Clayton McCray](https://github.com/ClaytonMcCray)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/go.sum
+++ b/go.sum
@@ -56,7 +56,6 @@ github.com/pion/transport v0.8.10 h1:lTiobMEw2PG6BH/mgIVqTV2mBp/mPT+IJLaN8ZxgdHk
 github.com/pion/transport v0.8.10/go.mod h1:tBmha/UCjpum5hqTWhfAEs3CO4/tHSg0MYRhSzR+CZ8=
 github.com/pion/turn/v2 v2.0.2 h1:5t31a/9MRYTKph8TTnV2Q/8pJfRdeiCgksyVuaXF3vg=
 github.com/pion/turn/v2 v2.0.2/go.mod h1:kl1hmT3NxcLynpXVnwJgObL8C9NaCyPTeqI2DcCpSZs=
-github.com/pion/webrtc v1.2.0 h1:3LGGPQEMacwG2hcDfhdvwQPz315gvjZXOfY4vaF4+I4=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/pion/transport v0.8.10 h1:lTiobMEw2PG6BH/mgIVqTV2mBp/mPT+IJLaN8ZxgdHk
 github.com/pion/transport v0.8.10/go.mod h1:tBmha/UCjpum5hqTWhfAEs3CO4/tHSg0MYRhSzR+CZ8=
 github.com/pion/turn/v2 v2.0.2 h1:5t31a/9MRYTKph8TTnV2Q/8pJfRdeiCgksyVuaXF3vg=
 github.com/pion/turn/v2 v2.0.2/go.mod h1:kl1hmT3NxcLynpXVnwJgObL8C9NaCyPTeqI2DcCpSZs=
+github.com/pion/webrtc v1.2.0 h1:3LGGPQEMacwG2hcDfhdvwQPz315gvjZXOfY4vaF4+I4=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/media/ivfreader/ivfreader_test.go
+++ b/pkg/media/ivfreader/ivfreader_test.go
@@ -89,6 +89,8 @@ func TestIVFReader_ParseValidFrames(t *testing.T) {
 			0xDE, 0xAD, 0xBE, 0xEF,
 		},
 		"Payload value should be 0xDEADBEEF")
+	assert.Equal(int64(ivfFrameHeaderSize+ivfFileHeaderSize+header.FrameSize), reader.bytesReadSuccesfully)
+	previousBytesRead := reader.bytesReadSuccesfully
 
 	// Parse Frame #2
 	payload, header, err = reader.ParseNextFrame()
@@ -103,6 +105,8 @@ func TestIVFReader_ParseValidFrames(t *testing.T) {
 			0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
 		},
 		"Payload value should be 0xDEADBEEFDEADBEEF")
+	assert.Equal(int64(ivfFrameHeaderSize+header.FrameSize)+previousBytesRead, reader.bytesReadSuccesfully)
+
 }
 
 func TestIVFReader_ParseIncompleteFrameHeader(t *testing.T) {

--- a/pkg/media/ivfreader/ivfreader_test.go
+++ b/pkg/media/ivfreader/ivfreader_test.go
@@ -106,7 +106,6 @@ func TestIVFReader_ParseValidFrames(t *testing.T) {
 		},
 		"Payload value should be 0xDEADBEEFDEADBEEF")
 	assert.Equal(int64(ivfFrameHeaderSize+header.FrameSize)+previousBytesRead, reader.bytesReadSuccesfully)
-
 }
 
 func TestIVFReader_ParseIncompleteFrameHeader(t *testing.T) {


### PR DESCRIPTION
#### Description
Add a receiver to `*IVFReader` that allows caller to reset the internal io.Reader stream for the reader. This can be used, for instance, to reset the stream if one is encoding raw data live and the previous call to `ivf.ParseNextFrame()` got EOF.

