### PR TITLE
Filter out non-sending incoming tracks

### DIFF
--- a/sdp_test.go
+++ b/sdp_test.go
@@ -96,6 +96,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						Media: "foobar",
 					},
 					Attributes: []sdp.Attribute{
+						{Key: "sendrecv"},
 						{Key: "ssrc", Value: "1000 msid:unknown_trk_label unknown_trk_guid"},
 					},
 				},
@@ -104,6 +105,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						Media: "audio",
 					},
 					Attributes: []sdp.Attribute{
+						{Key: "sendrecv"},
 						{Key: "ssrc", Value: "2000 msid:audio_trk_label audio_trk_guid"},
 					},
 				},
@@ -112,6 +114,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						Media: "video",
 					},
 					Attributes: []sdp.Attribute{
+						{Key: "sendrecv"},
 						{Key: "ssrc-group", Value: "FID 3000 4000"},
 						{Key: "ssrc", Value: "3000 msid:video_trk_label video_trk_guid"},
 						{Key: "ssrc", Value: "4000 msid:rtx_trk_label rtx_trck_guid"},
@@ -122,8 +125,27 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						Media: "video",
 					},
 					Attributes: []sdp.Attribute{
+						{Key: "sendonly"},
 						{Key: "msid", Value: "video_stream_id video_trk_id"},
 						{Key: "ssrc", Value: "5000"},
+					},
+				},
+				{
+					MediaName: sdp.MediaName{
+						Media: "video",
+					},
+					Attributes: []sdp.Attribute{
+						{Key: "inactive"},
+						{Key: "ssrc", Value: "6000"},
+					},
+				},
+				{
+					MediaName: sdp.MediaName{
+						Media: "video",
+					},
+					Attributes: []sdp.Attribute{
+						{Key: "recvonly"},
+						{Key: "ssrc", Value: "7000"},
 					},
 				},
 			},

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -130,24 +130,6 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						{Key: "ssrc", Value: "5000"},
 					},
 				},
-				{
-					MediaName: sdp.MediaName{
-						Media: "video",
-					},
-					Attributes: []sdp.Attribute{
-						{Key: "inactive"},
-						{Key: "ssrc", Value: "6000"},
-					},
-				},
-				{
-					MediaName: sdp.MediaName{
-						Media: "video",
-					},
-					Attributes: []sdp.Attribute{
-						{Key: "recvonly"},
-						{Key: "ssrc", Value: "7000"},
-					},
-				},
 			},
 		}
 
@@ -181,5 +163,32 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 			assert.Equal(t, "video_trk_id", track.id)
 			assert.Equal(t, "video_stream_id", track.label)
 		}
+	})
+
+	t.Run("inactive and recvonly tracks ignored", func(t *testing.T) {
+		s := &sdp.SessionDescription{
+			MediaDescriptions: []*sdp.MediaDescription{
+				{
+					MediaName: sdp.MediaName{
+						Media: "video",
+					},
+					Attributes: []sdp.Attribute{
+						{Key: "inactive"},
+						{Key: "ssrc", Value: "6000"},
+					},
+				},
+				{
+					MediaName: sdp.MediaName{
+						Media: "video",
+					},
+					Attributes: []sdp.Attribute{
+						{Key: "recvonly"},
+						{Key: "ssrc", Value: "7000"},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, 0, len(trackDetailsFromSDP(nil, s)))
 	})
 }


### PR DESCRIPTION
This modification will only keep incoming tracks from media sections
with `a=sendrecv` or `a=sendonly` attributes. This modification is not
necessary for pion-to-pion peer connections, but for browser-to-pion
connections using Unified Plan.

Background:

When a `RTCPeerConnection#removeTrack()` is called in the browser and
the connection is renegotiated, the browser (tested in Firefox 75.0)
will change the media section attribute to `a=recvonly` from
`a=sendrecv`, or `a=inactive` from `a=sendonly`, but will keep the same
`a=ssrc:<ssrc>` associated with the same media (mid) section.

Previously, when a remote track obtained with Pion's `OnTrack()` handler
was being read from, and this remote track was later removed in the
browser, the track's `Read()` method would never return `io.EOF` (unless
the peer connection was closed).

With this commit, the `trackDetailsFromSDP` function will only include
remote track details whose media section has `a=sendonly` or
`a=sendrecv` attributes, and previously existing logic will ensure that
a receiver for that specific ssrc is stopped, so that
`webrtc.Track#Read()` method returns `io.EOF`.
