### PR TITLE
WASM: Fallback to parsing SDP line for OnICECandidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Cedric Fung](https://github.com/cedricfung)
 * [Norman Rasmussen](https://github.com/normanr) - *Fix Empty DataChannel messages*
 * [Josh Bleecher Snyder](https://github.com/josharian)
+* [salmān aljammāz](https://github.com/saljam)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/ice_go.go
+++ b/ice_go.go
@@ -2,33 +2,9 @@
 
 package webrtc
 
-import "github.com/pion/sdp/v2"
-
 // NewICETransport creates a new NewICETransport.
 // This constructor is part of the ORTC API. It is not
 // meant to be used together with the basic WebRTC API.
 func (api *API) NewICETransport(gatherer *ICEGatherer) *ICETransport {
 	return NewICETransport(gatherer, api.settingEngine.LoggerFactory)
-}
-
-func newICECandidateFromSDP(c sdp.ICECandidate) (ICECandidate, error) {
-	typ, err := NewICECandidateType(c.Typ)
-	if err != nil {
-		return ICECandidate{}, err
-	}
-	protocol, err := NewICEProtocol(c.Protocol)
-	if err != nil {
-		return ICECandidate{}, err
-	}
-	return ICECandidate{
-		Foundation:     c.Foundation,
-		Priority:       c.Priority,
-		Address:        c.Address,
-		Protocol:       protocol,
-		Port:           c.Port,
-		Component:      c.Component,
-		Typ:            typ,
-		RelatedAddress: c.RelatedAddress,
-		RelatedPort:    c.RelatedPort,
-	}, nil
 }

--- a/icecandidate.go
+++ b/icecandidate.go
@@ -153,6 +153,28 @@ func iceCandidateToSDP(c ICECandidate) sdp.ICECandidate {
 	}
 }
 
+func newICECandidateFromSDP(c sdp.ICECandidate) (ICECandidate, error) {
+	typ, err := NewICECandidateType(c.Typ)
+	if err != nil {
+		return ICECandidate{}, err
+	}
+	protocol, err := NewICEProtocol(c.Protocol)
+	if err != nil {
+		return ICECandidate{}, err
+	}
+	return ICECandidate{
+		Foundation:     c.Foundation,
+		Priority:       c.Priority,
+		Address:        c.Address,
+		Protocol:       protocol,
+		Port:           c.Port,
+		Component:      c.Component,
+		Typ:            typ,
+		RelatedAddress: c.RelatedAddress,
+		RelatedPort:    c.RelatedPort,
+	}, nil
+}
+
 // ToJSON returns an ICECandidateInit
 // as indicated by the spec https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson
 func (c ICECandidate) ToJSON() ICECandidateInit {

--- a/peerconnection_js_test.go
+++ b/peerconnection_js_test.go
@@ -1,0 +1,69 @@
+package webrtc
+
+import (
+	"encoding/json"
+	"syscall/js"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValueToICECandidate(t *testing.T) {
+	testCases := []struct {
+		jsonCandidate string
+		expect        ICECandidate
+	}{
+		{
+			// Firefox-style ICECandidateInit:
+			`{"candidate":"1966762133 1 udp 2122260222 192.168.20.128 47298 typ srflx raddr 203.0.113.1 rport 5000"}`,
+			ICECandidate{
+				Foundation:     "1966762133",
+				Priority:       2122260222,
+				Address:        "192.168.20.128",
+				Protocol:       ICEProtocolUDP,
+				Port:           47298,
+				Typ:            ICECandidateTypeSrflx,
+				Component:      1,
+				RelatedAddress: "203.0.113.1",
+				RelatedPort:    5000,
+			},
+		}, {
+			// Chrome/Webkit-style ICECandidate:
+			`{"foundation":"1966762134", "component":"rtp", "protocol":"udp", "priority":2122260223, "address":"192.168.20.129", "port":47299, "type":"host", "relatedAddress":null}`,
+			ICECandidate{
+				Foundation:     "1966762134",
+				Priority:       2122260223,
+				Address:        "192.168.20.129",
+				Protocol:       ICEProtocolUDP,
+				Port:           47299,
+				Typ:            ICECandidateTypeHost,
+				Component:      1,
+				RelatedAddress: "<null>",
+				RelatedPort:    0,
+			},
+		}, {
+			// Both are present, Chrome/Webkit-style takes precedent:
+			`{"candidate":"1966762133 1 udp 2122260222 192.168.20.128 47298 typ srflx raddr 203.0.113.1 rport 5000", "foundation":"1966762134", "component":"rtp", "protocol":"udp", "priority":2122260223, "address":"192.168.20.129", "port":47299, "type":"host", "relatedAddress":null}`,
+			ICECandidate{
+				Foundation:     "1966762134",
+				Priority:       2122260223,
+				Address:        "192.168.20.129",
+				Protocol:       ICEProtocolUDP,
+				Port:           47299,
+				Typ:            ICECandidateTypeHost,
+				Component:      1,
+				RelatedAddress: "<null>",
+				RelatedPort:    0,
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		v := map[string]interface{}{}
+		err := json.Unmarshal([]byte(testCase.jsonCandidate), &v)
+		if err != nil {
+			t.Errorf("Case %d: bad test, got error: %v", i, err)
+		}
+		assert.Equal(t, testCase.expect, *valueToICECandidate(js.ValueOf(v)))
+	}
+}


### PR DESCRIPTION
On Firefox, the RTCIceCandidate interface appears to just be an RTCIceCandidateInit in disguise. That is, it does not have properties for each individual component of the candidate line. It only has the raw SDP string in the candidate property.

This change falls back to parsing the candidate line if some expected property is missing when preparing the candidate for the callback OnICECandidate.

https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate

https://caniuse.com/#feat=mdn-api_rtcicecandidate_priority

Let me know what you think!