### PR TITLE
Process SetRemoteDescription calls serially

### DIFF
--- a/peerconnection_renegotation_test.go
+++ b/peerconnection_renegotation_test.go
@@ -170,15 +170,7 @@ func TestPeerConnection_RoleSwitch(t *testing.T) {
 		onTrackFiredFunc()
 	})
 
-	connected, connectedFunc := context.WithCancel(context.Background())
-	pcFirstOfferer.OnConnectionStateChange(func(c PeerConnectionState) {
-		if c == PeerConnectionStateConnected {
-			connectedFunc()
-		}
-	})
-
 	assert.NoError(t, signalPair(pcFirstOfferer, pcSecondOfferer))
-	<-connected.Done()
 
 	// Add a new Track to the second offerer
 	// This asserts that it will match the ordering of the last RemoteDescription, but then also add new Transceivers to the end


### PR DESCRIPTION
Each negotation must be finished before processing the next one.
Before we would process multiple calls at once, and since they are
performed async we would have undefined behavior.

Resolves #1074