### PR TITLE
Add replay protection setting to SettingEngine

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -156,6 +156,18 @@ func (t *DTLSTransport) startSRTP() error {
 		Profile:       srtp.ProtectionProfileAes128CmHmacSha1_80,
 		LoggerFactory: t.api.settingEngine.LoggerFactory,
 	}
+	if t.api.settingEngine.replayProtection.SRTP != nil {
+		srtpConfig.RemoteOptions = append(
+			srtpConfig.RemoteOptions,
+			srtp.SRTPReplayProtection(*t.api.settingEngine.replayProtection.SRTP),
+		)
+	}
+	if t.api.settingEngine.replayProtection.SRTCP != nil {
+		srtpConfig.RemoteOptions = append(
+			srtpConfig.RemoteOptions,
+			srtp.SRTCPReplayProtection(*t.api.settingEngine.replayProtection.SRTCP),
+		)
+	}
 
 	err := srtpConfig.ExtractSessionKeysFromDTLS(t.conn, t.role() == DTLSRoleClient)
 	if err != nil {
@@ -273,6 +285,10 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 	role, dtlsConfig, err := prepareTransport()
 	if err != nil {
 		return err
+	}
+
+	if t.api.settingEngine.replayProtection.DTLS != nil {
+		dtlsConfig.ReplayProtectionWindow = int(*t.api.settingEngine.replayProtection.DTLS)
 	}
 
 	// Connect as DTLS Client/Server, function is blocking and we

--- a/settingengine.go
+++ b/settingengine.go
@@ -43,6 +43,11 @@ type SettingEngine struct {
 		UsernameFragment               string
 		Password                       string
 	}
+	replayProtection struct {
+		DTLS  *uint
+		SRTP  *uint
+		SRTCP *uint
+	}
 	answeringDTLSRole                         DTLSRole
 	disableCertificateFingerprintVerification bool
 	vnet                                      *vnet.Net
@@ -204,4 +209,19 @@ func (e *SettingEngine) SetICECredentials(usernameFragment, password string) {
 // DisableCertificateFingerprintVerification disables fingerprint verification after DTLS Handshake has finished
 func (e *SettingEngine) DisableCertificateFingerprintVerification(isDisabled bool) {
 	e.disableCertificateFingerprintVerification = isDisabled
+}
+
+// SetDTLSReplayProtectionWindow sets a replay attack protection window size of DTLS connection.
+func (e *SettingEngine) SetDTLSReplayProtectionWindow(n uint) {
+	e.replayProtection.DTLS = &n
+}
+
+// SetSRTPReplayProtectionWindow sets a replay attack protection window size of SRTP session.
+func (e *SettingEngine) SetSRTPReplayProtectionWindow(n uint) {
+	e.replayProtection.SRTP = &n
+}
+
+// SetSRTCPReplayProtectionWindow sets a replay attack protection window size of SRTCP session.
+func (e *SettingEngine) SetSRTCPReplayProtectionWindow(n uint) {
+	e.replayProtection.SRTCP = &n
 }

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -89,3 +89,30 @@ func TestSetAnsweringDTLSRole(t *testing.T) {
 	assert.Error(t, s.SetAnsweringDTLSRole(DTLSRoleAuto), "SetAnsweringDTLSRole can only be called with DTLSRoleClient or DTLSRoleServer")
 	assert.Error(t, s.SetAnsweringDTLSRole(DTLSRole(0)), "SetAnsweringDTLSRole can only be called with DTLSRoleClient or DTLSRoleServer")
 }
+
+func TestSetReplayProtection(t *testing.T) {
+	s := SettingEngine{}
+
+	if s.replayProtection.DTLS != nil ||
+		s.replayProtection.SRTP != nil ||
+		s.replayProtection.SRTCP != nil {
+		t.Fatalf("SettingEngine defaults aren't as expected.")
+	}
+
+	s.SetDTLSReplayProtectionWindow(128)
+	s.SetSRTPReplayProtectionWindow(64)
+	s.SetSRTCPReplayProtectionWindow(32)
+
+	if s.replayProtection.DTLS == nil ||
+		*s.replayProtection.DTLS != 128 {
+		t.Errorf("Failed to set DTLS replay protection window")
+	}
+	if s.replayProtection.SRTP == nil ||
+		*s.replayProtection.SRTP != 64 {
+		t.Errorf("Failed to set SRTP replay protection window")
+	}
+	if s.replayProtection.SRTCP == nil ||
+		*s.replayProtection.SRTCP != 32 {
+		t.Errorf("Failed to set SRTCP replay protection window")
+	}
+}


### PR DESCRIPTION
Set windows size of each protocol by:
- SetDTLSReplayProtectionWindow
- SetSRTPReplayProtectionWindow
- SetSRTCPReplayProtectionWindow

### Reference issue
Fixes #1098 
