### PR TITLE
Fix wrong comment on peerconnection.go

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1378,7 +1378,7 @@ func (pc *PeerConnection) AddTransceiverFromKind(kind RTPCodecType, init ...RtpT
 	}
 }
 
-// AddTransceiverFromTrack Get RTPCodecType from track and creates a new RTCRtpTransceiver(SendRecv or RecvOnly) and add it to the set of transceivers.
+// AddTransceiverFromTrack Get RTPCodecType from track and creates a new RTCRtpTransceiver(SendRecv or SendOnly) and add it to the set of transceivers.
 func (pc *PeerConnection) AddTransceiverFromTrack(track *Track, init ...RtpTransceiverInit) (*RTPTransceiver, error) {
 	if pc.isClosed.get() {
 		return nil, &rtcerr.InvalidStateError{Err: ErrConnectionClosed}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1378,7 +1378,7 @@ func (pc *PeerConnection) AddTransceiverFromKind(kind RTPCodecType, init ...RtpT
 	}
 }
 
-// AddTransceiverFromTrack Creates a new send only transceiver and add it to the set of
+// AddTransceiverFromTrack Get RTPCodecType from track and creates a new RTCRtpTransceiver(SendRecv or RecvOnly) and add it to the set of transceivers.
 func (pc *PeerConnection) AddTransceiverFromTrack(track *Track, init ...RtpTransceiverInit) (*RTPTransceiver, error) {
 	if pc.isClosed.get() {
 		return nil, &rtcerr.InvalidStateError{Err: ErrConnectionClosed}


### PR DESCRIPTION
#### Description
Fix wrong comment on peerconnection.go
#### Reference issue
* Original comment -> 
`// AddTransceiverFromTrack Creates a new send only transceiver and add it to the set of`
* Changed comment -> 
`// AddTransceiverFromTrack Get RTPCodecType from track and creates a new RTCRtpTransceiver(SendRecv or SendOnly) and add it to the set of transceivers.
`

AddTransceiverFromTack also creates RTCRtpTransceiver(SendRecv or SendOnly).
Thanks!