### PR TITLE
Replace js.Value comparisons deprecated in Go 1.14

### DIFF
--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -162,7 +162,7 @@ func (d *DataChannel) Label() string {
 // out-of-order delivery is allowed.
 func (d *DataChannel) Ordered() bool {
 	ordered := d.underlying.Get("ordered")
-	if ordered == js.Undefined() {
+	if jsValueIsUndefined(ordered) {
 		return true // default is true
 	}
 	return ordered.Bool()
@@ -171,7 +171,7 @@ func (d *DataChannel) Ordered() bool {
 // MaxPacketLifeTime represents the length of the time window (msec) during
 // which transmissions and retransmissions may occur in unreliable mode.
 func (d *DataChannel) MaxPacketLifeTime() *uint16 {
-	if d.underlying.Get("maxPacketLifeTime") != js.Undefined() {
+	if !jsValueIsUndefined(d.underlying.Get("maxPacketLifeTime")) {
 		return valueToUint16Pointer(d.underlying.Get("maxPacketLifeTime"))
 	} else {
 		// See https://bugs.chromium.org/p/chromium/issues/detail?id=696681

--- a/js_compare.go
+++ b/js_compare.go
@@ -1,0 +1,13 @@
+// +build js,go1.14
+
+package webrtc
+
+import "syscall/js"
+
+func jsValueIsUndefined(v js.Value) bool {
+	return v.IsUndefined()
+}
+
+func jsValueIsNull(v js.Value) bool {
+	return v.IsNull()
+}

--- a/js_compare_legacy.go
+++ b/js_compare_legacy.go
@@ -1,0 +1,13 @@
+// +build js,!go1.14
+
+package webrtc
+
+import "syscall/js"
+
+func jsValueIsUndefined(v js.Value) bool {
+	return v == js.Undefined()
+}
+
+func jsValueIsNull(v js.Value) bool {
+	return v == js.Null()
+}

--- a/js_utils.go
+++ b/js_utils.go
@@ -42,7 +42,7 @@ func awaitPromise(promise js.Value) (js.Value, error) {
 }
 
 func valueToUint16Pointer(val js.Value) *uint16 {
-	if val == js.Null() || val == js.Undefined() {
+	if jsValueIsNull(val) || jsValueIsUndefined(val) {
 		return nil
 	}
 	convertedVal := uint16(val.Int())
@@ -50,7 +50,7 @@ func valueToUint16Pointer(val js.Value) *uint16 {
 }
 
 func valueToStringPointer(val js.Value) *string {
-	if val == js.Null() || val == js.Undefined() {
+	if jsValueIsNull(val) || jsValueIsUndefined(val) {
 		return nil
 	}
 	stringVal := val.String()
@@ -79,28 +79,28 @@ func interfaceToValueOrUndefined(val interface{}) js.Value {
 }
 
 func valueToStringOrZero(val js.Value) string {
-	if val == js.Undefined() || val == js.Null() {
+	if jsValueIsUndefined(val) || jsValueIsNull(val) {
 		return ""
 	}
 	return val.String()
 }
 
 func valueToUint8OrZero(val js.Value) uint8 {
-	if val == js.Undefined() || val == js.Null() {
+	if jsValueIsUndefined(val) || jsValueIsNull(val) {
 		return 0
 	}
 	return uint8(val.Int())
 }
 
 func valueToUint16OrZero(val js.Value) uint16 {
-	if val == js.Null() || val == js.Undefined() {
+	if jsValueIsNull(val) || jsValueIsUndefined(val) {
 		return 0
 	}
 	return uint16(val.Int())
 }
 
 func valueToUint32OrZero(val js.Value) uint32 {
-	if val == js.Null() || val == js.Undefined() {
+	if jsValueIsNull(val) || jsValueIsUndefined(val) {
 		return 0
 	}
 	return uint32(val.Int())

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -486,7 +486,7 @@ func iceServerToValue(server ICEServer) js.Value {
 }
 
 func valueToConfiguration(configValue js.Value) Configuration {
-	if configValue == js.Null() || configValue == js.Undefined() {
+	if jsValueIsNull(configValue) || jsValueIsUndefined(configValue) {
 		return Configuration{}
 	}
 	return Configuration{
@@ -503,7 +503,7 @@ func valueToConfiguration(configValue js.Value) Configuration {
 }
 
 func valueToICEServers(iceServersValue js.Value) []ICEServer {
-	if iceServersValue == js.Null() || iceServersValue == js.Undefined() {
+	if jsValueIsNull(iceServersValue) || jsValueIsUndefined(iceServersValue) {
 		return nil
 	}
 	iceServers := make([]ICEServer, iceServersValue.Length())
@@ -524,7 +524,7 @@ func valueToICEServer(iceServerValue js.Value) ICEServer {
 }
 
 func valueToICECandidate(val js.Value) *ICECandidate {
-	if val == js.Null() || val == js.Undefined() {
+	if jsValueIsNull(val) || jsValueIsUndefined(val) {
 		return nil
 	}
 	protocol, _ := NewICEProtocol(val.Get("protocol").String())
@@ -564,7 +564,7 @@ func sessionDescriptionToValue(desc *SessionDescription) js.Value {
 }
 
 func valueToSessionDescription(descValue js.Value) *SessionDescription {
-	if descValue == js.Null() || descValue == js.Undefined() {
+	if jsValueIsNull(descValue) || jsValueIsUndefined(descValue) {
 		return nil
 	}
 	return &SessionDescription{


### PR DESCRIPTION
Replace js.Undefined() and js.Null() comparisons with IsUndefined() and
IsNull().

#### Description
Directly comparing js.Value instances to js.Undefined() and js.Null() was deprecated in Go 1.14. See: https://golang.org/doc/go1.14#wasm


