### PR TITLE
Add detection for removed remote tracks

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1587,8 +1587,11 @@ func (pc *PeerConnection) startRenegotation(currentTransceivers []*RTPTransceive
 		for _, t := range currentTransceivers {
 			if t.Receiver() == nil || t.Receiver().Track() == nil {
 				continue
-			} else if _, ok := trackDetails[t.Receiver().Track().ssrc]; ok {
-				continue
+			} else if trackDetail, ok := trackDetails[t.Receiver().Track().ssrc]; ok {
+				if trackDetail.direction == RTPTransceiverDirectionSendrecv || trackDetail.direction == RTPTransceiverDirectionSendonly {
+					// Keep the receiver only, when the remote track is actually sending
+					continue
+				}
 			}
 
 			if err := t.Receiver().Stop(); err != nil {

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -830,6 +830,10 @@ func (pc *PeerConnection) startRTPReceivers(incomingTracks map[uint32]trackDetai
 	}
 
 	for ssrc, incoming := range incomingTracks {
+		if incoming.direction == RTPTransceiverDirectionRecvonly {
+			// Skip recv only tracks, avoid starting a receiver for those.
+			continue
+		}
 		for i := range localTransceivers {
 			t := localTransceivers[i]
 


### PR DESCRIPTION
This PR adds support for `recvonly` remote senders by cleaning up existing local receivers and by preventing start of new local receivers for tracks which are not sending, to make it possible to detect removed remote tracks.
