### PR TITLE
Assert SDPType in setDescription

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -592,8 +592,11 @@ func (pc *PeerConnection) CreateAnswer(options *AnswerOptions) (SessionDescripti
 
 // 4.4.1.6 Set the SessionDescription
 func (pc *PeerConnection) setDescription(sd *SessionDescription, op stateChangeOp) error {
-	if pc.isClosed.get() {
+	switch {
+	case pc.isClosed.get():
 		return &rtcerr.InvalidStateError{Err: ErrConnectionClosed}
+	case newSDPType(sd.Type.String()) == SDPType(Unknown):
+		return &rtcerr.TypeError{Err: fmt.Errorf("the provided value '%d' is not a valid enum value of type SDPType", sd.Type)}
 	}
 
 	nextState, err := func() (SignalingState, error) {

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -253,9 +253,11 @@ a=sctpmap:5000 webrtc-datachannel 1024
 
 func TestSetRemoteDescription(t *testing.T) {
 	testCases := []struct {
-		desc SessionDescription
+		desc        SessionDescription
+		expectError bool
 	}{
-		{SessionDescription{Type: SDPTypeOffer, SDP: minimalOffer}},
+		{SessionDescription{Type: SDPTypeOffer, SDP: minimalOffer}, false},
+		{SessionDescription{Type: 0, SDP: ""}, true},
 	}
 
 	for i, testCase := range testCases {
@@ -264,8 +266,10 @@ func TestSetRemoteDescription(t *testing.T) {
 			t.Errorf("Case %d: got error: %v", i, err)
 		}
 
-		if err = peerConn.SetRemoteDescription(testCase.desc); err != nil {
-			t.Errorf("Case %d: got error: %v", i, err)
+		if testCase.expectError {
+			assert.Error(t, peerConn.SetRemoteDescription(testCase.desc))
+		} else {
+			assert.NoError(t, peerConn.SetRemoteDescription(testCase.desc))
 		}
 
 		assert.NoError(t, peerConn.Close())


### PR DESCRIPTION
Before users could pass a SessionDescription with a 0 type. This would
be discarded silently. Now we return an error that matches browser
behavior.

Resolves #1297