### PR TITLE
Append media data section after transceivers

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1655,7 +1655,6 @@ func (pc *PeerConnection) generateUnmatchedSDP(useIdentity bool) (*sdp.SessionDe
 		}
 		mediaSections = append(mediaSections, mediaSection{id: "data", data: true})
 	} else {
-
 		for _, t := range pc.GetTransceivers() {
 			mediaSections = append(mediaSections, mediaSection{id: strconv.Itoa(len(mediaSections)), transceivers: []*RTPTransceiver{t}})
 		}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1655,11 +1655,12 @@ func (pc *PeerConnection) generateUnmatchedSDP(useIdentity bool) (*sdp.SessionDe
 		}
 		mediaSections = append(mediaSections, mediaSection{id: "data", data: true})
 	} else {
-		mediaSections = append(mediaSections, mediaSection{id: strconv.Itoa(len(mediaSections)), data: true})
 
 		for _, t := range pc.GetTransceivers() {
 			mediaSections = append(mediaSections, mediaSection{id: strconv.Itoa(len(mediaSections)), transceivers: []*RTPTransceiver{t}})
 		}
+
+		mediaSections = append(mediaSections, mediaSection{id: strconv.Itoa(len(mediaSections)), data: true})
 	}
 
 	return populateSDP(d, isPlanB, pc.api.settingEngine.candidates.ICELite, pc.api.mediaEngine, connectionRoleFromDtlsRole(defaultDtlsRoleOffer), candidates, iceParams, mediaSections)

--- a/peerconnection_renegotation_test.go
+++ b/peerconnection_renegotation_test.go
@@ -128,29 +128,6 @@ func TestPeerConnection_Renegotation_RemoveTrack(t *testing.T) {
 	assert.NoError(t, pcAnswer.Close())
 }
 
-// When creating an offer the first media section MUST be SCTP
-// This is to make renegotation easier, instead of having to remember where it
-// is was interleaved
-func TestPeerConnection_Renegotation_ApplicationFirst(t *testing.T) {
-	pc, err := NewPeerConnection(Configuration{})
-	assert.NoError(t, err)
-
-	addTransceiverAndAssert := func() {
-		_, err = pc.AddTransceiverFromKind(RTPCodecTypeVideo)
-		assert.NoError(t, err)
-
-		offer, err := pc.CreateOffer(nil)
-		assert.NoError(t, err)
-
-		assert.Equal(t, offer.parsed.MediaDescriptions[0].MediaName.Media, "application")
-	}
-
-	addTransceiverAndAssert()
-	addTransceiverAndAssert()
-
-	assert.NoError(t, pc.Close())
-}
-
 func TestPeerConnection_RoleSwitch(t *testing.T) {
 	api := NewAPI()
 	lim := test.TimeOut(time.Second * 30)


### PR DESCRIPTION
For some reason edge prechromium does not like media data section before video/audio in the sdp.

It generates the following error:

> 0: Unable to get property 'state' of undefined or null reference    rtcpeerconnection.js (1016,1)


Fixes #1113 
