### PR TITLE
Datachannel: Don't set state open before datachannel valid

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -278,10 +278,10 @@ func (d *DataChannel) onMessage(msg DataChannelMessage) {
 }
 
 func (d *DataChannel) handleOpen(dc *datachannel.DataChannel) {
-	d.setReadyState(DataChannelStateOpen)
 	d.mu.Lock()
 	d.dataChannel = dc
 	d.mu.Unlock()
+	d.setReadyState(DataChannelStateOpen)
 
 	d.onOpen()
 


### PR DESCRIPTION
Previously it was possible for datachannel writers to see
"DataChannelStateOpen" without "dataChannel" non-nil and
crash

#### Description

#### Reference issue
Fixes #...
