### PR TITLE
Fix empty response bug in pion-to-pion/answer example if pion-to-pion/offer is run from Chrome

### DIFF
--- a/examples/pion-to-pion/answer/main.go
+++ b/examples/pion-to-pion/answer/main.go
@@ -101,6 +101,21 @@ func mustSignalViaHTTP(address string) (offerOut chan webrtc.SessionDescription,
 	answerIn = make(chan webrtc.SessionDescription)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Body == nil {
+			http.Error(w, "Please send a request body", 400)
+			return
+		}
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", http.MethodPost)
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Please send a "+http.MethodPost+" request", 400)
+			return
+		}
+
 		var offer webrtc.SessionDescription
 		err := json.NewDecoder(r.Body).Decode(&offer)
 		if err != nil {

--- a/examples/pion-to-pion/offer/main.go
+++ b/examples/pion-to-pion/offer/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	addr := flag.String("address", ":50000", "Address that the HTTP server is hosted on.")
+	addr := flag.String("address", "127.0.0.1:50000", "Address that the HTTP server is hosted on.")
 	flag.Parse()
 
 	// Everything below is the Pion WebRTC API! Thanks for using it ❤️.


### PR DESCRIPTION
#### Description

Add CORS code to the answer example code
Prefix default "address" flag with "127.0.0.1" so that http.Post works in the browser

#### Reference issue
Fixes #1149