### PR TITLE
Fix race in PeerConnection.ConnectionState

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1578,6 +1578,9 @@ func (pc *PeerConnection) ICEGatheringState() ICEGatheringState {
 // ConnectionState attribute returns the connection state of the
 // PeerConnection instance.
 func (pc *PeerConnection) ConnectionState() PeerConnectionState {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
 	return pc.connectionState
 }
 


### PR DESCRIPTION
#### Description

The data race detector detects a race if PeerConnection.ConnectionState is called while PeerConnection.updateConnectionState is changing the connection state.