### PR TITLE
Don't allow reading from send track

### DIFF
--- a/track.go
+++ b/track.go
@@ -87,11 +87,12 @@ func (t *Track) Packetizer() rtp.Packetizer {
 // Read reads data from the track. If this is a local track this will error
 func (t *Track) Read(b []byte) (n int, err error) {
 	t.mu.RLock()
-	if len(t.activeSenders) != 0 {
+	r := t.receiver
+
+	if t.totalSenderCount != 0 || r == nil {
 		t.mu.RUnlock()
 		return 0, fmt.Errorf("this is a local track and must not be read from")
 	}
-	r := t.receiver
 	t.mu.RUnlock()
 
 	return r.readRTP(b)

--- a/track_test.go
+++ b/track_test.go
@@ -5,6 +5,8 @@ package webrtc
 import (
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewVideoTrack(t *testing.T) {
@@ -114,4 +116,15 @@ func TestNewTracksWrite(t *testing.T) {
 	if err != nil {
 		t.Error("Failed to write to audio track")
 	}
+}
+
+func TestTrackReadWhenNotAdded(t *testing.T) {
+	peerConnection, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	track, err := peerConnection.NewTrack(DefaultPayloadTypeOpus, rand.Uint32(), "audio", "pion")
+	assert.NoError(t, err)
+
+	_, err = track.Read([]byte{})
+	assert.Error(t, err)
 }


### PR DESCRIPTION
If Read is called before AddTrack a panic would happen.
Check that the Track has a Receiver and return an error if it doesn't

Resolves #1240
