### PR TITLE
Answer with sendonly when remote is recvonly

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -818,7 +818,15 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 				if err != nil {
 					return err
 				}
-				t = pc.newRTPTransceiver(receiver, nil, RTPTransceiverDirectionRecvonly, kind)
+
+				switch direction {
+				case RTPTransceiverDirectionSendonly, RTPTransceiverDirectionSendrecv:
+					t = pc.newRTPTransceiver(receiver, nil, RTPTransceiverDirectionRecvonly, kind)
+				default:
+					// Inactive for RTPTransceiverDirectionRecvonly or RTPTransceiverDirectionInactive
+					t = pc.newRTPTransceiver(receiver, nil, RTPTransceiverDirectionInactive, kind)
+				}
+
 			}
 			if t.Mid() == "" {
 				_ = t.setMid(midValue)

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -810,7 +810,20 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 			}
 
 			t, localTransceivers = findByMid(midValue, localTransceivers)
-			if t == nil {
+			if t != nil {
+				transceiveDirection := t.Direction()
+
+				switch direction {
+				case RTPTransceiverDirectionRecvonly:
+					if transceiveDirection == RTPTransceiverDirectionRecvonly {
+						t.setDirection(RTPTransceiverDirectionInactive)
+					}
+				case RTPTransceiverDirectionSendonly:
+					if transceiveDirection == RTPTransceiverDirectionSendonly {
+						t.setDirection(RTPTransceiverDirectionInactive)
+					}
+				}
+			} else {
 				t, localTransceivers = satisfyTypeAndDirection(kind, direction, localTransceivers)
 			}
 			if t == nil {


### PR DESCRIPTION
When receiving a remote offer with a transceiver which is recvonly, the
answer must not set the transceiver to a receiving mode to avoid Firefox
from complaining and failing to set the remote description with the
following error:

```
Answer tried to set recv when offer did not set send
```

While Chrome is more forgiving and happily sets remote transceiver which
include receive even when the offer did not request ist, this needs to
be changed to get interop with Firefox.

The change is to create the implicitly created receivers introduced with
#1179 as inactive if the remote description does offer only to
receive. This will later on switch the transceiver to sendonly as soon
as a matching track is added.


Example of wrong behavior:

Pion receives the following offer
```
v=0
o=mozilla...THIS_IS_SDPARTA-77.0 954045388085230531 1 IN IP4 0.0.0.0
s=-
t=0 0
a=sendrecv
a=fingerprint:sha-256 B3:0E:89:A3:47:8C:A7:92:6E:3B:45:7A:C3:FF:58:F1:4A:36:2A:15:1E:A9:A0:A8:9C:3B:36:92:89:E4:F3:A9
a=group:BUNDLE 0 1
a=ice-options:trickle
a=msid-semantic:WMS *
m=application 36396 DTLS/SCTP 5000
c=IN IP4 172.17.0.1
a=candidate:0 1 UDP 2121269503 192.168.1.164 51738 typ host
a=candidate:3 1 UDP 2122055935 10.98.91.1 55680 typ host
a=candidate:6 1 UDP 2122121471 172.18.0.1 37378 typ host
a=candidate:9 1 UDP 2122187007 172.17.0.1 36396 typ host
a=candidate:12 1 UDP 2121793791 172.31.0.1 52583 typ host
a=candidate:15 1 UDP 2121728255 172.21.0.1 56611 typ host
a=candidate:18 1 UDP 2121662719 172.22.0.1 35638 typ host
a=candidate:21 1 UDP 2121597183 172.30.0.1 58337 typ host
a=candidate:24 1 UDP 2121924863 172.29.0.1 53127 typ host
a=candidate:27 1 UDP 2121859327 172.28.0.1 60922 typ host
a=candidate:30 1 UDP 2121531647 172.19.0.1 35106 typ host
a=candidate:33 1 UDP 2121466111 172.27.0.1 45025 typ host
a=candidate:36 1 UDP 2121335039 fd00:1:1:1:c191:bec9:270b:d79f 37412 typ host
a=candidate:39 1 UDP 2121400575 fd00:1:1:1:6357:fe0b:460e:f3f8 50434 typ host
a=candidate:42 1 UDP 2122252543 fd1f:a918:4924:ab6::1 60620 typ host
a=candidate:45 1 TCP 2104541439 192.168.1.164 9 typ host tcptype active
a=candidate:47 1 TCP 2105327871 10.98.91.1 9 typ host tcptype active
a=candidate:49 1 TCP 2105393407 172.18.0.1 9 typ host tcptype active
a=candidate:51 1 TCP 2105458943 172.17.0.1 9 typ host tcptype active
a=candidate:53 1 TCP 2105065727 172.31.0.1 9 typ host tcptype active
a=candidate:55 1 TCP 2105000191 172.21.0.1 9 typ host tcptype active
a=candidate:57 1 TCP 2104934655 172.22.0.1 9 typ host tcptype active
a=candidate:59 1 TCP 2104869119 172.30.0.1 9 typ host tcptype active
a=candidate:61 1 TCP 2105196799 172.29.0.1 9 typ host tcptype active
a=candidate:63 1 TCP 2105131263 172.28.0.1 9 typ host tcptype active
a=candidate:65 1 TCP 2104803583 172.19.0.1 9 typ host tcptype active
a=candidate:67 1 TCP 2104738047 172.27.0.1 9 typ host tcptype active
a=candidate:69 1 TCP 2104606975 fd00:1:1:1:c191:bec9:270b:d79f 9 typ host tcptype active
a=candidate:71 1 TCP 2104672511 fd00:1:1:1:6357:fe0b:460e:f3f8 9 typ host tcptype active
a=candidate:73 1 TCP 2105524479 fd1f:a918:4924:ab6::1 9 typ host tcptype active
a=candidate:75 1 TCP 2105262335 fd00:3984:3989::1 9 typ host tcptype active
a=sendrecv
a=ice-pwd:1f43c65a10eb94d6a5412620ecc37390
a=ice-ufrag:7f7be20e
a=mid:0
a=sctpmap:5000 webrtc-datachannel 256
a=setup:actpass
a=max-message-size:1073741823
m=video 9 UDP/TLS/RTP/SAVPF 120 121 126 97
c=IN IP4 0.0.0.0
b=TIAS:934000
a=recvonly
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:5 urn:ietf:params:rtp-hdrext:toffset
a=extmap:6/recvonly http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:7 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
a=fmtp:120 max-fs=12288;max-fr=60
a=fmtp:121 max-fs=12288;max-fr=60
a=ice-pwd:1f43c65a10eb94d6a5412620ecc37390
a=ice-ufrag:7f7be20e
a=mid:1
a=rtcp-fb:120 nack
a=rtcp-fb:120 nack pli
a=rtcp-fb:120 ccm fir
a=rtcp-fb:120 goog-remb
a=rtcp-fb:120 transport-cc
a=rtcp-fb:121 nack
a=rtcp-fb:121 nack pli
a=rtcp-fb:121 ccm fir
a=rtcp-fb:121 goog-remb
a=rtcp-fb:121 transport-cc
a=rtcp-fb:126 nack
a=rtcp-fb:126 nack pli
a=rtcp-fb:126 ccm fir
a=rtcp-fb:126 goog-remb
a=rtcp-fb:126 transport-cc
a=rtcp-fb:97 nack
a=rtcp-fb:97 nack pli
a=rtcp-fb:97 ccm fir
a=rtcp-fb:97 goog-remb
a=rtcp-fb:97 transport-cc
a=rtcp-mux
a=rtpmap:120 VP8/90000
a=rtpmap:121 VP9/90000
a=rtpmap:126 H264/90000
a=rtpmap:97 H264/90000
a=setup:actpass
a=ssrc:92658898 cname:{bbbe3e94-ec86-48ab-a323-487920b70395}
```

Without this change, Pion generates the following answer

```
v=0
o=- 636424965 1589461269 IN IP4 0.0.0.0
s=-
t=0 0
a=fingerprint:sha-256 93:57:62:7F:82:31:81:3D:77:02:06:1E:E2:D5:C7:04:30:FC:71:32:E1:8E:D1:DC:05:89:D7:BC:60:23:0B:80
a=group:BUNDLE 0 1
m=application 9 DTLS/SCTP 5000
c=IN IP4 0.0.0.0
a=setup:passive
a=mid:0
a=sendrecv
a=sctpmap:5000 webrtc-datachannel 1024
a=ice-ufrag:MAkcUnXzgQXeJziG
a=ice-pwd:wDByKGxpnpnAtlQQBsHTWlVnOlWJdpzQ
a=candidate:foundation 1 udp 2130706431 192.168.1.164 32465 typ host generation 0
a=candidate:foundation 2 udp 2130706431 192.168.1.164 32465 typ host generation 0
a=end-of-candidates
m=video 9 UDP/TLS/RTP/SAVPF 120 121 126 97
c=IN IP4 0.0.0.0
a=setup:passive
a=mid:1
a=ice-ufrag:MAkcUnXzgQXeJziG
a=ice-pwd:wDByKGxpnpnAtlQQBsHTWlVnOlWJdpzQ
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:120 VP8/90000
a=fmtp:120 max-fs=12288;max-fr=60
a=rtcp-fb:120 goog-remb 
a=rtcp-fb:120 ccm 
a=rtcp-fb:120 nack 
a=rtcp-fb:120 nack pli 
a=rtpmap:121 VP9/90000
a=fmtp:121 max-fs=12288;max-fr=60
a=rtcp-fb:121 goog-remb 
a=rtcp-fb:121 ccm 
a=rtcp-fb:121 nack 
a=rtcp-fb:121 nack pli 
a=rtpmap:126 H264/90000
a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
a=rtcp-fb:126 goog-remb 
a=rtcp-fb:126 ccm 
a=rtcp-fb:126 nack 
a=rtcp-fb:126 nack pli 
a=rtpmap:97 H264/90000
a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
a=rtcp-fb:97 goog-remb 
a=rtcp-fb:97 ccm 
a=rtcp-fb:97 nack 
a=rtcp-fb:97 nack pli 
a=ssrc:1824975778 cname:stream_user2
a=ssrc:1824975778 msid:stream_user2 486caddd-ce12-49e0-823d-0cef7037ab91
a=ssrc:1824975778 mslabel:stream_user2
a=ssrc:1824975778 label:486caddd-ce12-49e0-823d-0cef7037ab91
a=msid:stream_user2 486caddd-ce12-49e0-823d-0cef7037ab91
a=sendrecv
a=candidate:foundation 1 udp 2130706431 192.168.1.164 32465 typ host generation 0
a=candidate:foundation 2 udp 2130706431 192.168.1.164 32465 typ host generation 0
a=end-of-candidates
```

Note the mid:1 transceiver which is recvonly in the offer, and sendrecv in the answer. After applying this patch, the answer mid:1 transceiver is `sendonly`.