### PR TITLE
Fix handling of Empty DataChannel messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Chad Retz](https://github.com/cretz)
 * [Simone Gotti](https://github.com/sgotti)
 * [Cedric Fung](https://github.com/cedricfung)
+* [Norman Rasmussen](https://github.com/normanr) - *Fix Empty DataChannel messages*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/datachannel.go
+++ b/datachannel.go
@@ -335,10 +335,6 @@ func (d *DataChannel) Send(data []byte) error {
 		return err
 	}
 
-	if len(data) == 0 {
-		data = []byte{0}
-	}
-
 	_, err = d.dataChannel.WriteDataChannel(data, false)
 	return err
 }
@@ -350,12 +346,7 @@ func (d *DataChannel) SendText(s string) error {
 		return err
 	}
 
-	data := []byte(s)
-	if len(data) == 0 {
-		data = []byte{0}
-	}
-
-	_, err = d.dataChannel.WriteDataChannel(data, true)
+	_, err = d.dataChannel.WriteDataChannel([]byte(s), true)
 	return err
 }
 


### PR DESCRIPTION
This is the second half of https://github.com/pion/datachannel/pull/60:

> Empty messages should be sent as one zero byte. When receiving an Empty
> message, the contents should be ignored.
> 
> Currently pion/webrtc converts zero-byte messages into single null-byte messages and datachannels transmits it as a regular message. This fixes datachannels to send the correct payload and strip the payload for Empty messages.
> 
> I'll send a PR for webrtc to remove the conversion from webrtc too.

Now that datachannel handles Empty messages correctly, webrtc should pass them to datachannel at they are.