### PR TITLE
Enable QUIC testing

### DIFF
--- a/.github/.ci.conf
+++ b/.github/.ci.conf
@@ -1,2 +1,4 @@
 GO_JS_WASM_EXEC=${PWD}/test-wasm/go_js_wasm_exec
 EXCLUDED_CONTRIBUTORS=('Josh Bleecher Snyder')
+TEST_EXTRA_ARGS="-tags quic"
+GOLANGCI_LINT_EXRA_ARGS="--build-tags quic"

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [JacobZwang](https://github.com/JacobZwang)
 * [박종훈](https://github.com/JonghunBok)
 * [Sam Lancia](https://github.com/nerd2)
+* [Henry](https://github.com/cryptix)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
Enable quic flags for `go test` and golangci-lint

Resolves #1277