### PR TITLE
use exported errors for reads/writes to stopped rtp i/o

### DIFF
--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -827,11 +827,11 @@ func TestRtpSenderReceiver_ReadClose_Error(t *testing.T) {
 	sender, receiver := tr.Sender(), tr.Receiver()
 	assert.NoError(t, sender.Stop())
 	_, err = sender.Read(make([]byte, 0, 1400))
-	assert.Error(t, err, "RtpSender has been stopped")
+	assert.Error(t, err, io.ErrClosedPipe)
 
 	assert.NoError(t, receiver.Stop())
 	_, err = receiver.Read(make([]byte, 0, 1400))
-	assert.Error(t, err, "RTPReceiver has been stopped")
+	assert.Error(t, err, io.ErrClosedPipe)
 
 	assert.NoError(t, pc.Close())
 }

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -4,6 +4,7 @@ package webrtc
 
 import (
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/pion/rtcp"
@@ -103,7 +104,7 @@ func (r *RTPReceiver) Read(b []byte) (n int, err error) {
 	case <-r.received:
 		return r.rtcpReadStream.Read(b)
 	case <-r.closed:
-		return 0, fmt.Errorf("RtpReceiver has been stopped")
+		return 0, io.ErrClosedPipe
 	}
 }
 

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -4,6 +4,7 @@ package webrtc
 
 import (
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/pion/rtcp"
@@ -145,7 +146,7 @@ func (r *RTPSender) Read(b []byte) (n int, err error) {
 	case <-r.sendCalled:
 		return r.rtcpReadStream.Read(b)
 	case <-r.stopCalled:
-		return 0, fmt.Errorf("RTPSender has been stopped")
+		return 0, io.ErrClosedPipe
 	}
 }
 


### PR DESCRIPTION
This makes checking for these errors much more robust
than doing a string comparison.

This is a follow-up to #1222 (which I was delighted to see). There are other possible errors we could use (io.ErrUnexpectedEOF, io.EOF, a new exported webrtc error var), but this one seemed appropriate.

Hopefully we could merge this or something like it before tagging a new release, to avoid backwards compatibillty problems.