### PR TITLE
Write to all of a track's active senders even if some fail.

### DIFF
--- a/track.go
+++ b/track.go
@@ -168,14 +168,15 @@ func (t *Track) WriteRTP(p *rtp.Packet) error {
 		return io.ErrClosedPipe
 	}
 
+	var firstErr error
 	for _, s := range senders {
 		_, err := s.SendRTP(&p.Header, p.Payload)
-		if err != nil {
-			return err
+		if err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
 
-	return nil
+	return firstErr
 }
 
 // NewTrack initializes a new *Track


### PR DESCRIPTION
#### Description

Currently, if one of a track's senders is in a bad state, `WriteRTP()` stops at that sender and returns an error. This change continues writing to the other senders and returns the first error, if any.

#### Reference issue
Fixes #...
