### PR TITLE
[WIP] Implement simulcast

### DIFF
--- a/examples/simulcast/README.md
+++ b/examples/simulcast/README.md
@@ -1,0 +1,27 @@
+# simulcast
+demonstrates of how to handle incoming track with multiple simulcast rtp streams and show all them back.
+
+## Instructions
+### Download simulcast
+```
+go get github.com/pion/webrtc/v2/examples/simulcast
+```
+
+### Open simulcast example page
+[jsfiddle.net](https://jsfiddle.net/rxk4bftc) you should see two text-areas and a 'Start Session' button.
+
+### Run simulcast, with your browsers SessionDescription as stdin
+In the jsfiddle the top textarea is your browser, copy that and:
+#### Linux/macOS
+Run `echo $BROWSER_SDP | simulcast`
+#### Windows
+1. Paste the SessionDescription into a file.
+1. Run `simulcast < my_file`
+
+### Input simulcast's SessionDescription into your browser
+Copy the text that `simulcast` just emitted and copy into second text area
+
+### Hit 'Start Session' in jsfiddle, enjoy your video!
+Your browser should send a simulcast track to Pion, and then all 3 incoming streams will be relayed back.
+
+Congrats, you have used Pion WebRTC! Now start building something cool

--- a/examples/simulcast/jsfiddle/demo.css
+++ b/examples/simulcast/jsfiddle/demo.css
@@ -1,0 +1,4 @@
+textarea {
+    width: 500px;
+    min-height: 75px;
+}

--- a/examples/simulcast/jsfiddle/demo.details
+++ b/examples/simulcast/jsfiddle/demo.details
@@ -1,0 +1,5 @@
+---
+ name: simulcast
+ description: Example of how to have Pion handle incoming track with multiple simulcast rtp streams and show all them back.
+ authors:
+   - Simone Gotti

--- a/examples/simulcast/jsfiddle/demo.html
+++ b/examples/simulcast/jsfiddle/demo.html
@@ -1,0 +1,18 @@
+<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+Browser base64 Session Description<br />
+<textarea id="localSessionDescription" readonly="true"></textarea> <br />
+
+Golang base64 Session Description<br />
+<textarea id="remoteSessionDescription"></textarea> <br />
+<button onclick="window.startSession()"> Start Session </button><br />
+
+<br />
+
+<div>
+  Browser stream<br />
+  <video id="browserVideo" width="200" height="200" autoplay muted></video>
+</div>
+
+<div id="serverVideos">
+  Video from server<br />
+</div>

--- a/examples/simulcast/jsfiddle/demo.js
+++ b/examples/simulcast/jsfiddle/demo.js
@@ -1,0 +1,92 @@
+// Create peer conn
+const pc = new RTCPeerConnection({
+  iceServers: [
+    {
+      urls: "stun:stun.l.google.com:19302",
+    },
+  ],
+});
+
+pc.oniceconnectionstatechange = (e) => {
+  console.log("connection state change", pc.iceConnectionState);
+};
+pc.onicecandidate = (event) => {
+  if (event.candidate === null) {
+    document.getElementById("localSessionDescription").value = btoa(
+      JSON.stringify(pc.localDescription)
+    );
+  }
+};
+
+pc.onnegotiationneeded = (e) =>
+  pc
+    .createOffer()
+    .then((d) => pc.setLocalDescription(d))
+    .catch(console.error);
+
+pc.ontrack = (event) => {
+  console.log("Got track event", event);
+  let video = document.createElement("video");
+  video.srcObject = event.streams[0];
+  video.autoplay = true;
+  video.width = "500";
+  let label = document.createElement("div");
+  label.textContent = event.streams[0].id;
+  document.getElementById("serverVideos").appendChild(label);
+  document.getElementById("serverVideos").appendChild(video);
+};
+
+navigator.mediaDevices
+  .getUserMedia({
+    video: {
+      width: {
+        ideal: 4096,
+      },
+      height: {
+        ideal: 2160,
+      },
+      frameRate: {
+        ideal: 60,
+        min: 10,
+      },
+    },
+    audio: false,
+  })
+  .then((stream) => {
+    document.getElementById("browserVideo").srcObject = stream;
+    pc.addTransceiver(stream.getVideoTracks()[0], {
+      direction: "sendonly",
+      streams: [stream],
+      sendEncodings: [
+        // for firefox order matters... first high resolution, then scaled resolutions...
+        {
+          rid: "f",
+        },
+        {
+          rid: "h",
+          scaleResolutionDownBy: 2.0,
+        },
+        {
+          rid: "q",
+          scaleResolutionDownBy: 4.0,
+        },
+      ],
+    });
+    pc.addTransceiver("video");
+    pc.addTransceiver("video");
+    pc.addTransceiver("video");
+  });
+
+window.startSession = () => {
+  const sd = document.getElementById("remoteSessionDescription").value;
+  if (sd === "") {
+    return alert("Session Description must not be empty");
+  }
+
+  try {
+    console.log("answer", JSON.parse(atob(sd)));
+    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))));
+  } catch (e) {
+    alert(e);
+  }
+};

