### PR TITLE
WASM: allow PeerConnection to be initialised from a JS object

### DIFF
--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -51,6 +51,10 @@ func (api *API) NewPeerConnection(configuration Configuration) (_ *PeerConnectio
 	}, nil
 }
 
+func (pc *PeerConnection) JSValue() js.Value {
+	return pc.underlying
+}
+
 // OnSignalingStateChange sets an event handler which is invoked when the
 // peer connection's signaling state changes
 func (pc *PeerConnection) OnSignalingStateChange(f func(SignalingState)) {


### PR DESCRIPTION
This allows us to make a new PeerConnection from an RTCPeerConnection js.Value.

#### Description

My use case for this is a Go package that handles the signalling parts, but leaves the rest to the application. A JS application can pass its own PeerConnection initialised with whatever datachannels/streams then wait for ICE/signalling to finish.