### PR TITLE
Copy ICEServers when creating new PeerConnection

### DIFF
--- a/configuration_common.go
+++ b/configuration_common.go
@@ -1,22 +1,23 @@
 package webrtc
 
-import (
-	"strings"
-)
+import "strings"
 
 // getICEServers side-steps the strict parsing mode of the ice package
-// (as defined in https://tools.ietf.org/html/rfc7064) by stripping any
-// erroneous queries from "stun(s):" URLs before parsing.
+// (as defined in https://tools.ietf.org/html/rfc7064) by copying and then
+// stripping any erroneous queries from "stun(s):" URLs before parsing.
 func (c Configuration) getICEServers() []ICEServer {
 	iceServers := append([]ICEServer{}, c.ICEServers...)
-	for _, server := range iceServers {
-		for i, rawURL := range server.URLs {
+
+	for iceServersIndex := range iceServers {
+		iceServers[iceServersIndex].URLs = append([]string{}, iceServers[iceServersIndex].URLs...)
+
+		for urlsIndex, rawURL := range iceServers[iceServersIndex].URLs {
 			if strings.HasPrefix(rawURL, "stun") {
 				// strip the query from "stun(s):" if present
 				parts := strings.Split(rawURL, "?")
 				rawURL = parts[0]
 			}
-			server.URLs[i] = rawURL
+			iceServers[iceServersIndex].URLs[urlsIndex] = rawURL
 		}
 	}
 	return iceServers

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pion/ice"
 	"github.com/pion/transport/test"
+	"github.com/pion/webrtc/v2/internal/util"
 	"github.com/pion/webrtc/v2/pkg/rtcerr"
 	"github.com/stretchr/testify/assert"
 )
@@ -121,6 +122,34 @@ func TestNew_Go(t *testing.T) {
 				assert.NoError(t, pc.Close())
 			}
 		}
+	})
+	t.Run("ICEServers_Copy", func(t *testing.T) {
+		const expectedURL = "stun:stun.l.google.com:19302?foo=bar"
+		const expectedUsername = "username"
+		const expectedPassword = "password"
+
+		cfg := Configuration{
+			ICEServers: []ICEServer{
+				{
+					URLs:       []string{expectedURL},
+					Username:   expectedUsername,
+					Credential: expectedPassword,
+				},
+			},
+		}
+		pc, err := api.NewPeerConnection(cfg)
+		assert.NoError(t, err)
+		assert.NotNil(t, pc)
+
+		pc.configuration.ICEServers[0].Username = util.RandSeq(15)
+		pc.configuration.ICEServers[0].Credential = util.RandSeq(15)
+		pc.configuration.ICEServers[0].URLs[0] = util.RandSeq(15)
+
+		assert.Equal(t, expectedUsername, cfg.ICEServers[0].Username)
+		assert.Equal(t, expectedPassword, cfg.ICEServers[0].Credential)
+		assert.Equal(t, expectedURL, cfg.ICEServers[0].URLs[0])
+
+		assert.NoError(t, pc.Close())
 	})
 }
 


### PR DESCRIPTION
Before ICEServers wasn't thread safe. If a Configuration
was shared among multiple PeerConnections the sanitization logic
could cause race conditions.

Resolves #1246
