### PR TITLE
Upgrade pion/ice to v2.0.0-rc.9

### DIFF
--- a/examples/ice-tcp/index.html
+++ b/examples/ice-tcp/index.html
@@ -4,8 +4,7 @@
   </head>
 
   <body>
-    <button onclick="window.doSignaling(true)"> ICE TCP </button><br />
-
+    <h1>ICE TCP</h1>
 
     <h3> ICE Connection States </h3>
     <div id="iceConnectionStates"></div> <br />

--- a/examples/ice-tcp/main.go
+++ b/examples/ice-tcp/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -25,7 +26,21 @@ func doSignaling(w http.ResponseWriter, r *http.Request) {
 			webrtc.NetworkTypeTCP4,
 			webrtc.NetworkTypeTCP6,
 		})
-		settingEngine.SetICETCPPort(8443)
+
+		var tcpListener net.Listener
+		tcpListener, err = net.ListenTCP("tcp", &net.TCPAddr{
+			IP:   net.IP{0, 0, 0, 0},
+			Port: 8443,
+		})
+
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("Listening for ICE TCP at %s\n", tcpListener.Addr())
+
+		tcpMux := webrtc.NewICETCPMux(nil, tcpListener, 8)
+		settingEngine.SetICETCPMux(tcpMux)
 
 		api := webrtc.NewAPI(
 			webrtc.WithMediaEngine(m),

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/pion/datachannel v1.4.19
 	github.com/pion/dtls/v2 v2.0.2
-	github.com/pion/ice/v2 v2.0.0-rc.8
+	github.com/pion/ice/v2 v2.0.0-rc.9
 	github.com/pion/logging v0.2.2
 	github.com/pion/quic v0.1.3
 	github.com/pion/randutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/pion/datachannel v1.4.19 h1:IcOmm5fdDzJVCMgFYDCMtFC+lrjG78KcMYXH+gOo6
 github.com/pion/datachannel v1.4.19/go.mod h1:JzKF/zzeWgkOYwQ+KFb8JzbrUt8s63um+Qunu8VqTyw=
 github.com/pion/dtls/v2 v2.0.2 h1:FHCHTiM182Y8e15aFTiORroiATUI16ryHiQh8AIOJ1E=
 github.com/pion/dtls/v2 v2.0.2/go.mod h1:27PEO3MDdaCfo21heT59/vsdmZc0zMt9wQPcSlLu/1I=
-github.com/pion/ice/v2 v2.0.0-rc.8 h1:rClk+AbvIn3hAZm0Pepf3Pc8wsGMphVp7nb9A/C9wKs=
-github.com/pion/ice/v2 v2.0.0-rc.8/go.mod h1:BH71LWfapOO69LRT1b+Rg9/be1qQPjSZT9Pm3qQRBdY=
+github.com/pion/ice/v2 v2.0.0-rc.9 h1:GPGwTQHimHneaxvbhFdJUxeaVgljP5QWp/LgQRHgtKk=
+github.com/pion/ice/v2 v2.0.0-rc.9/go.mod h1:BH71LWfapOO69LRT1b+Rg9/be1qQPjSZT9Pm3qQRBdY=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=
 github.com/pion/logging v0.2.2/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/mdns v0.0.4 h1:O4vvVqr4DGX63vzmO6Fw9vpy3lfztVWHGCQfyw0ZLSY=

--- a/icegatherer.go
+++ b/icegatherer.go
@@ -109,7 +109,7 @@ func (g *ICEGatherer) createAgent() error {
 		MulticastDNSHostName:   g.api.settingEngine.candidates.MulticastDNSHostName,
 		LocalUfrag:             g.api.settingEngine.candidates.UsernameFragment,
 		LocalPwd:               g.api.settingEngine.candidates.Password,
-		TCPListenPort:          g.api.settingEngine.iceTCPPort,
+		TCPMux:                 g.api.settingEngine.iceTCPMux,
 	}
 
 	requestedNetworkTypes := g.api.settingEngine.candidates.ICENetworkTypes

--- a/icetcp.go
+++ b/icetcp.go
@@ -1,0 +1,18 @@
+package webrtc
+
+import (
+	"net"
+
+	"github.com/pion/ice/v2"
+	"github.com/pion/logging"
+)
+
+// NewICETCPMux creates a new instance of ice.TCPMuxDefault. It enables use of
+// passive ICE TCP candidates.
+func NewICETCPMux(logger logging.LeveledLogger, listener net.Listener, readBufferSize int) ice.TCPMux {
+	return ice.NewTCPMuxDefault(ice.TCPMuxParams{
+		Listener:       listener,
+		Logger:         logger,
+		ReadBufferSize: readBufferSize,
+	})
+}

--- a/settingengine.go
+++ b/settingengine.go
@@ -56,7 +56,7 @@ type SettingEngine struct {
 	disableSRTCPReplayProtection              bool
 	vnet                                      *vnet.Net
 	LoggerFactory                             logging.LoggerFactory
-	iceTCPPort                                int
+	iceTCPMux                                 ice.TCPMux
 }
 
 // DetachDataChannels enables detaching data channels. When enabled
@@ -243,10 +243,10 @@ func (e *SettingEngine) SetSDPMediaLevelFingerprints(sdpMediaLevelFingerprints b
 	e.sdpMediaLevelFingerprints = sdpMediaLevelFingerprints
 }
 
-// SetICETCPPort to a non-zero value enables ICE-TCP listener. This API is experimental and
-// is likely to change in the future.
-func (e *SettingEngine) SetICETCPPort(port int) {
-	e.iceTCPPort = port
+// SetICETCPMux enables ICE-TCP when set to a non-nil value. Make sure that
+// NetworkTypeTCP4 or NetworkTypeTCP6 is enabled as well.
+func (e *SettingEngine) SetICETCPMux(tcpMux ice.TCPMux) {
+	e.iceTCPMux = tcpMux
 }
 
 // AddSDPExtensions adds available and offered extensions for media type.

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -3,9 +3,11 @@
 package webrtc
 
 import (
+	"net"
 	"testing"
 	"time"
 
+	"github.com/pion/transport/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -111,4 +113,29 @@ func TestSetReplayProtection(t *testing.T) {
 		*s.replayProtection.SRTCP != 32 {
 		t.Errorf("Failed to set SRTCP replay protection window")
 	}
+}
+
+func TestSettingEngine_SetICETCP(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{})
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	tcpMux := NewICETCPMux(nil, listener, 8)
+
+	defer func() {
+		_ = tcpMux.Close()
+	}()
+
+	settingEngine := SettingEngine{}
+	settingEngine.SetICETCPMux(tcpMux)
+
+	assert.Equal(t, tcpMux, settingEngine.iceTCPMux)
 }


### PR DESCRIPTION
This adds support for enabling ICE TCP by providing `ice.TCPMux` to `settingEngine`. The global state in `pion/ice` was removed and users can now specify their own `net.Listener` when creating a `ice.TCPMux`. A convenience function `NewICETCPMux` was added that returns a new instance of `ice.TCPMuxDefault`.

See https://github.com/pion/ice/pull/254 for more details.