### PR TITLE
Put application media section first

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -428,16 +428,16 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 		if len(video) > 1 {
 			mediaSections = append(mediaSections, mediaSection{id: "video", transceivers: video})
 		}
-
 		if len(audio) > 1 {
 			mediaSections = append(mediaSections, mediaSection{id: "audio", transceivers: audio})
 		}
 		mediaSections = append(mediaSections, mediaSection{id: "data", data: true})
 	} else {
+		mediaSections = append(mediaSections, mediaSection{id: strconv.Itoa(len(mediaSections)), data: true})
+
 		for _, t := range pc.GetTransceivers() {
 			mediaSections = append(mediaSections, mediaSection{id: strconv.Itoa(len(mediaSections)), transceivers: []*RTPTransceiver{t}})
 		}
-		mediaSections = append(mediaSections, mediaSection{id: strconv.Itoa(len(mediaSections)), data: true})
 	}
 
 	if d, err = populateSDP(d, isPlanB, pc.api.settingEngine.candidates.ICELite, pc.api.mediaEngine, connectionRoleFromDtlsRole(defaultDtlsRoleOffer), candidates, iceParams, mediaSections); err != nil {

--- a/peerconnection_renegotation_test.go
+++ b/peerconnection_renegotation_test.go
@@ -127,3 +127,24 @@ func TestPeerConnection_Renegotation_RemoveTrack(t *testing.T) {
 	assert.NoError(t, pcOffer.Close())
 	assert.NoError(t, pcAnswer.Close())
 }
+
+// When creating an offer the first media section MUST be SCTP
+// This is to make renegotation easier, instead of having to remember where it
+// is was interleaved
+func TestPeerConnection_Renegotation_ApplicationFirst(t *testing.T) {
+	pc, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	addTransceiverAndAssert := func() {
+		_, err = pc.AddTransceiverFromKind(RTPCodecTypeVideo)
+		assert.NoError(t, err)
+
+		offer, err := pc.CreateOffer(nil)
+		assert.NoError(t, err)
+
+		assert.Equal(t, offer.parsed.MediaDescriptions[0].MediaName.Media, "application")
+	}
+
+	addTransceiverAndAssert()
+	addTransceiverAndAssert()
+}


### PR DESCRIPTION
When offering always put application first. Before during re-negotation
we would break the order if media sections because we would always place
it last. Instead of remembering what order the application was place
just always place it first.