### PR TITLE
fix bug: rtpsender.Read may block infinite when rtpsender stopped bef…

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Norman Rasmussen](https://github.com/normanr) - *Fix Empty DataChannel messages*
 * [Josh Bleecher Snyder](https://github.com/josharian)
 * [salmān aljammāz](https://github.com/saljam)
+* [cnderrauber](https://github.com/cnderrauber)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -811,6 +811,31 @@ func TestAddTransceiverAddTrack_NewRTPSender_Error(t *testing.T) {
 	assert.NoError(t, pc.Close())
 }
 
+func TestRtpSenderReceiver_ReadClose_Error(t *testing.T) {
+	mediaEngine := MediaEngine{}
+	mediaEngine.RegisterDefaultCodecs()
+	api := NewAPI(WithMediaEngine(mediaEngine))
+	pc, err := api.NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	tr, err := pc.AddTransceiverFromKind(
+		RTPCodecTypeVideo,
+		RtpTransceiverInit{Direction: RTPTransceiverDirectionSendrecv},
+	)
+	assert.NoError(t, err)
+
+	sender, receiver := tr.Sender(), tr.Receiver()
+	assert.NoError(t, sender.Stop())
+	_, err = sender.Read(make([]byte, 0, 1400))
+	assert.Error(t, err, "RtpSender has been stopped")
+
+	assert.NoError(t, receiver.Stop())
+	_, err = receiver.Read(make([]byte, 0, 1400))
+	assert.Error(t, err, "RTPReceiver has been stopped")
+
+	assert.NoError(t, pc.Close())
+}
+
 // nolint: dupl
 func TestAddTransceiverFromKind(t *testing.T) {
 	lim := test.TimeOut(time.Second * 30)

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -99,8 +99,12 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 
 // Read reads incoming RTCP for this RTPReceiver
 func (r *RTPReceiver) Read(b []byte) (n int, err error) {
-	<-r.received
-	return r.rtcpReadStream.Read(b)
+	select {
+	case <-r.received:
+		return r.rtcpReadStream.Read(b)
+	case <-r.closed:
+		return 0, fmt.Errorf("RtpReceiver has been stopped")
+	}
 }
 
 // ReadRTCP is a convenience method that wraps Read and unmarshals for you

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -141,8 +141,12 @@ func (r *RTPSender) Stop() error {
 
 // Read reads incoming RTCP for this RTPReceiver
 func (r *RTPSender) Read(b []byte) (n int, err error) {
-	<-r.sendCalled
-	return r.rtcpReadStream.Read(b)
+	select {
+	case <-r.sendCalled:
+		return r.rtcpReadStream.Read(b)
+	case <-r.stopCalled:
+		return 0, fmt.Errorf("RTPSender has been stopped")
+	}
 }
 
 // ReadRTCP is a convenience method that wraps Read and unmarshals for you


### PR DESCRIPTION
rtpsender.Read return err when rtpsender stopped

#### Description
rtpsender.Read may block infinite when rtpsender stopped before Send been called
#### Reference issue
Fixes #...
