### PR TITLE
fixed failing test in issue #1384

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Kuzmin Vladimir](https://github.com/tekig)
 * [Alessandro Ros](https://github.com/aler9)
 * [Thomas Miller](https://github.com/tmiv)
+* [Joshua Obasaju](https://github.com/obasajujoshua31)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -890,11 +890,8 @@ func TestNegotiationNeededRemoveTrack(t *testing.T) {
 
 	wg.Wait()
 
-	wg.Add(1)
 	err = pcOffer.RemoveTrack(sender)
 	assert.NoError(t, err)
-
-	wg.Wait()
 
 	assert.NoError(t, pcOffer.Close())
 	assert.NoError(t, pcAnswer.Close())


### PR DESCRIPTION
#### Description
Remove wait group that continually makes the wg.Done in the peerconnection on negotiation handler to continually fail.
#### Reference issue
Fixes #...
[#1212 1384](https://github.com/pion/webrtc/issues/1384)