--- a/examples/simulcast/main.go
+++ b/examples/simulcast/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"time"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/webrtc/v2"
+	"github.com/pion/webrtc/v2/examples/internal/signal"
+)
+
+func main() {
+	// Everything below is the Pion WebRTC API! Thanks for using it ❤️.
+
+	// Wait for the offer to be pasted
+	offer := webrtc.SessionDescription{}
+	signal.Decode(signal.MustReadStdin(), &offer)
+
+	// We make our own mediaEngine so we can place the sender's codecs in it. Since we are echoing their RTP packet
+	// back to them we are actually codec agnostic - we can accept all their codecs. This also ensures that we use the
+	// dynamic media type from the sender in our answer.
+	mediaEngine := webrtc.MediaEngine{}
+
+	// Add codecs to the mediaEngine. Note that even though we are only going to echo back the sender's video we also
+	// add audio codecs. This is because createAnswer will create an audioTransceiver and associated SDP and we currently
+	// cannot tell it not to. The audio SDP must match the sender's codecs too...
+	err := mediaEngine.PopulateFromSDP(offer)
+	if err != nil {
+		panic(err)
+	}
+
+	videoCodecs := mediaEngine.GetCodecsByKind(webrtc.RTPCodecTypeVideo)
+	if len(videoCodecs) == 0 {
+		panic("Offer contained no video codecs")
+	}
+
+	api := webrtc.NewAPI(webrtc.WithMediaEngine(mediaEngine))
+
+	// Prepare the configuration
+	config := webrtc.Configuration{
+		ICEServers: []webrtc.ICEServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	}
+	// Create a new RTCPeerConnection
+	peerConnection, err := api.NewPeerConnection(config)
+	if err != nil {
+		panic(err)
+	}
+
+	outputTracks := map[string]*webrtc.Track{}
+
+	// Create Track that we send video back to browser on
+	outputTrack, err := peerConnection.NewTrack(videoCodecs[0].PayloadType, rand.Uint32(), "video_q", "pion_q")
+	if err != nil {
+		panic(err)
+	}
+	outputTracks["q"] = outputTrack
+
+	outputTrack, err = peerConnection.NewTrack(videoCodecs[0].PayloadType, rand.Uint32(), "video_h", "pion_h")
+	if err != nil {
+		panic(err)
+	}
+	outputTracks["h"] = outputTrack
+
+	outputTrack, err = peerConnection.NewTrack(videoCodecs[0].PayloadType, rand.Uint32(), "video_f", "pion_f")
+	if err != nil {
+		panic(err)
+	}
+	outputTracks["f"] = outputTrack
+
+	// Add this newly created track to the PeerConnection
+	if _, err = peerConnection.AddTrack(outputTracks["q"]); err != nil {
+		panic(err)
+	}
+	if _, err = peerConnection.AddTrack(outputTracks["h"]); err != nil {
+		panic(err)
+	}
+	if _, err = peerConnection.AddTrack(outputTracks["f"]); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("offer: %s\n", offer.SDP)
+	// Set the remote SessionDescription
+	err = peerConnection.SetRemoteDescription(offer)
+	if err != nil {
+		panic(err)
+	}
+
+	// Set a handler for when a new remote track starts
+	peerConnection.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
+		fmt.Printf("Track has started\n")
+
+		// Start reading from all the streams and sending them to the related output track
+		for _, inStream := range track.Streams() {
+			go func(inStream *webrtc.TrackRTPStream) {
+				rid := inStream.RID()
+				go func() {
+					ticker := time.NewTicker(3 * time.Second)
+					for range ticker.C {
+						fmt.Printf("Sending pli for stream with rid: %q, ssrc: %d\n", inStream.RID(), inStream.SSRC())
+						if writeErr := peerConnection.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: inStream.SSRC()}}); writeErr != nil {
+							fmt.Println(writeErr)
+						}
+						// Send a remb message with a very high bandwidth to trigger chrome to send also the high bitrate stream
+						fmt.Printf("Sending remb for stream with rid: %q, ssrc: %d\n", inStream.RID(), inStream.SSRC())
+						if writeErr := peerConnection.WriteRTCP([]rtcp.Packet{&rtcp.ReceiverEstimatedMaximumBitrate{Bitrate: 10000000, SenderSSRC: inStream.SSRC()}}); writeErr != nil {
+							fmt.Println(writeErr)
+						}
+					}
+				}()
+				for {
+					var readErr error
+					// Read RTP packets being sent to Pion
+					packet, readErr := inStream.ReadRTP()
+					if err != nil {
+						panic(readErr)
+					}
+
+					packet.SSRC = outputTracks[rid].SSRC()
+
+					if writeErr := outputTracks[rid].WriteRTP(packet); writeErr != nil && writeErr != io.ErrClosedPipe {
+						panic(writeErr)
+					}
+				}
+			}(inStream)
+		}
+	})
+	// Set the handler for ICE connection state and update chan if connected
+	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
+		fmt.Printf("Connection State has changed %s \n", connectionState.String())
+	})
+
+	// Create an answer
+	answer, err := peerConnection.CreateAnswer(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("answer: %s\n", answer.SDP)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output the answer in base64 so we can paste it in browser
+	fmt.Printf("Paste below base64 in browser:\n%v\n", signal.Encode(answer))
+
+	// Block forever
+	select {}
+}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -810,7 +810,26 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 			}
 
 			t, localTransceivers = findByMid(midValue, localTransceivers)
