### PR TITLE
Fix RTPReceiver Stop race

### DIFF
--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -66,7 +66,7 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 		return fmt.Errorf("Receive has already been called")
 	default:
 	}
-	close(r.received)
+	defer close(r.received)
 
 	r.track = &Track{
 		kind:     r.kind,
@@ -136,11 +136,15 @@ func (r *RTPReceiver) Stop() error {
 
 	select {
 	case <-r.received:
-		if err := r.rtcpReadStream.Close(); err != nil {
-			return err
+		if r.rtcpReadStream != nil {
+			if err := r.rtcpReadStream.Close(); err != nil {
+				return err
+			}
 		}
-		if err := r.rtpReadStream.Close(); err != nil {
-			return err
+		if r.rtpReadStream != nil {
+			if err := r.rtpReadStream.Close(); err != nil {
+				return err
+			}
 		}
 	default:
 	}


### PR DESCRIPTION
I saw panics like this, when an RTPTransceiver is stopped.

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9479b2]
goroutine 37117 [running]:
github.com/pion/srtp.(*ReadStreamSRTCP).Close(0x0, 0x0, 0x0)
        github.com/pion/srtp@v1.2.7/stream_srtcp.go:66 +0x42
github.com/pion/webrtc/v2.(*RTPReceiver).Stop(0xc011d4f3e0, 0x0, 0x0)
        github.com/pion/webrtc/v2@v2.2.4-0.20200310073244-be9fde1fd3cf/rtpreceiver.go:139 +0xfb
github.com/pion/webrtc/v2.(*RTPTransceiver).Stop(0xc000ced300, 0x1137798, 0x10)
        github.com/pion/webrtc/v2@v2.2.4-0.20200310073244-be9fde1fd3cf/rtptransceiver.go:55 +0x15a
github.com/pion/webrtc/v2.(*PeerConnection).Close(0xc0395a1d40, 0xc04a5cbbc0, 0xc7f200)
```

If a RTPReceiver is stopped before it ever receivers, no streams are
attached to it which can be closed. This change does adds a check
to ensure that the RTPReceivers's streams are not nil before trying to
close them.