### PR TITLE
Ignore rtx ssrc from FID group when extracting tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Akil](https://github.com/akilude)
 * [Quentin Renard](https://github.com/asticode)
 * [opennota](https://github.com/opennota)
+* [Simon Eisenmann](https://github.com/longsleep)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
If the remote description contains rtx information via a `ssrc-group`,
    the extra `ssrc` entries must be ignored to ensure thats no receiver
    is added for them.

This can solve issues like `Incoming unhandled RTP ssrc(1858531374)` if
    those are caused by a wrong receiver getting started for the rtx ssrc
    but not for the track ssrc, based on the ssrc/transceiver oder in the
    remote description.

Until rtx is properly supported, this change fixes the imediate issue
    that some remote streams are randomly not received because of a remotes
    rtx information.

Fixes: #1081
Related: #1083
