### PR TITLE
Simplify operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Josh Bleecher Snyder](https://github.com/josharian)
 * [salmān aljammāz](https://github.com/saljam)
 * [cnderrauber](https://github.com/cnderrauber)
+* [Juliusz Chroboczek](https://github.com/jech)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/operations.go
+++ b/operations.go
@@ -37,6 +37,7 @@ func (o *operations) Enqueue(op operation) {
 }
 
 // Done blocks until all currently enqueued operations are finished executing.
+// For more complex synchronization, use Enqueue directly.
 func (o *operations) Done() {
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/operations_test.go
+++ b/operations_test.go
@@ -18,7 +18,7 @@ func TestOperations_Enqueue(t *testing.T) {
 			}(i)
 		}
 
-		<-ops.Done()
+		ops.Done()
 		expected := []int{0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225}
 		assert.Equal(t, len(expected), len(results))
 		assert.Equal(t, expected, results)
@@ -27,5 +27,5 @@ func TestOperations_Enqueue(t *testing.T) {
 
 func TestOperations_Done(t *testing.T) {
 	ops := newOperations()
-	<-ops.Done()
+	ops.Done()
 }

--- a/operations_test.go
+++ b/operations_test.go
@@ -1,7 +1,9 @@
 package webrtc
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -28,4 +30,22 @@ func TestOperations_Enqueue(t *testing.T) {
 func TestOperations_Done(t *testing.T) {
 	ops := newOperations()
 	ops.Done()
+}
+
+func Exampleoperations_Done_timeout() {
+	ops := newOperations()
+	ch := make(chan struct{})
+	ops.Enqueue(func() {
+		close(ch)
+	})
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ch:
+		timer.Stop()
+		fmt.Println("Done!")
+	case <-timer.C:
+		fmt.Println("Timed out!")
+	}
+	//Output:
+	//Done!
 }

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -1140,7 +1140,7 @@ func TestPeerConnection_Start_Only_Negotiated_Senders(t *testing.T) {
 	assert.NoError(t, pcOffer.SetRemoteDescription(answer))
 
 	// Wait for senders to be started by startTransports spawned goroutine
-	<-pcOffer.ops.Done()
+	pcOffer.ops.Done()
 
 	// sender1 should be started but sender2 should not be started
 	assert.True(t, sender1.hasSent(), "sender1 is not started but should be started")
@@ -1183,8 +1183,8 @@ func TestPeerConnection_Start_Right_Receiver(t *testing.T) {
 
 	assert.NoError(t, signalPair(pcOffer, pcAnswer))
 
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 
 	// transceiver with mid 0 should be started
 	started, err := isTransceiverReceiverStarted(pcAnswer, "0")
@@ -1196,8 +1196,8 @@ func TestPeerConnection_Start_Right_Receiver(t *testing.T) {
 
 	assert.NoError(t, signalPair(pcOffer, pcAnswer))
 
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 
 	// transceiver with mid 0 should not be started
 	started, err = isTransceiverReceiverStarted(pcAnswer, "0")
@@ -1213,8 +1213,8 @@ func TestPeerConnection_Start_Right_Receiver(t *testing.T) {
 
 	assert.NoError(t, signalPair(pcOffer, pcAnswer))
 
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 
 	// transceiver with mid 0 should not be started
 	started, err = isTransceiverReceiverStarted(pcAnswer, "0")

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -118,12 +118,12 @@ func TestPeerConnection_Renegotiation_AddTrack(t *testing.T) {
 
 	assert.NoError(t, pcAnswer.SetLocalDescription(answer))
 
-	<-pcOffer.ops.Done()
+	pcOffer.ops.Done()
 	assert.Equal(t, 0, len(vp8Track.activeSenders))
 
 	assert.NoError(t, pcOffer.SetRemoteDescription(answer))
 
-	<-pcOffer.ops.Done()
+	pcOffer.ops.Done()
 	assert.Equal(t, 1, len(vp8Track.activeSenders))
 
 	sendVideoUntilDone(onTrackFired.Done(), t, []*Track{vp8Track})
@@ -286,8 +286,8 @@ func TestPeerConnection_Transceiver_Mid(t *testing.T) {
 	// apply answer so we'll test generateMatchedSDP
 	assert.NoError(t, pcOffer.SetRemoteDescription(answer))
 
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 
 	// Must have 3 media descriptions (2 video and 1 datachannel)
 	assert.Equal(t, len(offer.parsed.MediaDescriptions), 3)
@@ -312,8 +312,8 @@ func TestPeerConnection_Transceiver_Mid(t *testing.T) {
 	// apply answer so we'll test generateMatchedSDP
 	assert.NoError(t, pcOffer.SetRemoteDescription(answer))
 
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 
 	track3, err := pcOffer.NewTrack(DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion3")
 	require.NoError(t, err)
@@ -579,8 +579,8 @@ func TestPeerConnection_Renegotiation_Trickle(t *testing.T) {
 	negotiate()
 	negotiate()
 
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 	wg.Wait()
 
 	assert.NoError(t, pcOffer.Close())
@@ -608,8 +608,8 @@ func TestPeerConnection_Renegotiation_SetLocalDescription(t *testing.T) {
 
 	assert.NoError(t, signalPair(pcOffer, pcAnswer))
 
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 
 	_, err = pcOffer.AddTransceiverFromKind(RTPCodecTypeVideo, RtpTransceiverInit{Direction: RTPTransceiverDirectionRecvonly})
 	assert.NoError(t, err)
@@ -629,12 +629,12 @@ func TestPeerConnection_Renegotiation_SetLocalDescription(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, sender.isNegotiated())
 
-	<-pcAnswer.ops.Done()
+	pcAnswer.ops.Done()
 	assert.Equal(t, 0, len(localTrack.activeSenders))
 
 	assert.NoError(t, pcAnswer.SetLocalDescription(answer))
 
-	<-pcAnswer.ops.Done()
+	pcAnswer.ops.Done()
 	assert.Equal(t, 1, len(localTrack.activeSenders))
 
 	assert.NoError(t, pcOffer.SetRemoteDescription(answer))
@@ -685,12 +685,12 @@ func TestPeerConnection_Renegotiation_NoApplication(t *testing.T) {
 	pcAnswer.sctpTransport = nil
 
 	signalPairExcludeDataChannel(pcOffer, pcAnswer)
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 
 	signalPairExcludeDataChannel(pcOffer, pcAnswer)
-	<-pcOffer.ops.Done()
-	<-pcAnswer.ops.Done()
+	pcOffer.ops.Done()
+	pcAnswer.ops.Done()
 
 	assert.NoError(t, pcOffer.Close())
 	assert.NoError(t, pcAnswer.Close())


### PR DESCRIPTION
This simplifies the operations queue.  While the new code should be slightly faster and more robust, the main benefit is to reduce the amount of noise in the blocking profile.

