### PR TITLE
Don't upcase opus when adding to SDP

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -337,7 +337,7 @@ func createTrack(offer webrtc.SessionDescription) (*webrtc.PeerConnection, *webr
 	}
 	var payloadType uint8
 	for _, videoCodec := range mediaEngine.GetCodecsByKind(webrtc.RTPCodecTypeAudio) {
-		if videoCodec.Name == "OPUS" {
+		if videoCodec.Name == webrtc.Opus {
 			payloadType = videoCodec.PayloadType
 			break
 		}

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -78,30 +78,27 @@ func (m *MediaEngine) PopulateFromSDP(sd SessionDescription) error {
 			}
 
 			var codec *RTPCodec
-			clockRate := payloadCodec.ClockRate
-			parameters := payloadCodec.Fmtp
-			codecName := strings.ToUpper(payloadCodec.Name)
-			switch codecName {
-			case PCMU:
-				codec = NewRTPPCMUCodec(payloadType, clockRate)
-			case PCMA:
-				codec = NewRTPPCMACodec(payloadType, clockRate)
-			case G722:
-				codec = NewRTPG722Codec(payloadType, clockRate)
-			case Opus:
-				codec = NewRTPOpusCodec(payloadType, clockRate)
-			case VP8:
-				codec = NewRTPVP8Codec(payloadType, clockRate)
-			case VP9:
-				codec = NewRTPVP9Codec(payloadType, clockRate)
-			case H264:
-				codec = NewRTPH264Codec(payloadType, clockRate)
+			switch {
+			case strings.EqualFold(payloadCodec.Name, PCMA):
+				codec = NewRTPPCMACodec(payloadType, payloadCodec.ClockRate)
+			case strings.EqualFold(payloadCodec.Name, PCMU):
+				codec = NewRTPPCMUCodec(payloadType, payloadCodec.ClockRate)
+			case strings.EqualFold(payloadCodec.Name, G722):
+				codec = NewRTPG722Codec(payloadType, payloadCodec.ClockRate)
+			case strings.EqualFold(payloadCodec.Name, Opus):
+				codec = NewRTPOpusCodec(payloadType, payloadCodec.ClockRate)
+			case strings.EqualFold(payloadCodec.Name, VP8):
+				codec = NewRTPVP8Codec(payloadType, payloadCodec.ClockRate)
+			case strings.EqualFold(payloadCodec.Name, VP9):
+				codec = NewRTPVP9Codec(payloadType, payloadCodec.ClockRate)
+			case strings.EqualFold(payloadCodec.Name, H264):
+				codec = NewRTPH264Codec(payloadType, payloadCodec.ClockRate)
 			default:
 				// ignoring other codecs
 				continue
 			}
-			codec.SDPFmtpLine = parameters
 
+			codec.SDPFmtpLine = payloadCodec.Fmtp
 			m.RegisterCodec(codec)
 		}
 	}
@@ -146,7 +143,7 @@ const (
 	PCMU = "PCMU"
 	PCMA = "PCMA"
 	G722 = "G722"
-	Opus = "OPUS"
+	Opus = "opus"
 	VP8  = "VP8"
 	VP9  = "VP9"
 	H264 = "H264"

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -3,6 +3,7 @@
 package webrtc
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/pion/sdp/v2"
@@ -91,4 +92,19 @@ a=sctpmap:5000 webrtc-datachannel 1024
 	assertCodecWithPayloadType(VP8, 105)
 	assertCodecWithPayloadType(H264, 115)
 	assertCodecWithPayloadType(VP9, 135)
+}
+
+// pion/webrtc#1078
+func TestOpusCase(t *testing.T) {
+	pc, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	_, err = pc.AddTransceiverFromKind(RTPCodecTypeAudio)
+	assert.NoError(t, err)
+
+	offer, err := pc.CreateOffer(nil)
+	assert.NoError(t, err)
+
+	assert.True(t, regexp.MustCompile(`(?m)^a=rtpmap:\d+ opus/48000/2`).MatchString(offer.SDP))
+	assert.NoError(t, pc.Close())
 }


### PR DESCRIPTION
When making MediaEngine case-insensitive in 20f2d18
Opus was upcased when adding to SDP. This returns it
to what it was before

Resolves #1078