### PR TITLE
examples/rtp-to-webrtc: simplify gstreamer pipeline

### DIFF
--- a/examples/rtp-to-webrtc/README.md
+++ b/examples/rtp-to-webrtc/README.md
@@ -30,7 +30,7 @@ On startup you will get a message `Waiting for RTP Packets`, you can use any sof
 
 #### GStreamer
 ```
-gst-launch-1.0 videotestsrc ! 'video/x-raw, width=640, height=480' ! videoconvert ! video/x-raw,format=I420 ! vp8enc error-resilient=partitions keyframe-max-dist=10 auto-alt-ref=true cpu-used=5 deadline=1 ! rtpvp8pay ! udpsink host=127.0.0.1 port=5004
+gst-launch-1.0 videotestsrc ! video/x-raw,width=640,height=480,format=I420 ! vp8enc error-resilient=partitions keyframe-max-dist=10 auto-alt-ref=true cpu-used=5 deadline=1 ! rtpvp8pay ! udpsink host=127.0.0.1 port=5004
 ```
 
 #### ffmpeg


### PR DESCRIPTION
#### Description

Hello, the GStreamer pipeline reported in the `rtp-to-webrtc` example is redundant, there's an additional element that can be safely removed.

#### Reference issue

none