### PR TITLE
Don't call OnTrack for same SSRC multiple times

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -829,6 +829,17 @@ func (pc *PeerConnection) startRTPReceivers(incomingTracks map[uint32]trackDetai
 		remoteIsPlanB = descriptionIsPlanB(pc.RemoteDescription())
 	}
 
+	// Ensure we haven't already started a transceiver for this ssrc
+	for ssrc := range incomingTracks {
+		for i := range localTransceivers {
+			if t := localTransceivers[i]; (t.Receiver()) == nil || t.Receiver().Track() == nil || t.Receiver().Track().ssrc != ssrc {
+				continue
+			}
+
+			delete(incomingTracks, ssrc)
+		}
+	}
+
 	for ssrc, incoming := range incomingTracks {
 		for i := range localTransceivers {
 			t := localTransceivers[i]


### PR DESCRIPTION
During re-negotiation we didn't properly SSRCes we had already handled.
This makes sure to loop the existing transceivers and assert we don't
try to handle the same SSRC again.

Resolves #1122