### PR TITLE
Use AddTransceiverFromKind

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -860,7 +860,7 @@ func (pc *PeerConnection) startRTPReceivers(incomingTracks map[uint32]trackDetai
 
 	if remoteIsPlanB {
 		for ssrc, incoming := range incomingTracks {
-			t, err := pc.AddTransceiver(incoming.kind, RtpTransceiverInit{
+			t, err := pc.AddTransceiverFromKind(incoming.kind, RtpTransceiverInit{
 				Direction: RTPTransceiverDirectionSendrecv,
 			})
 			if err != nil {
@@ -948,7 +948,7 @@ func (pc *PeerConnection) drainSRTP() {
 					incoming.kind = RTPCodecTypeAudio
 				}
 
-				t, err := pc.AddTransceiver(incoming.kind, RtpTransceiverInit{
+				t, err := pc.AddTransceiverFromKind(incoming.kind, RtpTransceiverInit{
 					Direction: RTPTransceiverDirectionSendrecv,
 				})
 				if err != nil {

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -475,16 +475,16 @@ func TestOneAttrKeyConnectionSetupPerMediaDescriptionInSDP(t *testing.T) {
 	pc, err := NewPeerConnection(Configuration{})
 	assert.NoError(t, err)
 
-	_, err = pc.AddTransceiver(RTPCodecTypeVideo)
+	_, err = pc.AddTransceiverFromKind(RTPCodecTypeVideo)
 	assert.NoError(t, err)
 
-	_, err = pc.AddTransceiver(RTPCodecTypeAudio)
+	_, err = pc.AddTransceiverFromKind(RTPCodecTypeAudio)
 	assert.NoError(t, err)
 
-	_, err = pc.AddTransceiver(RTPCodecTypeAudio)
+	_, err = pc.AddTransceiverFromKind(RTPCodecTypeAudio)
 	assert.NoError(t, err)
 
-	_, err = pc.AddTransceiver(RTPCodecTypeVideo)
+	_, err = pc.AddTransceiverFromKind(RTPCodecTypeVideo)
 	assert.NoError(t, err)
 
 	sdp, err := pc.CreateOffer(nil)

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -57,7 +57,7 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = pcAnswer.AddTransceiver(RTPCodecTypeVideo)
+	_, err = pcAnswer.AddTransceiverFromKind(RTPCodecTypeVideo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,12 +227,12 @@ func TestPeerConnection_Media_Shutdown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = pcOffer.AddTransceiver(RTPCodecTypeVideo, RtpTransceiverInit{Direction: RTPTransceiverDirectionRecvonly})
+	_, err = pcOffer.AddTransceiverFromKind(RTPCodecTypeVideo, RtpTransceiverInit{Direction: RTPTransceiverDirectionRecvonly})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = pcAnswer.AddTransceiver(RTPCodecTypeVideo, RtpTransceiverInit{Direction: RTPTransceiverDirectionRecvonly})
+	_, err = pcAnswer.AddTransceiverFromKind(RTPCodecTypeVideo, RtpTransceiverInit{Direction: RTPTransceiverDirectionRecvonly})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func TestPeerConnection_Media_Closed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = pcAnswer.AddTransceiver(RTPCodecTypeVideo)
+	_, err = pcAnswer.AddTransceiverFromKind(RTPCodecTypeVideo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -480,7 +480,7 @@ func TestUndeclaredSSRC(t *testing.T) {
 	pcOffer, pcAnswer, err := api.newPair()
 	assert.NoError(t, err)
 
-	_, err = pcAnswer.AddTransceiver(RTPCodecTypeVideo)
+	_, err = pcAnswer.AddTransceiverFromKind(RTPCodecTypeVideo)
 	assert.NoError(t, err)
 
 	vp8Writer, err := pcOffer.NewTrack(DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
@@ -981,7 +981,7 @@ func TestPlanBMultiTrack(t *testing.T) {
 		close(done)
 	}()
 
-	_, err = pcAnswer.AddTransceiver(RTPCodecTypeVideo)
+	_, err = pcAnswer.AddTransceiverFromKind(RTPCodecTypeVideo)
 	assert.NoError(t, err)
 
 	track1 := addSingleTrack(pcOffer)

--- a/peerconnection_setlocaldescription_test.go
+++ b/peerconnection_setlocaldescription_test.go
@@ -65,7 +65,7 @@ func runAnsweringPeer(offerChan <-chan SessionDescription, answerChan chan<- Ses
 	peerConnection, err := api.NewPeerConnection(Configuration{})
 	check(err)
 
-	_, err = peerConnection.AddTransceiver(RTPCodecTypeAudio)
+	_, err = peerConnection.AddTransceiverFromKind(RTPCodecTypeAudio)
 	check(err)
 
 	peerConnection.OnTrack(func(track *Track, receiver *RTPReceiver) {

--- a/sdpsemantics_test.go
+++ b/sdpsemantics_test.go
@@ -65,22 +65,22 @@ func TestSDPSemantics_PlanBOfferTransceivers(t *testing.T) {
 		t.Errorf("NewPeerConnection failed: %v", err)
 	}
 
-	if _, err = opc.AddTransceiver(RTPCodecTypeVideo, RtpTransceiverInit{
+	if _, err = opc.AddTransceiverFromKind(RTPCodecTypeVideo, RtpTransceiverInit{
 		Direction: RTPTransceiverDirectionSendrecv,
 	}); err != nil {
 		t.Errorf("AddTransceiver failed: %v", err)
 	}
-	if _, err = opc.AddTransceiver(RTPCodecTypeVideo, RtpTransceiverInit{
+	if _, err = opc.AddTransceiverFromKind(RTPCodecTypeVideo, RtpTransceiverInit{
 		Direction: RTPTransceiverDirectionSendrecv,
 	}); err != nil {
 		t.Errorf("AddTransceiver failed: %v", err)
 	}
-	if _, err = opc.AddTransceiver(RTPCodecTypeAudio, RtpTransceiverInit{
+	if _, err = opc.AddTransceiverFromKind(RTPCodecTypeAudio, RtpTransceiverInit{
 		Direction: RTPTransceiverDirectionSendrecv,
 	}); err != nil {
 		t.Errorf("AddTransceiver failed: %v", err)
 	}
-	if _, err = opc.AddTransceiver(RTPCodecTypeAudio, RtpTransceiverInit{
+	if _, err = opc.AddTransceiverFromKind(RTPCodecTypeAudio, RtpTransceiverInit{
 		Direction: RTPTransceiverDirectionSendrecv,
 	}); err != nil {
 		t.Errorf("AddTransceiver failed: %v", err)
@@ -131,12 +131,12 @@ func TestSDPSemantics_PlanBAnswerSenders(t *testing.T) {
 		t.Errorf("NewPeerConnection failed: %v", err)
 	}
 
-	if _, err = opc.AddTransceiver(RTPCodecTypeVideo, RtpTransceiverInit{
+	if _, err = opc.AddTransceiverFromKind(RTPCodecTypeVideo, RtpTransceiverInit{
 		Direction: RTPTransceiverDirectionRecvonly,
 	}); err != nil {
 		t.Errorf("Failed to add transceiver")
 	}
-	if _, err = opc.AddTransceiver(RTPCodecTypeAudio, RtpTransceiverInit{
+	if _, err = opc.AddTransceiverFromKind(RTPCodecTypeAudio, RtpTransceiverInit{
 		Direction: RTPTransceiverDirectionRecvonly,
 	}); err != nil {
 		t.Errorf("Failed to add transceiver")
@@ -216,12 +216,12 @@ func TestSDPSemantics_UnifiedPlanWithFallback(t *testing.T) {
 		t.Errorf("NewPeerConnection failed: %v", err)
 	}
 
-	if _, err = opc.AddTransceiver(RTPCodecTypeVideo, RtpTransceiverInit{
+	if _, err = opc.AddTransceiverFromKind(RTPCodecTypeVideo, RtpTransceiverInit{
 		Direction: RTPTransceiverDirectionRecvonly,
 	}); err != nil {
 		t.Errorf("Failed to add transceiver")
 	}
-	if _, err = opc.AddTransceiver(RTPCodecTypeAudio, RtpTransceiverInit{
+	if _, err = opc.AddTransceiverFromKind(RTPCodecTypeAudio, RtpTransceiverInit{
 		Direction: RTPTransceiverDirectionRecvonly,
 	}); err != nil {
 		t.Errorf("Failed to add transceiver")


### PR DESCRIPTION
#### Description
I found `AddTransceiver` is used in `peerconnection` and some tests, although it is a deprecated method.
So I updated those code except `TestAddTransceiver` to use `AddTransceiverFromKind`.

#### Reference issue
This PR is continued from #1128.