### PR TITLE
Add signaling state case in CreateAnswer()

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -84,6 +84,9 @@ var (
 	// generate SDP Answers with different SDP Semantics than the received Offer
 	ErrIncorrectSDPSemantics = errors.New("offer SDP semantics does not match configuration")
 
+	// ErrIncorrectSignalingState indicates that the signaling state of PeerConnection is not correct
+	ErrIncorrectSignalingState = errors.New("signaling state is not match requirement")
+
 	// ErrProtocolTooLarge indicates that value given for a DataChannelInit protocol is
 	//longer then 65535 bytes
 	ErrProtocolTooLarge = errors.New("protocol is larger then 65535 bytes")

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -711,6 +711,8 @@ func (pc *PeerConnection) CreateAnswer(options *AnswerOptions) (SessionDescripti
 		return SessionDescription{}, fmt.Errorf("TODO handle identity provider")
 	case pc.isClosed.get():
 		return SessionDescription{}, &rtcerr.InvalidStateError{Err: ErrConnectionClosed}
+	case pc.signalingState != SignalingStateHaveRemoteOffer && pc.signalingState != SignalingStateHaveLocalPranswer:
+		return SessionDescription{}, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState}
 	}
 
 	connectionRole := connectionRoleFromDtlsRole(pc.api.settingEngine.answeringDTLSRole)

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -4,6 +4,7 @@ package webrtc
 
 import (
 	"context"
+	"github.com/pion/webrtc/v3/pkg/rtcerr"
 	"io"
 	"math/rand"
 	"strconv"
@@ -314,10 +315,7 @@ func TestPeerConnection_Transceiver_Mid(t *testing.T) {
 	assert.True(t, sdpMidHasSsrc(offer, "1", track2.SSRC()), "Expected mid %q with ssrc %d, offer.SDP: %s", "1", track2.SSRC(), offer.SDP)
 
 	answer, err = pcAnswer.CreateAnswer(nil)
-	assert.NoError(t, err)
-	assert.NoError(t, pcAnswer.SetLocalDescription(answer))
-	// apply answer so we'll test generateMatchedSDP
-	assert.NoError(t, pcOffer.SetRemoteDescription(answer))
+	assert.Error(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
 
 	pcOffer.ops.Done()
 	pcAnswer.ops.Done()

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -298,6 +298,12 @@ func TestCreateOfferAnswer(t *testing.T) {
 	assert.NoError(t, answerPeerConn.SetLocalDescription(answer))
 	assert.NoError(t, offerPeerConn.SetRemoteDescription(answer))
 
+	// after setLocalDescription(answer), signaling state should be stable.
+	// so CreateAnswer should return an InvalidStateError
+	assert.Equal(t, answerPeerConn.signalingState, SignalingStateStable)
+	answer, err = answerPeerConn.CreateAnswer(nil)
+	assert.Error(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
+
 	assert.NoError(t, offerPeerConn.Close())
 	assert.NoError(t, answerPeerConn.Close())
 }

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -301,7 +301,7 @@ func TestCreateOfferAnswer(t *testing.T) {
 	// after setLocalDescription(answer), signaling state should be stable.
 	// so CreateAnswer should return an InvalidStateError
 	assert.Equal(t, answerPeerConn.signalingState, SignalingStateStable)
-	answer, err = answerPeerConn.CreateAnswer(nil)
+	_, err = answerPeerConn.CreateAnswer(nil)
 	assert.Error(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
 
 	assert.NoError(t, offerPeerConn.Close())

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -300,7 +300,7 @@ func TestCreateOfferAnswer(t *testing.T) {
 
 	// after setLocalDescription(answer), signaling state should be stable.
 	// so CreateAnswer should return an InvalidStateError
-	assert.Equal(t, answerPeerConn.signalingState, SignalingStateStable)
+	assert.Equal(t, answerPeerConn.SignalingState(), SignalingStateStable)
 	_, err = answerPeerConn.CreateAnswer(nil)
 	assert.Error(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
 


### PR DESCRIPTION

According to
https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createanswer.
If connection's signaling state is neither "have-remote-offer" nor
"have-local-pranswer", return a newly created InvalidStateError.
