### PR TITLE
Always return sdpMid & sdpMLineIndex if value is null

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sam Lancia](https://github.com/nerd2)
 * [Henry](https://github.com/cryptix)
 * [Jeff Tchang](https://github.com/tachang)
-* [JooYoung](https://github.com/DevRockstarZ)
+* [JooYoung Lim](https://github.com/DevRockstarZ)
 * [Sidney San Martín](https://github.com/s4y)
 * [soolaugust](https://github.com/soolaugust)
 

--- a/icecandidate.go
+++ b/icecandidate.go
@@ -203,9 +203,7 @@ func newICECandidateFromSDP(c sdp.ICECandidate) (ICECandidate, error) {
 // ToJSON returns an ICECandidateInit
 // as indicated by the spec https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson
 func (c ICECandidate) ToJSON() ICECandidateInit {
-	var sdpmLineIndex uint16
 	return ICECandidateInit{
 		Candidate:     fmt.Sprintf("candidate:%s", iceCandidateToSDP(c).Marshal()),
-		SDPMLineIndex: &sdpmLineIndex,
 	}
 }

--- a/icecandidateinit.go
+++ b/icecandidateinit.go
@@ -3,7 +3,7 @@ package webrtc
 // ICECandidateInit is used to serialize ice candidates
 type ICECandidateInit struct {
 	Candidate        string  `json:"candidate"`
-	SDPMid           *string `json:"sdpMid,omitempty"`
-	SDPMLineIndex    *uint16 `json:"sdpMLineIndex,omitempty"`
+	SDPMid           *string `json:"sdpMid"`
+	SDPMLineIndex    *uint16 `json:"sdpMLineIndex"`
 	UsernameFragment string  `json:"usernameFragment"`
 }

--- a/icecandidateinit.go
+++ b/icecandidateinit.go
@@ -5,5 +5,5 @@ type ICECandidateInit struct {
 	Candidate        string  `json:"candidate"`
 	SDPMid           *string `json:"sdpMid"`
 	SDPMLineIndex    *uint16 `json:"sdpMLineIndex"`
-	UsernameFragment string  `json:"usernameFragment"`
+	UsernameFragment *string  `json:"usernameFragment"`
 }


### PR DESCRIPTION
#### Description
sdpMid & sdpMLineIndex ToJSON description : (https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson)
I thought ICECandidateInit should return sdpMid & sdpMLineIndex if value is null.
I'm doing some stuffs using react-native-webrtc, I suffered issue in this [line](https://github.com/react-native-webrtc/react-native-webrtc/blob/9e627e07102f4b83c72d0ca1dcaa9f549d84c6c7/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java#L873).
So I thought sdpMind & sdpMLineIndex should not be null, therefore I request PR.
Thanks!