### PR TITLE
Close stream in oggwriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Simon Eisenmann](https://github.com/longsleep)
 * [Ben Weitzman](https://github.com/benweitzman)
 * [Masahiro Nakamura](https://github.com/tsuu32)
+* [Tarrence van As](https://github.com/tarrencev)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/pkg/media/oggwriter/oggwriter.go
+++ b/pkg/media/oggwriter/oggwriter.go
@@ -198,6 +198,10 @@ func (i *OggWriter) Close() error {
 	// Returns no error has it may be convenient to call
 	// Close() multiple times
 	if i.fd == nil {
+		// Close stream if we are operating on a stream
+		if closer, ok := i.stream.(io.Closer); ok {
+			return closer.Close()
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Update to properly close an oggwriter when writing to a stream. 