### PR TITLE
Update play-from-disk example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Egon Elbre](https://github.com/egonelbre)
 * [Jerko Steiner](https://github.com/jeremija)
 * [Roman Romanenko](https://github.com/r-novel)
+* [Magnus Wahlstrand](https://github.com/kyeett)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
#### Suggested improvement
Added two things, that I think make this example easier to run and understand
1. If the `ivfErr` is `io.EOF` we assume that the whole file has been read, print `All frames parsed and sent` and then exit out of the goroutine.
2. Wait for the state of the peer connection to become `webrtc.ICEConnectionStateConnected` before we start sending the frames.

#### Description
When I ran this example, I was confused why I kept getting the EOF panic:
```
panic: EOF
goroutine 11 [running]:
main.main.func1(0xc00019a5a0)
	/Users/test/go/src/github.com/pion/webrtc/examples/play-from-disk/main.go:88 +0x369
created by main.main
	/Users/test/go/src/github.com/pion/webrtc/examples/play-from-disk/main.go:64 +0x3c8
```

#### Reference issue
Didn't create an issue :-) Let me know if I should.
