### PR TITLE
Fix TestPeerConnection_GetStats stability

### DIFF
--- a/stats_go_test.go
+++ b/stats_go_test.go
@@ -264,6 +264,7 @@ func TestPeerConnection_GetStats(t *testing.T) {
 	})
 	assert.NoError(t, answerDC.Close())
 	waitWithTimeout(t, &dcWait)
+	time.Sleep(10 * time.Millisecond)
 
 	reportPCOffer = offerPC.GetStats()
 	reportPCAnswer = answerPC.GetStats()


### PR DESCRIPTION
Add sleep to ensure counting the last packet.

### Reference issue
Fixes #1127 
