### PR TITLE
Ensure existing transceivers are reused

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1100,20 +1100,22 @@ func (pc *PeerConnection) AddTrack(track *Track) (*RTPSender, error) {
 
 	var transceiver *RTPTransceiver
 	for _, t := range pc.GetTransceivers() {
-		if !t.stopped && t.Sender() != nil &&
-			!t.Sender().hasSent() &&
-			t.Receiver() != nil &&
-			t.Receiver().Track() != nil &&
-			t.Receiver().Track().Kind() == track.Kind() {
+		if !t.stopped && t.kind == track.Kind() && t.Sender() == nil {
 			transceiver = t
 			break
 		}
 	}
 	if transceiver != nil {
+		sender, err := pc.api.NewRTPSender(track, pc.dtlsTransport)
+		if err != nil {
+			return nil, err
+		}
+		transceiver.setSender(sender)
+		// we still need to call setSendingTrack to ensure direction has changed
 		if err := transceiver.setSendingTrack(track); err != nil {
 			return nil, err
 		}
-		return transceiver.Sender(), nil
+		return sender, nil
 	}
 
 	transceiver, err := pc.AddTransceiverFromTrack(track)


### PR DESCRIPTION
#### Description

This might cause problems for existing users who have gotten used to the fact that a new transceiver will always be created when `AddTrack` is called.

I'm not sure if we can simply merge it to master and tag as a patch/minor release. Would greatly appreciate feedback!

#### Reference issue
Fixes #1155