### PR TITLE
Fix race in TestPopulateLocalCandidates

### DIFF
--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -769,7 +769,10 @@ func TestPopulateLocalCandidates(t *testing.T) {
 		offer, err := pc.CreateOffer(nil)
 		assert.NoError(t, err)
 
+		offerGatheringComplete := GatheringCompletePromise(pc)
 		assert.NoError(t, pc.SetLocalDescription(offer))
+		<-offerGatheringComplete
+
 		assert.Equal(t, pc.PendingLocalDescription(), pc.PendingLocalDescription())
 		assert.NoError(t, pc.Close())
 	})


### PR DESCRIPTION
Test would compare PendingLocalDescription while it was still gathering.
If a candidate trickled between calls it would fail the test.