### PR TITLE
Extmap Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [salmān aljammāz](https://github.com/saljam)
 * [cnderrauber](https://github.com/cnderrauber)
 * [Juliusz Chroboczek](https://github.com/jech)
+* [Jason Brady](https://github.com/jbrady42)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/sdp.go
+++ b/sdp.go
@@ -12,6 +12,28 @@ import (
 	"github.com/pion/sdp/v2"
 )
 
+const (
+	extMapValueABSSendTime     = 1
+	extMapValueTransportCC     = 2
+	extMapValueSDESMid         = 3
+	extMapValueSDESRTPStreamID = 4
+
+	// TODO(sgotti) add these to pion/sdp
+	ABSSendTimeURI     = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+	TransportCCURI     = "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
+	SDESMidURI         = "urn:ietf:params:rtp-hdrext:sdes:mid"
+	SDESRTPStreamIDURI = "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+)
+
+type streamDetails struct {
+	rid  string
+	ssrc uint32
+
+	trackID string
+	msid    string
+	mstid   string
+}
+
 type trackDetails struct {
 	mid   string
 	kind  RTPCodecType

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -157,7 +157,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 			assert.Equal(t, "video_trk_label", track.label)
 		}
 		if _, ok := tracks[4000]; ok {
-			assert.Fail(t, "got the rtx track ssrc:3000 which should have been skipped")
+			assert.Fail(t, "got the rtx track ssrc:4000 which should have been skipped")
 		}
 		if track, ok := tracks[5000]; !ok {
 			assert.Fail(t, "missing video track with ssrc:5000")


### PR DESCRIPTION
#### Description

Continuation from https://github.com/pion/webrtc/pull/1230

Comments from @Sean-Der 
- Should the extmap be empty by default? Since we don't by default support anything we probably shouldn't set it.
- It would be nice if we could put the logic around media type when setting. It seems like I should as a user be able to set an extmap for only audio, video or datachannels (or all).
- `updateExtMaps` should probably be moved into sdp.go. Would love for it to not be aware of the PeerConnection at all and keep the logic smaller. In general I would like to see if we can pull this off without adding anything extra to the PeerConnection
I also need to confirm myself the logic around extmap handling. It sounds like when answering we MUST not include an extension the remote doesn't support? I think we could make the logic simpler, we just need to filter extensions if the remote list is set.

TODO
- [ ] No extensions by default
- [ ] Set extensions conditionally (global, audio, video, application)
- [ ] Move SDP specific logic into `sdp.go` and cover with unit tests.