### PR TITLE
Make the IVF reader able to read from a network connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Jorropo](https://github.com/Jorropo)
 * [Akil](https://github.com/akilude)
 * [Quentin Renard](https://github.com/asticode)
+* [opennota](https://github.com/opennota)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
Use `io.ReadFull` to read from the `io.Reader`.

Fixes #1086
