### PR TITLE
Issue 494 followup

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Egon Elbre](https://github.com/egonelbre)
 * [Jerko Steiner](https://github.com/jeremija)
 * [Roman Romanenko](https://github.com/r-novel)
+* [John Berthels](https://github.com/jbert)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/dtlsrole.go
+++ b/dtlsrole.go
@@ -21,8 +21,22 @@ const (
 )
 
 const (
-	defaultDtlsRoleAnswer = DTLSRoleServer
-	defaultDtlsRoleOffer  = DTLSRoleAuto
+	// https://tools.ietf.org/html/rfc5763
+	/*
+		The answerer MUST use either a
+		setup attribute value of setup:active or setup:passive.  Note that
+		if the answerer uses setup:passive, then the DTLS handshake will
+		not begin until the answerer is received, which adds additional
+		latency. setup:active allows the answer and the DTLS handshake to
+		occur in parallel.  Thus, setup:active is RECOMMENDED.
+	*/
+	defaultDtlsRoleAnswer = DTLSRoleClient
+	/*
+		The endpoint that is the offerer MUST use the setup attribute
+		value of setup:actpass and be prepared to receive a client_hello
+		before it receives the answer.
+	*/
+	defaultDtlsRoleOffer = DTLSRoleAuto
 )
 
 func (r DTLSRole) String() string {


### PR DESCRIPTION
#### Description
Set default dtlsRole for answer client rather than server.

This is done to change the sdp ConnectionRole to  'active' rather than 'passive' when answering, as is recommended by the RFC (details in comments).


#### Reference issue
Fixes #494 follow up issue
