### PR TITLE
media: add NSamples

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Simone Gotti](https://github.com/sgotti)
 * [Cedric Fung](https://github.com/cedricfung)
 * [Norman Rasmussen](https://github.com/normanr) - *Fix Empty DataChannel messages*
+* [Josh Bleecher Snyder](https://github.com/josharian)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -2,13 +2,22 @@
 package media
 
 import (
+	"time"
+
 	"github.com/pion/rtp"
 )
 
-// Sample contains media, and the amount of samples in it
+// A Sample contains encoded media and the number of samples in that media (see NSamples).
 type Sample struct {
 	Data    []byte
 	Samples uint32
+}
+
+// NSamples calculates the number of samples in media of length d with sampling frequency f.
+// For example, NSamples(20 * time.Millisecond, 48000) will return the number of samples
+// in a 20 millisecond segment of Opus audio recorded at 48000 samples per second.
+func NSamples(d time.Duration, freq int) uint32 {
+	return uint32(time.Duration(freq) * d / time.Second)
 }
 
 // Writer defines an interface to handle

--- a/pkg/media/media_test.go
+++ b/pkg/media/media_test.go
@@ -1,0 +1,16 @@
+package media_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v2/pkg/media"
+)
+
+func TestNSamples(t *testing.T) {
+	got := media.NSamples(20*time.Millisecond, 48000)
+	want := uint32(48000 * 0.02)
+	if got != want {
+		t.Errorf("media.NSamples(20*time.Millisecond, 48000)=%v want %v", got, want)
+	}
+}


### PR DESCRIPTION
media.Sample is hard to use. A more natural formulation would
be in terms of a time.Duration. See discussion at
https://gophers.slack.com/archives/CAK2124AG/p1589839755436500.

That change could occur in v3. In the meantime, add a helper
function to calculate the number of samples given a time.Duration
and a sampling frequency, and refer to it from the Sample docs.
