### PR TITLE
Move transceiver selection inside SetRemoteDescription and CreateOffer

### DIFF
--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -58,11 +58,6 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = pcAnswer.AddTransceiverFromKind(RTPCodecTypeVideo)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	awaitRTPRecv := make(chan bool)
 	awaitRTPRecvClosed := make(chan bool)
 	awaitRTPSend := make(chan bool)
@@ -130,7 +125,7 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rtpReceiver, err := pcOffer.AddTrack(vp8Track)
+	rtpSender, err := pcOffer.AddTrack(vp8Track)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +163,7 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 	}()
 
 	go func() {
-		if _, routineErr := rtpReceiver.Read(make([]byte, 1400)); routineErr == nil {
+		if _, routineErr := rtpSender.Read(make([]byte, 1400)); routineErr == nil {
 			close(awaitRTCPSenderRecv)
 		}
 	}()


### PR DESCRIPTION
#### Description

This tries to better match the JSEP spec and will fix at least two
issues:  #1171 and #1178

* Move transceiver selection/creation in SetRemoteDescription and
CreateOffer
* In SetRemoteDescription also create new Transceivers of type recvonly
when no satisfying transceiver is available
* In CreateOffer generate unique mid in number format avoiding possible
collisions with remote provide mids and to also already handle a future
implementation of m= section rejection and reuse
* Now generateMatchedSDP will just find the transceivers with the
required mid since they are already selected previously.

More details in these extract from JSEP:

JSEP 5.10 (Applying a Remote Description) says:

```
For each m= section, the following steps MUST be performed

[...]

If the m= section is not associated with any RtpTransceiver
(possibly because it was dissociated in the previous step),
either find an RtpTransceiver or create one according to the
following steps:
```

JSEP 5.2 (Constructing an Offer) says:

```
[...]

An m= section is generated for each RtpTransceiver
that has been added to the PeerConnection, excluding any stopped
RtpTransceivers;
```

Note that we are currently directly associating a mid to a transceiver
in CreateOffer, instead the spec says to also keep a m= section index
mapping to a transceiver and set the transceiver mid only when applying
the local description. This is needed to support rollback of proposed
offer/answer but currently we don't have support and tests for rollback
situations.

#### Reference issue
Fixes #1171 
Fixes #1178
