### PR TITLE
Fix potential issue of misinterpreting format string

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Masahiro Nakamura](https://github.com/tsuu32)
 * [Tarrence van As](https://github.com/tarrencev)
 * [Yuki Igarashi](https://github.com/bonprosoft)
+* [Egon Elbre](https://github.com/egonelbre)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -89,29 +89,32 @@ type testCatchAllLeveledLogger struct {
 	callback func(string)
 }
 
-func (t testCatchAllLeveledLogger) handleMsg(format string, args ...interface{}) {
+func (t testCatchAllLeveledLogger) handleMsg(msg string) {
+	t.callback(msg)
+}
+func (t testCatchAllLeveledLogger) handleMsgf(format string, args ...interface{}) {
 	t.callback(fmt.Sprintf(format, args...))
 }
 
 func (t testCatchAllLeveledLogger) Trace(msg string) { t.handleMsg(msg) }
 func (t testCatchAllLeveledLogger) Tracef(format string, args ...interface{}) {
-	t.handleMsg(format, args...)
+	t.handleMsgf(format, args...)
 }
 func (t testCatchAllLeveledLogger) Debug(msg string) { t.handleMsg(msg) }
 func (t testCatchAllLeveledLogger) Debugf(format string, args ...interface{}) {
-	t.handleMsg(format, args...)
+	t.handleMsgf(format, args...)
 }
 func (t testCatchAllLeveledLogger) Info(msg string) { t.handleMsg(msg) }
 func (t testCatchAllLeveledLogger) Infof(format string, args ...interface{}) {
-	t.handleMsg(format, args...)
+	t.handleMsgf(format, args...)
 }
 func (t testCatchAllLeveledLogger) Warn(msg string) { t.handleMsg(msg) }
 func (t testCatchAllLeveledLogger) Warnf(format string, args ...interface{}) {
-	t.handleMsg(format, args...)
+	t.handleMsgf(format, args...)
 }
 func (t testCatchAllLeveledLogger) Error(msg string) { t.handleMsg(msg) }
 func (t testCatchAllLeveledLogger) Errorf(format string, args ...interface{}) {
-	t.handleMsg(format, args...)
+	t.handleMsgf(format, args...)
 }
 
 type testCatchAllLoggerFactory struct {


### PR DESCRIPTION
Fixes potential issue with calling non-formatting functions with strings that maybe interpreted as a format string. 

As an example `log.Trace("%v")n` would end up logging "%!v(MISSING)" instead.