### PR TITLE
Adding OnICEGatheringFinish.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Hendrik Hofstadt](https://github.com/hendrikhofstadt)
 * [Clayton McCray](https://github.com/ClaytonMcCray)
 * [lawl](https://github.com/lawl)
+* [Jorropo](https://github.com/Jorropo)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -247,6 +247,14 @@ func (pc *PeerConnection) OnICEGatheringStateChange(f func(ICEGathererState)) {
 	pc.iceGatherer.OnStateChange(f)
 }
 
+// OnICEGatheringFinish sets an event handler which is invoked when the ICE
+// candidate gathering state has finished.
+// Unlike OnICEGatheringStateChange is invoked after OnICECandidate handler
+// returns.
+func (pc *PeerConnection) OnICEGatheringFinish(f func()) {
+	pc.iceGatherer.OnFinish(f)
+}
+
 // OnTrack sets an event handler which is called when remote track
 // arrives from a remote peer.
 func (pc *PeerConnection) OnTrack(f func(*Track, *RTPReceiver)) {


### PR DESCRIPTION
# Description

It would also be possible to swap the order of event execution but, but that require breaking change to the execution flow maybe breaking some apps. (First setting state completed then executing onLocalCandidateHdlr and then onStateChangeHdlr but that still breaking change to the execution flow).
This is way safer.

# Reference issue
Fixes #1051.
