### PR TITLE
Populate network types from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Yuki Igarashi](https://github.com/bonprosoft)
 * [Egon Elbre](https://github.com/egonelbre)
 * [Jerko Steiner](https://github.com/jeremija)
+* [Roman Romanenko](https://github.com/r-novel)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/networktype.go
+++ b/networktype.go
@@ -71,7 +71,9 @@ func (t NetworkType) Protocol() string {
 	}
 }
 
-func newNetworkType(raw string) (NetworkType, error) {
+// NewNetworkType allows create network type from string
+// It will be useful for getting custom network types from external config.
+func NewNetworkType(raw string) (NetworkType, error) {
 	switch raw {
 	case networkTypeUDP4Str:
 		return NetworkTypeUDP4, nil

--- a/networktype_test.go
+++ b/networktype_test.go
@@ -41,7 +41,7 @@ func TestNetworkType(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		actual, err := newNetworkType(testCase.typeString)
+		actual, err := NewNetworkType(testCase.typeString)
 		if (err != nil) != testCase.shouldFail {
 			t.Error(err)
 		}


### PR DESCRIPTION
Added function for setting network types from external side;

#### Description

This patch allows to populate network types from external user's side. It might be data from yaml config or simple string slice.
Since function for creating network type from string is private we can't move this function to user side.
