### PR TITLE
Update examples to use AddTransceiverFromKind

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Ben Weitzman](https://github.com/benweitzman)
 * [Masahiro Nakamura](https://github.com/tsuu32)
 * [Tarrence van As](https://github.com/tarrencev)
+* [Yuki Igarashi](https://github.com/bonprosoft)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/examples/broadcast/main.go
+++ b/examples/broadcast/main.go
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	// Allow us to receive 1 video track
-	if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeVideo); err != nil {
+	if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeVideo); err != nil {
 		panic(err)
 	}
 

--- a/examples/rtp-forwarder/main.go
+++ b/examples/rtp-forwarder/main.go
@@ -49,9 +49,9 @@ func main() {
 	}
 
 	// Allow us to receive 1 audio track, and 1 video track
-	if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeAudio); err != nil {
+	if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeAudio); err != nil {
 		panic(err)
-	} else if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeVideo); err != nil {
+	} else if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeVideo); err != nil {
 		panic(err)
 	}
 

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -62,9 +62,9 @@ func main() {
 	}
 
 	// Allow us to receive 1 audio track, and 1 video track
-	if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeAudio); err != nil {
+	if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeAudio); err != nil {
 		panic(err)
-	} else if _, err = peerConnection.AddTransceiver(webrtc.RTPCodecTypeVideo); err != nil {
+	} else if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeVideo); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
#### Description
I found some example projects use `AddTransceiver`, which is a deprecated method.
So I updated those examples to use `AddTransceiverFromKind`.

#### Reference issue
None

---

I also found the method is used in `peerconnection` and some tests.
If there is no reason to use `AddTransceiver` in those codes, I am happy to fix them as well.