### PR TITLE
Fix synchronized lint script

### DIFF
--- a/.github/.ci.conf
+++ b/.github/.ci.conf
@@ -1,1 +1,2 @@
 GO_JS_WASM_EXEC=${PWD}/test-wasm/go_js_wasm_exec
+EXCLUDED_CONTRIBUTORS=('Josh Bleecher Snyder')

--- a/.github/assert-contributors.sh
+++ b/.github/assert-contributors.sh
@@ -21,7 +21,7 @@ then
   . ${SCRIPT_PATH}/.ci.conf
 fi
 
-EXCLUDED_CONTRIBUTORS+=('John R. Bradley' 'renovate[bot]' 'Renovate Bot' 'Pion Bot' 'Josh Bleecher Snyder')
+EXCLUDED_CONTRIBUTORS+=('John R. Bradley' 'renovate[bot]' 'Renovate Bot' 'Pion Bot')
 MISSING_CONTRIBUTORS=()
 
 shouldBeIncluded () {


### PR DESCRIPTION
Lint scripts are automatically synchronized from pion/.goassets.
Please don't edit these files directly.
