### PR TITLE
Fix DataChannel open race

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -152,12 +152,10 @@ func (d *DataChannel) open(sctpTransport *SCTPTransport) error {
 	}
 
 	if d.id == nil {
-		generatedID, err := d.sctpTransport.generateDataChannelID(d.sctpTransport.dtlsTransport.role())
+		err := d.sctpTransport.generateAndSetDataChannelID(d.sctpTransport.dtlsTransport.role(), &d.id)
 		if err != nil {
 			return err
 		}
-
-		d.id = &generatedID
 	}
 
 	dc, err := datachannel.Dial(d.sctpTransport.association, *d.id, cfg)

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -33,13 +33,14 @@ func TestGenerateDataChannelID(t *testing.T) {
 		{DTLSRoleServer, sctpTransportWithChannels([]uint16{1, 5}), 3},
 	}
 	for _, testCase := range testCases {
-		id, err := testCase.s.generateDataChannelID(testCase.role)
+		idPtr := new(uint16)
+		err := testCase.s.generateAndSetDataChannelID(testCase.role, &idPtr)
 		if err != nil {
 			t.Errorf("failed to generate id: %v", err)
 			return
 		}
-		if id != testCase.result {
-			t.Errorf("Wrong id: %d expected %d", id, testCase.result)
+		if *idPtr != testCase.result {
+			t.Errorf("Wrong id: %d expected %d", *idPtr, testCase.result)
 		}
 	}
 }


### PR DESCRIPTION
Concurrent call of generateDataChannelID caused data race.

### Reference issue
Fixes #1103 