### PR TITLE
Fix race when accessing DataChannel.id

### DIFF
--- a/datachannel_go_test.go
+++ b/datachannel_go_test.go
@@ -152,13 +152,14 @@ func TestDataChannelParamters_Go(t *testing.T) {
 
 	t.Run("All other property methods", func(t *testing.T) {
 		id := uint16(123)
+
 		dc := &DataChannel{}
-		dc.id = &id
+		dc.id.Store(&id)
 		dc.label = "mylabel"
 		dc.protocol = "myprotocol"
 		dc.negotiated = true
 
-		assert.Equal(t, dc.id, dc.ID(), "should match")
+		assert.Equal(t, id, *dc.ID(), "should match")
 		assert.Equal(t, dc.label, dc.Label(), "should match")
 		assert.Equal(t, dc.protocol, dc.Protocol(), "should match")
 		assert.Equal(t, dc.negotiated, dc.Negotiated(), "should match")

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -342,7 +342,7 @@ func (r *SCTPTransport) collectStats(collector *statsReportCollector) {
 func (r *SCTPTransport) generateDataChannelID(dtlsRole DTLSRole) (uint16, error) {
 	isChannelWithID := func(id uint16) bool {
 		for _, d := range r.dataChannels {
-			if d.id != nil && *d.id == id {
+			if d.ID() != nil && *d.ID() == id {
 				return true
 			}
 		}

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -9,8 +9,8 @@ func TestGenerateDataChannelID(t *testing.T) {
 		ret := &SCTPTransport{dataChannels: []*DataChannel{}}
 
 		for i := range ids {
-			id := ids[i]
-			ret.dataChannels = append(ret.dataChannels, &DataChannel{id: &id})
+			ret.dataChannels = append(ret.dataChannels, &DataChannel{})
+			ret.dataChannels[len(ret.dataChannels)-1].id.Store(&ids[i])
 		}
 
 		return ret


### PR DESCRIPTION
Use the accessor method instead of reading the value from the struct
directly.

Fixes #1103