### PR TITLE
Update godoc link to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/pion/awesome-pion" alt="Awesome Pion"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg"></a>
   <br>
   <a href="https://travis-ci.org/pion/webrtc"><img src="https://travis-ci.org/pion/webrtc.svg?branch=master" alt="Build Status"></a>
-  <a href="https://pkg.go.dev/github.com/pion/webrtc/v3"><img src="https://godoc.org/github.com/pion/webrtc?status.svg" alt="GoDoc"></a>
+  <a href="https://pkg.go.dev/github.com/pion/webrtc/v3"><img src="https://pkg.go.dev/badge/github.com/pion/webrtc/v3" alt="PkgGoDev"></a>
   <a href="https://codecov.io/gh/pion/webrtc"><img src="https://codecov.io/gh/pion/webrtc/branch/master/graph/badge.svg" alt="Coverage Status"></a>
   <a href="https://goreportcard.com/report/github.com/pion/webrtc"><img src="https://goreportcard.com/badge/github.com/pion/webrtc" alt="Go Report Card"></a>
   <a href="https://www.codacy.com/app/Sean-Der/webrtc"><img src="https://api.codacy.com/project/badge/Grade/18f4aec384894e6aac0b94effe51961d" alt="Codacy Badge"></a>
@@ -43,7 +43,7 @@ See [DESIGN.md](DESIGN.md) for the guiding principals/inspirations of the projec
 
 **[awesome-pion](https://github.com/pion/awesome-pion)** contains projects that have used Pion, and serve as real world examples of usage.
 
-**[GoDoc](https://godoc.org/github.com/pion/webrtc)** is an auto generated API reference. All our Public APIs are commented.
+**[GoDoc](https://pkg.go.dev/github.com/pion/webrtc/v3)** is an auto generated API reference. All our Public APIs are commented.
 
 **[FAQ](https://github.com/pion/webrtc/wiki/FAQ)** has answers to common questions. If you have a question not covered please ask in [Slack](https://pion.ly/slack) we are always looking to expand it.
 

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -72,7 +72,7 @@ func (d *DataChannel) OnMessage(f func(msg DataChannelMessage)) {
 		go func() {
 			// valueToDataChannelMessage may block when handling 'Blob' data
 			// so we need to call it from a new routine. See:
-			// https://godoc.org/syscall/js#FuncOf
+			// https://pkg.go.dev/syscall/js#FuncOf
 			msg := valueToDataChannelMessage(data)
 			f(msg)
 		}()


### PR DESCRIPTION
#### Description
Use links and a badge from https://pkg.go.dev.
https://pkg.go.dev/badge/ supports creating a badge now.
#### Reference issue
~Fixes #...~
