### PR TITLE
Unreference garbage in SampleBuilder buffer

### DIFF
--- a/pkg/media/samplebuilder/samplebuilder.go
+++ b/pkg/media/samplebuilder/samplebuilder.go
@@ -45,8 +45,13 @@ func New(maxLate uint16, depacketizer rtp.Depacketizer, opts ...Option) *SampleB
 // Push adds an RTP Packet to s's buffer.
 func (s *SampleBuilder) Push(p *rtp.Packet) {
 	s.buffer[p.SequenceNumber] = p
+
+	// Remove outdated references
+	for i := s.lastPush; i != p.SequenceNumber+1; i++ {
+		s.buffer[i-s.maxLate] = nil
+	}
+
 	s.lastPush = p.SequenceNumber
-	s.buffer[p.SequenceNumber-s.maxLate] = nil
 }
 
 // We have a valid collection of RTP Packets

--- a/pkg/media/samplebuilder/samplebuilder_test.go
+++ b/pkg/media/samplebuilder/samplebuilder_test.go
@@ -237,3 +237,18 @@ func TestSeqnumDistance(t *testing.T) {
 		}
 	}
 }
+
+func TestSampleBuilderCleanReference(t *testing.T) {
+	s := New(10, &fakeDepacketizer{})
+
+	s.Push(&rtp.Packet{Header: rtp.Header{SequenceNumber: 0, Timestamp: 0}, Payload: []byte{0x01}})
+	s.Push(&rtp.Packet{Header: rtp.Header{SequenceNumber: 1, Timestamp: 0}, Payload: []byte{0x02}})
+	s.Push(&rtp.Packet{Header: rtp.Header{SequenceNumber: 2, Timestamp: 0}, Payload: []byte{0x03}})
+	s.Push(&rtp.Packet{Header: rtp.Header{SequenceNumber: 13, Timestamp: 120}, Payload: []byte{0x04}})
+
+	for i := 0; i < 3; i++ {
+		if s.buffer[i] != nil {
+			t.Errorf("Old packet (%d) is not unreferenced (maxLate: 10, pushed: 12)", i)
+		}
+	}
+}


### PR DESCRIPTION
`SampleBuilder` held reference to outdated packets when the `SequenceNumber` is jumped.
