### PR TITLE
Add helpers to disable replay protection

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -162,10 +162,25 @@ func (t *DTLSTransport) startSRTP() error {
 			srtp.SRTPReplayProtection(*t.api.settingEngine.replayProtection.SRTP),
 		)
 	}
+
+	if t.api.settingEngine.disableSRTPReplayProtection {
+		srtpConfig.RemoteOptions = append(
+			srtpConfig.RemoteOptions,
+			srtp.SRTPNoReplayProtection(),
+		)
+	}
+
 	if t.api.settingEngine.replayProtection.SRTCP != nil {
 		srtpConfig.RemoteOptions = append(
 			srtpConfig.RemoteOptions,
 			srtp.SRTCPReplayProtection(*t.api.settingEngine.replayProtection.SRTCP),
+		)
+	}
+
+	if t.api.settingEngine.disableSRTCPReplayProtection {
+		srtpConfig.RemoteOptions = append(
+			srtpConfig.RemoteOptions,
+			srtp.SRTCPNoReplayProtection(),
 		)
 	}
 

--- a/settingengine.go
+++ b/settingengine.go
@@ -50,6 +50,8 @@ type SettingEngine struct {
 	}
 	answeringDTLSRole                         DTLSRole
 	disableCertificateFingerprintVerification bool
+	disableSRTPReplayProtection               bool
+	disableSRTCPReplayProtection              bool
 	vnet                                      *vnet.Net
 	LoggerFactory                             logging.LoggerFactory
 }
@@ -218,10 +220,22 @@ func (e *SettingEngine) SetDTLSReplayProtectionWindow(n uint) {
 
 // SetSRTPReplayProtectionWindow sets a replay attack protection window size of SRTP session.
 func (e *SettingEngine) SetSRTPReplayProtectionWindow(n uint) {
+	e.disableSRTPReplayProtection = false
 	e.replayProtection.SRTP = &n
 }
 
 // SetSRTCPReplayProtectionWindow sets a replay attack protection window size of SRTCP session.
 func (e *SettingEngine) SetSRTCPReplayProtectionWindow(n uint) {
+	e.disableSRTCPReplayProtection = false
 	e.replayProtection.SRTCP = &n
+}
+
+// DisableSRTPReplayProtection disables SRTP replay protection.
+func (e *SettingEngine) DisableSRTPReplayProtection(isDisabled bool) {
+	e.disableSRTPReplayProtection = isDisabled
+}
+
+// DisableSRTCPReplayProtection disables SRTCP replay protection.
+func (e *SettingEngine) DisableSRTCPReplayProtection(isDisabled bool) {
+	e.disableSRTCPReplayProtection = isDisabled
 }


### PR DESCRIPTION
Sometimes the replay protection of SRTP and SRTCP needs to be disabled.
This change adds disableSRTPReplayProtection and
DisableSRTCPReplayProtection helpers to SettingEngine.
