### PR TITLE
Start only negotiated senders

### DIFF
--- a/rtpsender.go
+++ b/rtpsender.go
@@ -18,6 +18,11 @@ type RTPSender struct {
 
 	transport *DTLSTransport
 
+	// TODO(sgotti) remove this when in future we'll avoid replacing
+	// a transceiver sender since we can just check the
+	// transceiver negotiation status
+	negotiated bool
+
 	// A reference to the associated api object
 	api *API
 
@@ -47,6 +52,18 @@ func (api *API) NewRTPSender(track *Track, transport *DTLSTransport) (*RTPSender
 		sendCalled: make(chan interface{}),
 		stopCalled: make(chan interface{}),
 	}, nil
+}
+
+func (r *RTPSender) isNegotiated() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.negotiated
+}
+
+func (r *RTPSender) setNegotiated() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.negotiated = true
 }
 
 // Transport returns the currently-configured *DTLSTransport or nil


### PR DESCRIPTION
#### Description

Only start senders that were negotiated.

Since `startTransports`/`startRenegotiation` start rtp senders in a goroutine,
an user could call AddTrack/Add*Transceiver/RemoveTrack causing a not negotiated
sender track ssrc to be started.

#### Reference issue
Fixes #1169 

