### PR TITLE
Only call iceGatherer.Gather once

### DIFF
--- a/icetransport_test.go
+++ b/icetransport_test.go
@@ -21,7 +21,7 @@ func TestICETransport_OnSelectedCandidatePairChange(t *testing.T) {
 
 	api := NewAPI()
 	api.mediaEngine.RegisterDefaultCodecs()
-	pcOffer, pcAnswer, err := api.newPair()
+	pcOffer, pcAnswer, err := api.newPair(Configuration{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -698,7 +698,10 @@ func (pc *PeerConnection) SetLocalDescription(desc SessionDescription) error {
 		return nil
 	}
 
-	return pc.iceGatherer.Gather()
+	if pc.iceGatherer.State() == ICEGathererStateNew {
+		return pc.iceGatherer.Gather()
+	}
+	return nil
 }
 
 // LocalDescription returns PendingLocalDescription if it is not null and

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -24,13 +24,13 @@ import (
 
 // newPair creates two new peer connections (an offerer and an answerer) using
 // the api.
-func (api *API) newPair() (pcOffer *PeerConnection, pcAnswer *PeerConnection, err error) {
-	pca, err := api.NewPeerConnection(Configuration{})
+func (api *API) newPair(cfg Configuration) (pcOffer *PeerConnection, pcAnswer *PeerConnection, err error) {
+	pca, err := api.NewPeerConnection(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	pcb, err := api.NewPeerConnection(Configuration{})
+	pcb, err := api.NewPeerConnection(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -311,7 +311,7 @@ func TestPeerConnection_ShutdownNoDTLS(t *testing.T) {
 	defer report()
 
 	api := NewAPI()
-	offerPC, answerPC, err := api.newPair()
+	offerPC, answerPC, err := api.newPair(Configuration{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -720,7 +720,7 @@ func TestPeerConnectionTrickle(t *testing.T) {
 	s.SetTrickle(true)
 
 	api := NewAPI(WithSettingEngine(s))
-	offerPC, answerPC, err := api.newPair()
+	offerPC, answerPC, err := api.newPair(Configuration{})
 	assert.NoError(t, err)
 
 	addOrCacheCandidate := func(pc *PeerConnection, c *ICECandidate, candidateCache []ICECandidateInit) []ICECandidateInit {

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -52,7 +52,7 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 	defer report()
 
 	api.mediaEngine.RegisterDefaultCodecs()
-	pcOffer, pcAnswer, err := api.newPair()
+	pcOffer, pcAnswer, err := api.newPair(Configuration{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestPeerConnection_Media_Shutdown(t *testing.T) {
 
 	api := NewAPI()
 	api.mediaEngine.RegisterDefaultCodecs()
-	pcOffer, pcAnswer, err := api.newPair()
+	pcOffer, pcAnswer, err := api.newPair(Configuration{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,7 +325,7 @@ func TestPeerConnection_Media_Disconnected(t *testing.T) {
 	api := NewAPI(WithSettingEngine(s))
 	api.mediaEngine.RegisterDefaultCodecs()
 
-	pcOffer, pcAnswer, err := api.newPair()
+	pcOffer, pcAnswer, err := api.newPair(Configuration{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestPeerConnection_Media_Closed(t *testing.T) {
 
 	api := NewAPI()
 	api.mediaEngine.RegisterDefaultCodecs()
-	pcOffer, pcAnswer, err := api.newPair()
+	pcOffer, pcAnswer, err := api.newPair(Configuration{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -477,7 +477,7 @@ func TestUndeclaredSSRC(t *testing.T) {
 
 	api := NewAPI()
 	api.mediaEngine.RegisterDefaultCodecs()
-	pcOffer, pcAnswer, err := api.newPair()
+	pcOffer, pcAnswer, err := api.newPair(Configuration{})
 	assert.NoError(t, err)
 
 	_, err = pcAnswer.AddTransceiverFromKind(RTPCodecTypeVideo)


### PR DESCRIPTION
In SetLocalDescription guard iceGatherer.Gather by checking state.
We don't put this check inside Gather because ORTC doesn't have the
function as re-entrant

Resolves #1144

Co-authored-by: Jerko Steiner @jeremija