### PR TITLE
Revert "Don't use omitempty for ICECandidateInit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sam Lancia](https://github.com/nerd2)
 * [Henry](https://github.com/cryptix)
 * [Jeff Tchang](https://github.com/tachang)
-* [JooYoung Lim](https://github.com/DevRockstarZ)
+* [JooYoung](https://github.com/DevRockstarZ)
 * [Sidney San Martín](https://github.com/s4y)
 * [soolaugust](https://github.com/soolaugust)
 * [Kuzmin Vladimir](https://github.com/tekig)

--- a/icecandidate.go
+++ b/icecandidate.go
@@ -203,7 +203,9 @@ func newICECandidateFromSDP(c sdp.ICECandidate) (ICECandidate, error) {
 // ToJSON returns an ICECandidateInit
 // as indicated by the spec https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson
 func (c ICECandidate) ToJSON() ICECandidateInit {
+	var sdpmLineIndex uint16
 	return ICECandidateInit{
-		Candidate: fmt.Sprintf("candidate:%s", iceCandidateToSDP(c).Marshal()),
+		Candidate:     fmt.Sprintf("candidate:%s", iceCandidateToSDP(c).Marshal()),
+		SDPMLineIndex: &sdpmLineIndex,
 	}
 }

--- a/icecandidate_test.go
+++ b/icecandidate_test.go
@@ -215,7 +215,6 @@ func TestICECandidate_ToJSON(t *testing.T) {
 
 	candidateInit := candidate.ToJSON()
 
-	var nilUint16Ptr *uint16
-	assert.Equal(t, nilUint16Ptr, candidateInit.SDPMLineIndex)
+	assert.Equal(t, uint16(0), *candidateInit.SDPMLineIndex)
 	assert.Equal(t, "candidate:foundation 1 udp 128 1.0.0.1 1234 typ host", candidateInit.Candidate)
 }

--- a/icecandidateinit.go
+++ b/icecandidateinit.go
@@ -3,7 +3,7 @@ package webrtc
 // ICECandidateInit is used to serialize ice candidates
 type ICECandidateInit struct {
 	Candidate        string  `json:"candidate"`
-	SDPMid           *string `json:"sdpMid"`
-	SDPMLineIndex    *uint16 `json:"sdpMLineIndex"`
-	UsernameFragment *string `json:"usernameFragment"`
+	SDPMid           *string `json:"sdpMid,omitempty"`
+	SDPMLineIndex    *uint16 `json:"sdpMLineIndex,omitempty"`
+	UsernameFragment string  `json:"usernameFragment"`
 }

--- a/icecandidateinit_test.go
+++ b/icecandidateinit_test.go
@@ -16,11 +16,12 @@ func TestICECandidateInit_Serialization(t *testing.T) {
 			Candidate:        "candidate:abc123",
 			SDPMid:           refString("0"),
 			SDPMLineIndex:    refUint16(0),
-			UsernameFragment: refString("def"),
+			UsernameFragment: "def",
 		}, `{"candidate":"candidate:abc123","sdpMid":"0","sdpMLineIndex":0,"usernameFragment":"def"}`},
 		{ICECandidateInit{
-			Candidate: "candidate:abc123",
-		}, `{"candidate":"candidate:abc123","sdpMid":null,"sdpMLineIndex":null,"usernameFragment":null}`},
+			Candidate:        "candidate:abc123",
+			UsernameFragment: "def",
+		}, `{"candidate":"candidate:abc123","usernameFragment":"def"}`},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
This reverts commit 6d3633e58923227e00e96ed80ae46e6fa25a39cc from pr https://github.com/pion/webrtc/pull/1377

I'm running into an error with this change:

```
Failed to execute 'addIceCandidate' on 'RTCPeerConnection': Candidate missing values for both sdpMid and sdpMLineIndex
```

MDN has this note:
```
Note: Attempting to add a candidate (using addIceCandidate()) that has a value of null for either sdpMid or sdpMLineIndex will throw a TypeError exception.
```
https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidateInit/sdpMLineIndex

So im not sure the key should exist with a null value

@DevRockstarZ 