### PR TITLE
Add H264 writer

### DIFF
--- a/pkg/media/h264writer/h264writer.go
+++ b/pkg/media/h264writer/h264writer.go
@@ -1,0 +1,90 @@
+// Package h264writer implements H264 media container writer
+package h264writer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+)
+
+type (
+	// H264Writer is used to take RTP packets, parse them and
+	// write the data to an io.Writer.
+	// Currently it only supports non-interleaved mode
+	// Therefore, only 1-23, 24 (STAP-A), 28 (FU-A) NAL types are allowed.
+	// https://tools.ietf.org/html/rfc6184#section-5.2
+	H264Writer struct {
+		writer      io.Writer
+		hasKeyFrame bool
+	}
+)
+
+// New builds a new H264 writer
+func New(filename string) (*H264Writer, error) {
+	f, err := os.Create(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewWith(f), nil
+}
+
+// NewWith initializes a new H264 writer with an io.Writer output
+func NewWith(w io.Writer) *H264Writer {
+	return &H264Writer{
+		writer: w,
+	}
+}
+
+// WriteRTP adds a new packet and writes the appropriate headers for it
+func (h *H264Writer) WriteRTP(packet *rtp.Packet) error {
+	if len(packet.Payload) == 0 {
+		return nil
+	}
+
+	if !h.hasKeyFrame {
+		if h.hasKeyFrame = isKeyFrame(packet.Payload); !h.hasKeyFrame {
+			// key frame not defined yet. discarding packet
+			return nil
+		}
+	}
+
+	data, err := (&codecs.H264Packet{}).Unmarshal(packet.Payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = h.writer.Write(data)
+
+	return err
+}
+
+// Close closes the underlying writer
+func (h *H264Writer) Close() error {
+	if h.writer != nil {
+		if closer, ok := h.writer.(io.Closer); ok {
+			return closer.Close()
+		}
+	}
+
+	return nil
+}
+
+func isKeyFrame(data []byte) bool {
+	const typeSTAPA = 24
+
+	var word uint32
+
+	payload := bytes.NewReader(data)
+	err := binary.Read(payload, binary.BigEndian, &word)
+
+	if err != nil || (word&0x1F000000)>>24 != typeSTAPA {
+		return false
+	}
+
+	return word&0x1F == 7
+}

--- a/pkg/media/h264writer/h264writer_test.go
+++ b/pkg/media/h264writer/h264writer_test.go
@@ -1,0 +1,124 @@
+package h264writer
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+)
+
+type writerCloser struct {
+	bytes.Buffer
+}
+
+func (w *writerCloser) Close() error {
+	return errors.New("close error")
+}
+
+func TestNewWith(t *testing.T) {
+	writer := &writerCloser{}
+	h264Writer := NewWith(writer)
+	assert.NotNil(t, h264Writer.Close())
+}
+
+func TestIsKeyFrame(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    bool
+	}{
+		{
+			"When given a non-keyframe; it should return false",
+			[]byte{0x27, 0x90, 0x90},
+			false,
+		},
+		{
+			"When given a keyframe; it should return true",
+			[]byte{0x38, 0x00, 0x03, 0x27, 0x90, 0x90, 0x00, 0x05, 0x28, 0x90, 0x90, 0x90, 0x90},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := isKeyFrame(tt.payload)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWriteRTP(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     []byte
+		hasKeyFrame bool
+		wantBytes   []byte
+		wantErr     error
+	}{
+		{
+			"When given an empty payload; it should return nil",
+			[]byte{},
+			false,
+			[]byte{},
+			nil,
+		},
+		{
+			"When no keyframe is defined; it should discard the packet",
+			[]byte{0x25, 0x90, 0x90},
+			false,
+			[]byte{},
+			nil,
+		},
+		{
+			"When a valid Single NAL Unit packet is given; it should unpack it without error",
+			[]byte{0x27, 0x90, 0x90},
+			true,
+			[]byte{0x00, 0x00, 0x00, 0x01, 0x27, 0x90, 0x90},
+			nil,
+		},
+		{
+			"When a valid STAP-A packet is given; it should unpack it without error",
+			[]byte{0x38, 0x00, 0x03, 0x27, 0x90, 0x90, 0x00, 0x05, 0x28, 0x90, 0x90, 0x90, 0x90},
+			true,
+			[]byte{0x00, 0x00, 0x00, 0x01, 0x27, 0x90, 0x90, 0x00, 0x00, 0x00, 0x01, 0x28, 0x90, 0x90, 0x90, 0x90},
+			nil,
+		},
+		{
+			"When a valid FU-A start packet is given; it should unpack it without error",
+			[]byte{0x3C, 0x85, 0x90, 0x90, 0x90},
+			true,
+			[]byte{0x00, 0x00, 0x00, 0x01, 0x25, 0x90, 0x90, 0x90},
+			nil,
+		},
+		{
+			"When a valid FU-A end packet is given; it should unpack it without error",
+			[]byte{0x3C, 0x45, 0x90, 0x90, 0x90},
+			true,
+			[]byte{0x90, 0x90, 0x90},
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			writer := &bytes.Buffer{}
+			h264Writer := &H264Writer{
+				hasKeyFrame: tt.hasKeyFrame,
+				writer:      writer,
+			}
+			packet := &rtp.Packet{
+				Payload: tt.payload,
+			}
+
+			err := h264Writer.WriteRTP(packet)
+
+			assert.Equal(t, tt.wantErr, err)
+			assert.True(t, bytes.Equal(tt.wantBytes, writer.Bytes()))
+			assert.Nil(t, h264Writer.Close())
+		})
+	}
+}


### PR DESCRIPTION
Currently it only supports non-interleaved mode
Therefore, only 1-23, 24 (STAP-A), 28 (FU-A) NAL types are allowed

#### Reference issue
Related #889 