### PR TITLE
RTPSender: Expose the 'track' attribute as per spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Luke S](https://github.com/encounter)
 * [Hendrik Hofstadt](https://github.com/hendrikhofstadt)
 * [Clayton McCray](https://github.com/ClaytonMcCray)
+* [lawl](https://github.com/lawl)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -57,6 +57,13 @@ func (r *RTPSender) Transport() *DTLSTransport {
 	return r.transport
 }
 
+// Track returns the RTCRtpTransceiver track, or nil
+func (r *RTPSender) Track() *Track {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.track
+}
+
 // Send Attempts to set the parameters controlling the sending of media.
 func (r *RTPSender) Send(parameters RTPSendParameters) error {
 	r.mu.Lock()


### PR DESCRIPTION
The webrtc spec in https://www.w3.org/TR/webrtc/#dom-rtcrtpsender sais an RtpSender object has a read-only attribute track. We expose this attribute via a 'Track()' method.

[`RTPReceiver`](https://github.com/pion/webrtc/blob/v2.2.0/rtpreceiver.go#L54) already exposes this attribute in the same way, so not including it in `RTPSender` was likely just an oversight.