### PR TITLE
make the RTPSender SendRTP public

### DIFF
--- a/rtpsender.go
+++ b/rtpsender.go
@@ -139,8 +139,8 @@ func (r *RTPSender) ReadRTCP() ([]rtcp.Packet, error) {
 	return rtcp.Unmarshal(b[:i])
 }
 
-// sendRTP should only be called by a track, this only exists so we can keep state in one place
-func (r *RTPSender) sendRTP(header *rtp.Header, payload []byte) (int, error) {
+// This is not the right way to do things, but Pion doesn't have a JitterBuffer yet
+func (r *RTPSender) SendRTP(header *rtp.Header, payload []byte) (int, error) {
 	select {
 	case <-r.stopCalled:
 		return 0, fmt.Errorf("RTPSender has been stopped")

--- a/track.go
+++ b/track.go
@@ -157,7 +157,7 @@ func (t *Track) WriteRTP(p *rtp.Packet) error {
 	}
 
 	for _, s := range senders {
-		_, err := s.sendRTP(&p.Header, p.Payload)
+		_, err := s.SendRTP(&p.Header, p.Payload)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
There is no JitterBuffer in Pion yet, and this will make it good to implement one in the application code.