### PR TITLE
Fix race condition on DTLSTransport init

### DIFF
--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -610,6 +610,9 @@ func TestPeerConnection_OfferingLite(t *testing.T) {
 }
 
 func TestPeerConnection_AnsweringLite(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
 	report := test.CheckRoutines(t)
 	defer report()
 
@@ -625,10 +628,6 @@ func TestPeerConnection_AnsweringLite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = signalPair(offerPC, answerPC); err != nil {
-		t.Fatal(err)
-	}
-
 	iceComplete := make(chan interface{})
 	answerPC.OnICEConnectionStateChange(func(iceState ICEConnectionState) {
 		if iceState == ICEConnectionStateConnected {
@@ -639,6 +638,10 @@ func TestPeerConnection_AnsweringLite(t *testing.T) {
 			}
 		}
 	})
+
+	if err = signalPair(offerPC, answerPC); err != nil {
+		t.Fatal(err)
+	}
 
 	<-iceComplete
 	assert.NoError(t, offerPC.Close())

--- a/peerconnection_renegotation_test.go
+++ b/peerconnection_renegotation_test.go
@@ -49,7 +49,7 @@ func TestPeerConnection_Renegotation_AddTrack(t *testing.T) {
 	onTrackFired, onTrackFiredFunc := context.WithCancel(context.Background())
 	pcAnswer.OnTrack(func(track *Track, r *RTPReceiver) {
 		if !haveRenegotiated.get() {
-			t.Fatal("OnTrack was called before renegotation")
+			t.Error("OnTrack was called before renegotation")
 		}
 		onTrackFiredFunc()
 	})


### PR DESCRIPTION
`startSRTP()` was called before establishing DTLS connection if renegotiation is triggered immediately after start.
Fix lock scope and cancel connection handshake by `context.Context` on `Stop()`.

### Reference issue
Fixes #1039 