### PR TITLE
Start the right receiver

### DIFF
--- a/sdp.go
+++ b/sdp.go
@@ -13,6 +13,7 @@ import (
 )
 
 type trackDetails struct {
+	mid   string
 	kind  RTPCodecType
 	label string
 	id    string
@@ -33,6 +34,11 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) m
 		if _, ok := media.Attribute(sdp.AttrKeyRecvOnly); ok {
 			continue
 		} else if _, ok := media.Attribute(sdp.AttrKeyInactive); ok {
+			continue
+		}
+
+		midValue := getMidValue(media)
+		if midValue == "" {
 			continue
 		}
 
@@ -97,7 +103,7 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) m
 
 				// Plan B might send multiple a=ssrc lines under a single m= section. This is also why a single trackDetails{}
 				// is not defined at the top of the loop over s.MediaDescriptions.
-				incomingTracks[uint32(ssrc)] = trackDetails{codecType, trackLabel, trackID, uint32(ssrc)}
+				incomingTracks[uint32(ssrc)] = trackDetails{midValue, codecType, trackLabel, trackID, uint32(ssrc)}
 			}
 		}
 	}

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -96,6 +96,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						Media: "foobar",
 					},
 					Attributes: []sdp.Attribute{
+						{Key: "mid", Value: "0"},
 						{Key: "sendrecv"},
 						{Key: "ssrc", Value: "1000 msid:unknown_trk_label unknown_trk_guid"},
 					},
@@ -105,6 +106,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						Media: "audio",
 					},
 					Attributes: []sdp.Attribute{
+						{Key: "mid", Value: "1"},
 						{Key: "sendrecv"},
 						{Key: "ssrc", Value: "2000 msid:audio_trk_label audio_trk_guid"},
 					},
@@ -114,6 +116,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						Media: "video",
 					},
 					Attributes: []sdp.Attribute{
+						{Key: "mid", Value: "2"},
 						{Key: "sendrecv"},
 						{Key: "ssrc-group", Value: "FID 3000 4000"},
 						{Key: "ssrc", Value: "3000 msid:video_trk_label video_trk_guid"},
@@ -125,6 +128,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						Media: "video",
 					},
 					Attributes: []sdp.Attribute{
+						{Key: "mid", Value: "3"},
 						{Key: "sendonly"},
 						{Key: "msid", Value: "video_stream_id video_trk_id"},
 						{Key: "ssrc", Value: "5000"},


### PR DESCRIPTION
#### Description

From PR #1158 during negotiation every required transceiver is assigned
to a specific media section (using the media section mid value).

The same should be done when starting receivers. We should start the
receiver assigned to the media section of that track.