-			if t == nil {
+			if t != nil {
+				transceiveDirection := t.Direction()
+
+				switch direction {
+				case RTPTransceiverDirectionRecvonly:
+					if transceiveDirection == RTPTransceiverDirectionRecvonly {
+						t.setDirection(RTPTransceiverDirectionInactive)
+					}
+					if transceiveDirection == RTPTransceiverDirectionSendrecv {
+						t.setDirection(RTPTransceiverDirectionSendonly)
+					}
+				case RTPTransceiverDirectionSendonly:
+					if transceiveDirection == RTPTransceiverDirectionSendonly {
+						t.setDirection(RTPTransceiverDirectionInactive)
+					}
+					if transceiveDirection == RTPTransceiverDirectionSendrecv {
+						t.setDirection(RTPTransceiverDirectionRecvonly)
+					}
+				}
+			} else {
 				t, localTransceivers = satisfyTypeAndDirection(kind, direction, localTransceivers)
 			}
 			if t == nil {
@@ -823,6 +842,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 			if t.Mid() == "" {
 				_ = t.setMid(midValue)
 			}
+			t.setRemoteDirection(direction)
 		}
 	}
 

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1198,7 +1198,12 @@ func (pc *PeerConnection) AddTrack(track *Track) (*RTPSender, error) {
 
 	var transceiver *RTPTransceiver
 	for _, t := range pc.GetTransceivers() {
-		if !t.stopped && t.kind == track.Kind() && t.Sender() == nil {
+		// use existing transceiver if:
+		// * not stopped
+		// * same kind
+		// * without a sender
+		// * the transceiver has not been negotiated yet or negotiated and remote direction can receive
+		if !t.stopped && t.kind == track.Kind() && t.Sender() == nil && (t.getRemoteDirection() == RTPTransceiverDirection(Unknown) || t.getRemoteDirection() == RTPTransceiverDirectionSendrecv || t.getRemoteDirection() == RTPTransceiverDirectionRecvonly) {
 			transceiver = t
 			break
 		}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	mathRand "math/rand"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -59,6 +60,10 @@ type PeerConnection struct {
 	// should be defined (see JSEP 3.4.1).
 	greaterMid int
 
+	// extmaps
+	remoteExtMaps map[int]*sdp.ExtMap
+	extMaps       map[int]*sdp.ExtMap
+
 	rtpTransceivers []*RTPTransceiver
 
 	onSignalingStateChangeHandler     func(SignalingState)
@@ -108,12 +113,40 @@ func (api *API) NewPeerConnection(configuration Configuration) (*PeerConnection,
 		lastOffer:                    "",
 		lastAnswer:                   "",
 		greaterMid:                   -1,
+		remoteExtMaps:                make(map[int]*sdp.ExtMap),
 		signalingState:               SignalingStateStable,
 		iceConnectionState:           ICEConnectionStateNew,
 		connectionState:              PeerConnectionStateNew,
 
 		api: api,
 		log: api.settingEngine.LoggerFactory.NewLogger("pc"),
+	}
+
+	transportCCURL, _ := url.Parse(TransportCCURI)
+	sdesMidURL, _ := url.Parse(SDESMidURI)
+	sdesRTPStreamIDURL, _ := url.Parse(SDESRTPStreamIDURI)
+
+	// populate with locally supported extmaps
+	pc.extMaps = map[int]*sdp.ExtMap{
+		// use the default value for transportcc
+		extMapValueTransportCC: {
+			Value: extMapValueTransportCC,
+			URI:   transportCCURL,
+			// support both send and recv direction
+			Direction: 0,
+		},
+		extMapValueSDESMid: {
+			Value: extMapValueSDESMid,
+			URI:   sdesMidURL,
+			// support both send and recv direction
+			Direction: 0,
+		},
+		extMapValueSDESRTPStreamID: {
+			Value: extMapValueSDESRTPStreamID,
+			URI:   sdesRTPStreamIDURL,
+			// support both send and recv direction
+			Direction: 0,
+		},
 	}
 
 	var err error
@@ -791,6 +824,10 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 	var t *RTPTransceiver
 	localTransceivers := append([]*RTPTransceiver{}, pc.GetTransceivers()...)
 	detectedPlanB := descriptionIsPlanB(pc.RemoteDescription())
+
+	if err := pc.updateExtMaps(weOffer); err != nil {
+		return err
+	}
 
 	if !weOffer && !detectedPlanB {
 		for _, media := range pc.RemoteDescription().parsed.MediaDescriptions {
@@ -1970,4 +2007,71 @@ func (pc *PeerConnection) generateMatchedSDP(useIdentity bool, includeUnmatched 
 	}
 
 	return populateSDP(d, detectedPlanB, pc.api.settingEngine.candidates.ICELite, pc.api.mediaEngine, connectionRole, candidates, iceParams, mediaSections, pc.ICEGatheringState())
+}
+
+func (pc *PeerConnection) updateExtMaps(weOffer bool) error {
+	remoteExtMaps := map[int]*sdp.ExtMap{}
+
+	// populate the extmaps from the current remote description
+	for _, media := range pc.RemoteDescription().parsed.MediaDescriptions {
+		// populate known remote extmap and handle conflicts.
+		for _, attr := range media.Attributes {
+			if attr.Key != "extmap" {
+				continue
+			}
+			em := &sdp.ExtMap{}
+			if err := em.Unmarshal("extmap:" + attr.Value); err != nil {
+				pc.log.Warnf("Failed to parse ExtMap: %v", err)
+				continue
+			}
+			if remoteExtMap, ok := remoteExtMaps[em.Value]; ok {
+				if remoteExtMap.Value != em.Value {
+					return fmt.Errorf("RemoteDescription changed some extmaps values")
+				}
+			} else {
+				remoteExtMaps[em.Value] = em
+			}
+		}
+	}
+
+	// update our know remote extmaps from new extmaps from the current remote description
+	for _, curRemoteExtMap := range remoteExtMaps {
+		if remoteExtMap, ok := pc.remoteExtMaps[curRemoteExtMap.Value]; ok {
+			// check that the remote extmaps haven't changed some already known values
+			if remoteExtMap.Value != curRemoteExtMap.Value {
+				return fmt.Errorf("RemoteDescription changed some extmaps values")
+			}
+		} else {
+			// add new extmap
+			pc.remoteExtMaps[curRemoteExtMap.Value] = curRemoteExtMap
+		}
+	}
+
+	// If we are receiving an offer update our extMaps adapting to the remote values
+	if !weOffer {
+		for _, remoteExtMap := range pc.remoteExtMaps {
+			// update existing locally provided value
+			for _, extMap := range pc.extMaps {
+				if extMap.URI.String() == remoteExtMap.URI.String() {
+					extMap.Value = remoteExtMap.Value
+					break
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetExtMapByURI return a copy of the extmap matching the provided
+// URI. Note that the extmap value will change if not yet negotiated
+func (pc *PeerConnection) GetExtMapByURI(uri string) *sdp.ExtMap {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	for _, extMap := range pc.extMaps {
+		if extMap.URI.String() == uri {
+			return extMap
+		}
+	}
+	return nil
 }

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -916,7 +916,7 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 	receiver.Track().mu.Unlock()
 
 	go func() {
-		if err = receiver.Track().determinePayloadType(); err != nil {
+		if err = receiver.Track().streams[0].determinePayloadType(); err != nil {
 			pc.log.Warnf("Could not determine PayloadType for SSRC %d", receiver.Track().SSRC())
 			return
 		}
@@ -932,7 +932,7 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 
 		receiver.Track().mu.Lock()
 		receiver.Track().kind = codec.Type
-		receiver.Track().codec = codec
+		receiver.Track().streams[0].codec = codec
 		receiver.Track().mu.Unlock()
 
 		if pc.onTrackHandler != nil {
@@ -1753,7 +1753,7 @@ func (pc *PeerConnection) startRTP(isRenegotiation bool, remoteDesc *SessionDesc
 				// check if there's a track with the same ssrc but different track id
 				for _, incoming := range trackDetails {
 					for ssrc := range incoming.ssrcStreams {
-						if t.Receiver().Track().ssrc == ssrc {
+						if t.Receiver().Track().streams[0].ssrc == ssrc {
 							matched = true
 							// update receiver track id and label
 							t.Receiver().Track().id = incoming.mstid
@@ -1769,7 +1769,7 @@ func (pc *PeerConnection) startRTP(isRenegotiation bool, remoteDesc *SessionDesc
 				// matching track id
 				for ssrc := range incoming.ssrcStreams {
 					// check if the incoming track as the same ssrc
-					if t.Receiver().Track().ssrc == ssrc {
+					if t.Receiver().Track().streams[0].ssrc == ssrc {
 						matched = true
 						// update receiver track id and label
 						t.Receiver().Track().id = incoming.mstid

--- a/rtpcodingparameters.go
+++ b/rtpcodingparameters.go
@@ -4,6 +4,7 @@ package webrtc
 // This is a subset of the RFC since Pion WebRTC doesn't implement encoding/decoding itself
 // http://draft.ortc.org/#dom-rtcrtpcodingparameters
 type RTPCodingParameters struct {
-	SSRC        uint32 `json:"ssrc"`
-	PayloadType uint8  `json:"payloadType"`
+	SSRC        uint32
+	RID         string
+	PayloadType uint8
 }

--- a/rtpreceiveparameters.go
+++ b/rtpreceiveparameters.go
@@ -2,5 +2,5 @@ package webrtc
 
 // RTPReceiveParameters contains the RTP stack settings used by receivers
 type RTPReceiveParameters struct {
-	Encodings RTPDecodingParameters
+	Encodings []RTPDecodingParameters
 }

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -70,8 +70,14 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 
 	r.track = &Track{
 		kind:     r.kind,
-		ssrc:     parameters.Encodings.SSRC,
 		receiver: r,
+	}
+
+	for _, enc := range parameters.Encodings {
+		r.track.ssrc = enc.SSRC
+
+		// only one ssrc is supported
+		break
 	}
 
 	srtpSession, err := r.transport.getSRTPSession()
@@ -79,7 +85,7 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 		return err
 	}
 
-	r.rtpReadStream, err = srtpSession.OpenReadStream(parameters.Encodings.SSRC)
+	r.rtpReadStream, err = srtpSession.OpenReadStream(parameters.Encodings[0].SSRC)
 	if err != nil {
 		return err
 	}
@@ -89,7 +95,7 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 		return err
 	}
 
-	r.rtcpReadStream, err = srtcpSession.OpenReadStream(parameters.Encodings.SSRC)
+	r.rtcpReadStream, err = srtcpSession.OpenReadStream(parameters.Encodings[0].SSRC)
 	if err != nil {
 		return err
 	}

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -9,10 +9,11 @@ import (
 
 // RTPTransceiver represents a combination of an RTPSender and an RTPReceiver that share a common mid.
 type RTPTransceiver struct {
-	mid       atomic.Value // string
-	sender    atomic.Value // *RTPSender
-	receiver  atomic.Value // *RTPReceiver
-	direction atomic.Value // RTPTransceiverDirection
+	mid             atomic.Value // string
+	sender          atomic.Value // *RTPSender
+	receiver        atomic.Value // *RTPReceiver
+	direction       atomic.Value // RTPTransceiverDirection
+	remoteDirection atomic.Value // RTPTransceiverDirection
 
 	stopped bool
 	kind    RTPCodecType
@@ -67,6 +68,13 @@ func (t *RTPTransceiver) Direction() RTPTransceiverDirection {
 	return t.direction.Load().(RTPTransceiverDirection)
 }
 
+func (t *RTPTransceiver) getRemoteDirection() RTPTransceiverDirection {
+	if v := t.remoteDirection.Load(); v != nil {
+		return v.(RTPTransceiverDirection)
+	}
+	return RTPTransceiverDirection(Unknown)
+}
+
 // Stop irreversibly stops the RTPTransceiver
 func (t *RTPTransceiver) Stop() error {
 	if t.Sender() != nil {
@@ -90,6 +98,10 @@ func (t *RTPTransceiver) setReceiver(r *RTPReceiver) {
 
 func (t *RTPTransceiver) setDirection(d RTPTransceiverDirection) {
 	t.direction.Store(d)
+}
+
+func (t *RTPTransceiver) setRemoteDirection(d RTPTransceiverDirection) {
+	t.remoteDirection.Store(d)
 }
 
 func (t *RTPTransceiver) setSendingTrack(track *Track) error {

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -132,7 +132,7 @@ func satisfyTypeAndDirection(remoteKind RTPCodecType, remoteDirection RTPTransce
 		case RTPTransceiverDirectionSendrecv:
 			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly, RTPTransceiverDirectionSendrecv}
 		case RTPTransceiverDirectionSendonly:
-			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly, RTPTransceiverDirectionSendrecv}
+			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly}
 		case RTPTransceiverDirectionRecvonly:
 			return []RTPTransceiverDirection{RTPTransceiverDirectionSendonly, RTPTransceiverDirectionSendrecv}
 		}

--- a/sdp.go
+++ b/sdp.go
@@ -12,6 +12,19 @@ import (
 	"github.com/pion/sdp/v2"
 )
 
+const (
+	extMapValueABSSendTime     = 1
+	extMapValueTransportCC     = 2
+	extMapValueSDESMid         = 3
+	extMapValueSDESRTPStreamID = 4
+
+	// TODO(sgotti) add these to pion/sdp
+	ABSSendTimeURI     = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+	TransportCCURI     = "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
+	SDESMidURI         = "urn:ietf:params:rtp-hdrext:sdes:mid"
+	SDESRTPStreamIDURI = "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+)
+
 type streamDetails struct {
 	rid  string
 	ssrc uint32

--- a/sdp.go
+++ b/sdp.go
@@ -12,23 +12,39 @@ import (
 	"github.com/pion/sdp/v2"
 )
 
+type streamDetails struct {
+	rid  string
+	ssrc uint32
+
+	trackID string
+	msid    string
+	mstid   string
+}
+
 type trackDetails struct {
-	mid   string
-	kind  RTPCodecType
-	label string
-	id    string
-	ssrc  uint32
+	id      string
+	kind    RTPCodecType
+	msid    string
+	mstid   string
+	useRid  bool
+	extMaps map[int]*sdp.ExtMap
+
+	ridStreams  map[string]*streamDetails
+	ssrcStreams map[uint32]*streamDetails
 }
 
 // extract all trackDetails from an SDP.
-func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) map[uint32]trackDetails {
-	incomingTracks := map[uint32]trackDetails{}
+func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription, isPlanB bool) map[string]trackDetails {
+	incomingTracks := map[string]trackDetails{}
 	rtxRepairFlows := map[uint32]bool{}
 
 	for _, media := range s.MediaDescriptions {
-		// Plan B can have multiple tracks in a signle media section
-		trackLabel := ""
-		trackID := ""
+		// Plan B can have multiple tracks in a single media section
+		msid := ""
+		mstid := ""
+		extMaps := map[int]*sdp.ExtMap{}
+		ridStreams := map[string]*streamDetails{}
+		ssrcStreams := map[uint32]*streamDetails{}
 
 		// If media section is recvonly or inactive skip
 		if _, ok := media.Attribute(sdp.AttrKeyRecvOnly); ok {
@@ -37,17 +53,23 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) m
 			continue
 		}
 
-		midValue := getMidValue(media)
-		if midValue == "" {
+		var useRid bool
+		var midValue string
+		if !isPlanB {
+			midValue = getMidValue(media)
+			if midValue == "" {
+				continue
+			}
+
+			_, useRid = media.Attribute("rid")
+		}
+
+		codecType := NewRTPCodecType(media.MediaName.Media)
+		if codecType == 0 {
 			continue
 		}
 
 		for _, attr := range media.Attributes {
-			codecType := NewRTPCodecType(media.MediaName.Media)
-			if codecType == 0 {
-				continue
-			}
-
 			switch attr.Key {
 			case sdp.AttrKeySSRCGroup:
 				split := strings.Split(attr.Value, " ")
@@ -68,7 +90,7 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) m
 							continue
 						}
 						rtxRepairFlows[uint32(rtxRepairFlow)] = true
-						delete(incomingTracks, uint32(rtxRepairFlow)) // Remove if rtx was added as track before
+						//delete(incomingTracks, uint32(rtxRepairFlow)) // Remove if rtx was added as track before
 					}
 				}
 
@@ -78,32 +100,90 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) m
 			case sdp.AttrKeyMsid:
 				split := strings.Split(attr.Value, " ")
 				if len(split) == 2 {
-					trackLabel = split[0]
-					trackID = split[1]
+					msid = split[0]
+					mstid = split[1]
 				}
 
+			// TODO(sgotti) define this in pion/sdp
+			case "rid":
+				split := strings.Split(attr.Value, " ")
+				rid := split[0]
+
+				ridStreams[rid] = &streamDetails{rid: rid}
+
 			case sdp.AttrKeySSRC:
+				if useRid {
+					log.Warnf("ignoring provided SSRC since we're using rid attributes")
+					continue
+				}
 				split := strings.Split(attr.Value, " ")
 				ssrc, err := strconv.ParseUint(split[0], 10, 32)
 				if err != nil {
 					log.Warnf("Failed to parse SSRC: %v", err)
 					continue
 				}
-				if rtxRepairFlow := rtxRepairFlows[uint32(ssrc)]; rtxRepairFlow {
-					continue // This ssrc is a RTX repair flow, ignore
-				}
-				if existingValues, ok := incomingTracks[uint32(ssrc)]; ok && existingValues.label != "" && existingValues.id != "" {
-					continue // This ssrc is already fully defined
-				}
-
+				var ssrcMsid string
+				var ssrcMstid string
 				if len(split) == 3 && strings.HasPrefix(split[1], "msid:") {
-					trackLabel = split[1][len("msid:"):]
-					trackID = split[2]
+					ssrcMsid = split[1][len("msid:"):]
+					ssrcMstid = split[2]
 				}
 
-				// Plan B might send multiple a=ssrc lines under a single m= section. This is also why a single trackDetails{}
-				// is not defined at the top of the loop over s.MediaDescriptions.
-				incomingTracks[uint32(ssrc)] = trackDetails{midValue, codecType, trackLabel, trackID, uint32(ssrc)}
+				if isPlanB {
+					if ssrcMsid != "" {
+						ssrcStreams[uint32(ssrc)] = &streamDetails{ssrc: uint32(ssrc), trackID: ssrcMstid, msid: ssrcMsid, mstid: ssrcMstid}
+					}
+				} else {
+					ssrcStreams[uint32(ssrc)] = &streamDetails{ssrc: uint32(ssrc), trackID: midValue}
+				}
+
+			// TODO(sgotti) define this in pion/sdp
+			case "extmap":
+				em := &sdp.ExtMap{}
+				if err := em.Unmarshal("extmap:" + attr.Value); err != nil {
+					log.Warnf("Failed to parse ExtMap: %v", err)
+					continue
+				}
+				extMaps[em.Value] = em
+			}
+		}
+
+		for ssrc := range ssrcStreams {
+			if rtxRepairFlow := rtxRepairFlows[ssrc]; rtxRepairFlow {
+				// This ssrc is a RTX repair flow, ignore
+				delete(ssrcStreams, ssrc)
+			}
+		}
+
+		if isPlanB {
+			// collect ssrcStreams with same trackID
+			for _, ssrcStream := range ssrcStreams {
+				ic, ok := incomingTracks[ssrcStream.trackID]
+				if !ok {
+					// create a new track
+					incomingTracks[ssrcStream.trackID] = trackDetails{
+						id:          ssrcStream.trackID,
+						kind:        codecType,
+						msid:        ssrcStream.msid,
+						mstid:       ssrcStream.mstid,
+						ssrcStreams: ssrcStreams,
+					}
+					continue
+				}
+
+				// add ssrcStream to existing track
+				ic.ssrcStreams[ssrcStream.ssrc] = ssrcStream
+			}
+		} else {
+			incomingTracks[midValue] = trackDetails{
+				id:          midValue,
+				kind:        codecType,
+				msid:        msid,
+				mstid:       mstid,
+				extMaps:     extMaps,
+				useRid:      useRid,
+				ridStreams:  ridStreams,
+				ssrcStreams: ssrcStreams,
 			}
 		}
 	}

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,185 @@
+// +build !js
+
+package webrtc
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/pion/rtp"
+	"github.com/pion/webrtc/v2/pkg/media"
+)
+
+const (
+	rtpOutboundMTU = 1200
+)
+
+// TrackRTPStream represents a single rtp stream
+type TrackRTPStream struct {
+	mu sync.RWMutex
+
+	// stream id, if rid based it's the rid, it ssrc based it's the ssrc as string
+	id string
+
+	ready bool
+
+	payloadType uint8
+	rid         string
+	ssrc        uint32
+	codec       *RTPCodec
+
+	packetizer rtp.Packetizer
+
+	track *Track
+}
+
+// Ready reports if the stream is ready. If it's a read stream it'll
+// be ready when it's SSRC, RID if rid based, payload are know. If
+// it's a write stream it'll always be ready
+func (s *TrackRTPStream) Ready() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.ready
+}
+
+// RID gets the RID of the stream. If this isn't a rid based stream
+// it'll return an empty value
+func (s *TrackRTPStream) RID() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.rid
+}
+
+// PayloadType gets the PayloadType of the stream. If this is a rid
+// based stream the payload may be not yet known until a packet is
+// received
+func (s *TrackRTPStream) PayloadType() uint8 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.payloadType
+}
+
+// SSRC gets the current SSRC of the stream. If a stream is RID based,
+// this is the currently known ssrc (may be 0 until a packet is
+// received) for the stream rid and may change
+func (s *TrackRTPStream) SSRC() uint32 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.ssrc
+}
+
+// Codec gets the Codec of the stream. If this is a rid based stream
+// the codec may be nil until a packet is received
+func (s *TrackRTPStream) Codec() *RTPCodec {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.codec
+}
+
+// Packetizer gets the Packetizer of the stream
+func (s *TrackRTPStream) Packetizer() rtp.Packetizer {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.packetizer
+}
+
+// Read reads data from the stream. If this is a local stream this will error
+func (s *TrackRTPStream) Read(b []byte) (n int, err error) {
+	return s.track.read(b, s.rid)
+}
+
+// ReadRTP is a convenience method that wraps Read and unmarshals for you
+func (s *TrackRTPStream) ReadRTP() (*rtp.Packet, error) {
+	b := make([]byte, receiveMTU)
+	i, err := s.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &rtp.Packet{}
+	if err := r.Unmarshal(b[:i]); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// Write writes data to the stream. If this is a remote stream this will error
+func (s *TrackRTPStream) Write(b []byte) (n int, err error) {
+	packet := &rtp.Packet{}
+	err = packet.Unmarshal(b)
+	if err != nil {
+		return 0, err
+	}
+
+	err = s.WriteRTP(packet)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(b), nil
+}
+
+// WriteSample packetizes and writes to the stream
+func (s *TrackRTPStream) WriteSample(sample media.Sample) error {
+	packets := s.packetizer.Packetize(sample.Data, sample.Samples)
+	for _, p := range packets {
+		err := s.WriteRTP(p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WriteRTP writes RTP packets to the stream
+func (s *TrackRTPStream) WriteRTP(p *rtp.Packet) error {
+	return s.track.WriteRTP(p)
+}
+
+// NewTrackRTPStream initializes a new RTPStream
+func NewTrackRTPStream(rid string, payloadType uint8, ssrc uint32, codec *RTPCodec) (*TrackRTPStream, error) {
+	if ssrc == 0 {
+		return nil, fmt.Errorf("SSRC supplied to NewStream() must be non-zero")
+	}
+
+	streamID := strconv.FormatUint(uint64(ssrc), 10)
+	// if rid is not empty use it as stream id
+	if rid != "" {
+		streamID = rid
+	}
+
+	packetizer := rtp.NewPacketizer(
+		rtpOutboundMTU,
+		payloadType,
+		ssrc,
+		codec.Payloader,
+		rtp.NewRandomSequencer(),
+		codec.ClockRate,
+	)
+
+	return &TrackRTPStream{
+		id:          streamID,
+		rid:         rid,
+		payloadType: payloadType,
+		ssrc:        ssrc,
+		codec:       codec,
+		packetizer:  packetizer,
+	}, nil
+}
+
+// determinePayloadType blocks and reads a single packet to determine the PayloadType for this Stream
+// This is useful if we are dealing with a remote stream and we can't announce it to the user until we know the payloadType
+func (s *TrackRTPStream) determinePayloadType() error {
+	r, err := s.ReadRTP()
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.payloadType = r.PayloadType
+	s.mu.Unlock()
+
+	return nil
+}

--- a/track.go
+++ b/track.go
@@ -205,7 +205,7 @@ func (t *Track) read(b []byte, streamID string) (n int, err error) {
 	r := t.receiver
 	t.mu.RUnlock()
 
-	return r.readRTP(b)
+	return r.readRTPStreamID(b, streamID)
 }
 
 // Read reads data from the track. If this is a local track this will


### PR DESCRIPTION
#### Description

---
#### NOTE
This should be considered a patch set. As a starting point I opened it as an unique PR so you can see all the work split in multiple patches (for an easier review) and the final outcome. The last patch is a simulcast example so everyone can test it with both chrome and firefox.

@Sean-Der @jeremija If you prefer that I create multiple PR for every commit let me know, opening them right now will make it difficult to follow the reason of every single PR without the global view.

---

Here's a list of the various patches

The first Patches are initial hacks to improve transceiver selection since simulcast requires sendonly sender and the transceiver must be read only, something that currently is not automatic without these patches.

The 3 patches:
* `Make trackDetails handle multi rtp streams tracks`
* `Make track multistream`
* `Make rtpreceiver multi stream`
Introduce the concept of multi rtp stream tracks. Every patch should have a quite complete explanation.

* `Negotiate extmaps` Adds extmaps negotiation (see commit description) 

* `Implement simulcast (receive)` Implement simulcast on the receiver side. The sending side is not yet implemented since the primary use case is to receive simulcast tracks from a browser (and browsers only implement simulcast sending).

* `Add simulast example` Adds a simulcast example that work with both chrome and firefox.

### TODO

[*] Add many tests. Without the sending part it's difficult to create e2e test pion<->pion. It'll also be good to implement tests using the browser e2e tests.

#### Reference issue
#1016 
