### PR TITLE
Update how to install in example projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [opennota](https://github.com/opennota)
 * [Simon Eisenmann](https://github.com/longsleep)
 * [Ben Weitzman](https://github.com/benweitzman)
+* [Masahiro Nakamura](https://github.com/tsuu32)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/examples/broadcast/README.md
+++ b/examples/broadcast/README.md
@@ -6,7 +6,7 @@ This could serve as the building block to building conferencing software, and ot
 ## Instructions
 ### Download broadcast
 ```
-go get github.com/pion/webrtc/examples/broadcast
+go get github.com/pion/webrtc/v2/examples/broadcast
 ```
 
 ### Open broadcast example page

--- a/examples/custom-logger/README.md
+++ b/examples/custom-logger/README.md
@@ -6,7 +6,7 @@ users to override this and process messages however they want.
 ## Instructions
 ### Download custom-logger
 ```
-go get github.com/pion/webrtc/examples/custom-logger
+go get github.com/pion/webrtc/v2/examples/custom-logger
 ```
 
 ### Run custom-logger

--- a/examples/data-channels-create/README.md
+++ b/examples/data-channels-create/README.md
@@ -4,7 +4,7 @@ data-channels-create is a Pion WebRTC application that shows how you can send/re
 ## Instructions
 ### Download data-channels-create
 ```
-go get github.com/pion/webrtc/examples/data-channels-create
+go get github.com/pion/webrtc/v2/examples/data-channels-create
 ```
 
 ### Open data-channels-create example page

--- a/examples/data-channels-detach-create/README.md
+++ b/examples/data-channels-detach-create/README.md
@@ -1,11 +1,11 @@
-# data-channels
+# data-channels-detach-create
 data-channels-detach-create is an example that shows how you can detach a data channel. This allows direct access the the underlying [pion/datachannel](https://github.com/pion/datachannel). This allows you to interact with the data channel using a more idiomatic API based on the `io.ReadWriteCloser` interface.
 
 The example mirrors the data-channels-create example.
 
 ## Install
 ```
-go get github.com/pion/webrtc/examples/data-channels-detach-create
+go get github.com/pion/webrtc/v2/examples/data-channels-detach-create
 ```
 
 ## Usage

--- a/examples/data-channels-detach/README.md
+++ b/examples/data-channels-detach/README.md
@@ -1,11 +1,11 @@
-# data-channels
+# data-channels-detach
 data-channels-detach is an example that shows how you can detach a data channel. This allows direct access the the underlying [pion/datachannel](https://github.com/pion/datachannel). This allows you to interact with the data channel using a more idiomatic API based on the `io.ReadWriteCloser` interface.
 
 The example mirrors the data-channels example.
 
 ## Install
 ```
-go get github.com/pion/webrtc/examples/data-channels-detach
+go get github.com/pion/webrtc/v2/examples/data-channels-detach
 ```
 
 ## Usage

--- a/examples/data-channels/README.md
+++ b/examples/data-channels/README.md
@@ -4,7 +4,7 @@ data-channels is a Pion WebRTC application that shows how you can send/recv Data
 ## Instructions
 ### Download data-channels
 ```
-go get github.com/pion/webrtc/examples/data-channels
+go get github.com/pion/webrtc/v2/examples/data-channels
 ```
 
 ### Open data-channels example page

--- a/examples/pion-to-pion/README.md
+++ b/examples/pion-to-pion/README.md
@@ -11,12 +11,12 @@ The `answer` side acts like a HTTP server and should therefore be ran first.
 ## Instructions
 First run `answer`:
 ```sh
-go install github.com/pion/webrtc/examples/pion-to-pion/answer
+go install github.com/pion/webrtc/v2/examples/pion-to-pion/answer
 answer
 ```
 Next, run `offer`:
 ```sh
-go install github.com/pion/webrtc/examples/pion-to-pion/offer
+go install github.com/pion/webrtc/v2/examples/pion-to-pion/offer
 offer
 ```
 

--- a/examples/pion-to-pion/answer/Dockerfile
+++ b/examples/pion-to-pion/answer/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12
 
-RUN go get -u github.com/pion/webrtc/examples/pion-to-pion/answer
+RUN go get -u github.com/pion/webrtc/v2/examples/pion-to-pion/answer
 
 CMD ["answer"]
 

--- a/examples/pion-to-pion/offer/Dockerfile
+++ b/examples/pion-to-pion/offer/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.12
 
-RUN go get -u github.com/pion/webrtc/examples/pion-to-pion/offer
+RUN go get -u github.com/pion/webrtc/v2/examples/pion-to-pion/offer
 
 CMD ["offer"]

--- a/examples/play-from-disk/README.md
+++ b/examples/play-from-disk/README.md
@@ -9,7 +9,7 @@ ffmpeg -i $INPUT_FILE -g 30 output.ivf
 
 ### Download play-from-disk
 ```
-go get github.com/pion/webrtc/examples/play-from-disk
+go get github.com/pion/webrtc/v2/examples/play-from-disk
 ```
 
 ### Open play-from-disk example page

--- a/examples/reflect/README.md
+++ b/examples/reflect/README.md
@@ -4,7 +4,7 @@ reflect demonstrates how with one PeerConnection you can send video to Pion and 
 ## Instructions
 ### Download reflect
 ```
-go get github.com/pion/webrtc/examples/reflect
+go get github.com/pion/webrtc/v2/examples/reflect
 ```
 
 ### Open reflect example page

--- a/examples/rtp-forwarder/README.md
+++ b/examples/rtp-forwarder/README.md
@@ -4,7 +4,7 @@ rtp-forwarder is a simple application that shows how to forward your webcam/micr
 ## Instructions
 ### Download rtp-forwarder
 ```
-go get github.com/pion/webrtc/examples/rtp-forwarder
+go get github.com/pion/webrtc/v2/examples/rtp-forwarder
 ```
 
 ### Open rtp-forwarder example page

--- a/examples/save-to-disk/README.md
+++ b/examples/save-to-disk/README.md
@@ -6,7 +6,7 @@ If you wish to save H264 to disk checkout out [save-to-webm](https://github.com/
 ## Instructions
 ### Download save-to-disk
 ```
-go get github.com/pion/webrtc/examples/save-to-disk
+go get github.com/pion/webrtc/v2/examples/save-to-disk
 ```
 
 ### Open save-to-disk example page


### PR DESCRIPTION
#### Description
I found `go get github.com/pion/webrtc/examples/data-channels` fails.
Currently download instructions should contain 'v2'.
#### Reference issue
None.
