### PR TITLE
Implement NewRTPVP9CodecExt

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -248,6 +248,19 @@ func NewRTPVP9Codec(payloadType uint8, clockrate uint32) *RTPCodec {
 	return c
 }
 
+// NewRTPVP9CodecExt is a helper to create an VP8 codec
+func NewRTPVP9CodecExt(payloadType uint8, clockrate uint32, rtcpfb []RTCPFeedback, fmtp string) *RTPCodec {
+	c := NewRTPCodecExt(RTPCodecTypeVideo,
+		VP9,
+		clockrate,
+		0,
+		fmtp,
+		payloadType,
+		rtcpfb,
+		&codecs.VP9Payloader{})
+	return c
+}
+
 // NewRTPH264Codec is a helper to create an H264 codec
 func NewRTPH264Codec(payloadType uint8, clockrate uint32) *RTPCodec {
 	c := NewRTPCodec(RTPCodecTypeVideo,


### PR DESCRIPTION
This was omitted for some reason.

Note that the `Ext` variants are missing for all audio codecs.  I'm refraining from adding them right now, since the Unnamed SFU doesn't use any RTCP feedback for audio tracks, and hence I'm not able to test them easily.
