### PR TITLE
Cure ICETransport gatherer agent race

### DIFF
--- a/icetransport.go
+++ b/icetransport.go
@@ -81,7 +81,7 @@ func (t *ICETransport) Start(gatherer *ICEGatherer, params ICEParameters, role *
 		return err
 	}
 
-	agent := t.gatherer.agent
+	agent := t.gatherer.getAgent()
 	if agent == nil {
 		return errors.New("ICEAgent does not exist, unable to start ICETransport")
 	}
@@ -208,12 +208,17 @@ func (t *ICETransport) SetRemoteCandidates(remoteCandidates []ICECandidate) erro
 		return err
 	}
 
+	agent := t.gatherer.getAgent()
+	if agent == nil {
+		return errors.New("ICEAgent does not exist, unable to set remote candidates")
+	}
+
 	for _, c := range remoteCandidates {
 		i, err := c.toICE()
 		if err != nil {
 			return err
 		}
-		err = t.gatherer.agent.AddRemoteCandidate(i)
+		err = agent.AddRemoteCandidate(i)
 		if err != nil {
 			return err
 		}
@@ -235,7 +240,13 @@ func (t *ICETransport) AddRemoteCandidate(remoteCandidate ICECandidate) error {
 	if err != nil {
 		return err
 	}
-	err = t.gatherer.agent.AddRemoteCandidate(c)
+
+	agent := t.gatherer.getAgent()
+	if agent == nil {
+		return errors.New("ICEAgent does not exist, unable to add remote candidates")
+	}
+
+	err = agent.AddRemoteCandidate(c)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The gatherer attached to ICETransport must check wether it actually has
an agent before trying to use it. This avoid a panic when when the
gather is closed while adding or setting remote candidates.

This resolves the following panic:
```
May 07 11:30:16  run.sh[8448]: panic: runtime error: invalid memory address or nil pointer dereference
May 07 11:30:16  run.sh[8448]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x1f0 pc=0x9b5cd2]
May 07 11:30:16  run.sh[8448]: goroutine 19 [running]:
May 07 11:30:16  run.sh[8448]: github.com/pion/ice.(*Agent).ok(0x0, 0xc0018d3e80, 0x10)
May 07 11:30:16  run.sh[8448]:         github.com/pion/ice@v0.7.10/agent.go:166 +0x22
May 07 11:30:16  run.sh[8448]: github.com/pion/ice.(*Agent).run(0x0, 0xc004368938, 0x6, 0xc000438600)
May 07 11:30:16  run.sh[8448]:         github.com/pion/ice@v0.7.10/agent.go:183 +0x40
May 07 11:30:16  run.sh[8448]: github.com/pion/ice.(*Agent).AddRemoteCandidate(0x0, 0xccc960, 0xc000ec9f40, 0x9, 0x5a7f1eff)
May 07 11:30:16  run.sh[8448]:         github.com/pion/ice@v0.7.10/agent.go:785 +0x1ee
May 07 11:30:16  run.sh[8448]: github.com/pion/webrtc/v2.(*ICETransport).AddRemoteCandidate(0xc0006c0480, 0x0, 0x0, 0xc0008fe28a, 0x9, 0x5a7f1eff, 0xc0008fe2a5, 0xc, 0x2, 0x9, ...)
May 07 11:30:16  run.sh[8448]:         github.com/pion/webrtc/v2@v2.2.4/icetransport.go:238 +0x10f
May 07 11:30:16  run.sh[8448]: github.com/pion/webrtc/v2.(*PeerConnection).SetRemoteDescription(0xc000dfbd40, 0x1, 0xc000cf6240, 0x22d, 0x0, 0x0, 0x0)
May 07 11:30:16  run.sh[8448]:         github.com/pion/webrtc/v2@v2.2.4/peerconnection.go:758 +0x46d

```