### PR TITLE
Fix issue #1425 - track event doesn't emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Ivan Egorov](https://github.com/vany-egorov)
 * [krishna chiatanya](https://github.com/kittuov)
 * [JacobZwang](https://github.com/JacobZwang)
+* [Mission Liao](https://github.com/mission-liao)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -277,8 +277,12 @@ func (pc *PeerConnection) onTrack(t *Track, r *RTPReceiver) {
 	pc.mu.RUnlock()
 
 	pc.log.Debugf("got new track: %+v", t)
-	if hdlr != nil && t != nil {
-		go hdlr(t, r)
+	if t != nil {
+		if hdlr != nil {
+			go hdlr(t, r)
+		} else {
+			pc.log.Warnf("OnTrack unset, unable to handle incoming media streams")
+		}
 	}
 }
 
@@ -900,9 +904,6 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 			return
 		}
 
-		pc.mu.RLock()
-		defer pc.mu.RUnlock()
-
 		codec, err := pc.api.mediaEngine.getCodec(receiver.Track().PayloadType())
 		if err != nil {
 			pc.log.Warnf("no codec could be found for payloadType %d", receiver.Track().PayloadType())
@@ -914,11 +915,7 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 		receiver.Track().codec = codec
 		receiver.Track().mu.Unlock()
 
-		if pc.onTrackHandler != nil {
-			pc.onTrack(receiver.Track(), receiver)
-		} else {
-			pc.log.Warnf("OnTrack unset, unable to handle incoming media streams")
-		}
+		pc.onTrack(receiver.Track(), receiver)
 	}()
 }
 

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/pion/ice"
+	"github.com/pion/rtp"
 	"github.com/pion/transport/test"
 	"github.com/pion/webrtc/v2/internal/util"
 	"github.com/pion/webrtc/v2/pkg/rtcerr"
@@ -879,4 +880,127 @@ func TestPopulateLocalCandidates(t *testing.T) {
 
 		assert.NoError(t, pc.Close())
 	})
+}
+
+type trackRecords struct {
+	mu               sync.Mutex
+	trackIDs         map[string]struct{}
+	receivedTrackIDs map[string]struct{}
+}
+
+func newTrackRecords() *trackRecords {
+	return &trackRecords{
+		trackIDs:         make(map[string]struct{}),
+		receivedTrackIDs: make(map[string]struct{}),
+	}
+}
+
+func (r *trackRecords) newTrackParameter() (uint8, uint32, string, string) {
+	trackID := fmt.Sprintf("pion-track-%d", len(r.trackIDs))
+	r.trackIDs[trackID] = struct{}{}
+	return DefaultPayloadTypeVP8, uint32(len(r.trackIDs)), trackID, "pion"
+}
+
+func (r *trackRecords) handleTrack(t *Track, _ *RTPReceiver) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	tID := t.ID()
+	if _, exist := r.trackIDs[tID]; exist {
+		r.receivedTrackIDs[tID] = struct{}{}
+	}
+}
+
+func (r *trackRecords) remains() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.trackIDs) - len(r.receivedTrackIDs)
+}
+
+// This test assure that all track events emits.
+func TestPeerConnection_MassiveTracks(t *testing.T) {
+	var (
+		api             = NewAPI()
+		tRecs           = newTrackRecords()
+		tracks          = []*Track{}
+		trackCount      = 256
+		pingInterval    = 1 * time.Second
+		noiseInterval   = 100 * time.Microsecond
+		timeoutDuration = 20 * time.Second
+		rawPkt          = []byte{
+			0x90, 0xe0, 0x69, 0x8f, 0xd9, 0xc2, 0x93, 0xda, 0x1c, 0x64,
+			0x27, 0x82, 0x00, 0x01, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x98, 0x36, 0xbe, 0x88, 0x9e,
+		}
+		samplePkt = &rtp.Packet{
+			Header: rtp.Header{
+				Marker:           true,
+				Extension:        false,
+				ExtensionProfile: 1,
+				Version:          2,
+				PayloadOffset:    20,
+				PayloadType:      DefaultPayloadTypeVP8,
+				SequenceNumber:   27023,
+				Timestamp:        3653407706,
+				CSRC:             []uint32{},
+			},
+			Payload: rawPkt[20:],
+		}
+		connected = make(chan struct{})
+		stopped   = make(chan struct{})
+	)
+	api.mediaEngine.RegisterDefaultCodecs()
+	offerPC, answerPC, err := api.newPair(Configuration{})
+	assert.NoError(t, err)
+	// Create massive tracks.
+	for range make([]struct{}, trackCount) {
+		track, err := offerPC.NewTrack(tRecs.newTrackParameter())
+		assert.NoError(t, err)
+		_, err = offerPC.AddTrack(track)
+		assert.NoError(t, err)
+		tracks = append(tracks, track)
+	}
+	answerPC.OnTrack(tRecs.handleTrack)
+	offerPC.OnICEConnectionStateChange(func(s ICEConnectionState) {
+		if s == ICEConnectionStateConnected {
+			close(connected)
+		}
+	})
+	// A routine to periodically call GetTransceivers. This action might cause
+	// the deadlock and prevent track event to emit.
+	go func() {
+		for {
+			answerPC.GetTransceivers()
+			time.Sleep(noiseInterval)
+			select {
+			case <-stopped:
+				return
+			default:
+			}
+		}
+	}()
+	assert.NoError(t, signalPair(offerPC, answerPC))
+	// Send a RTP packets to each track to trigger track event after connected.
+	<-connected
+	time.Sleep(1 * time.Second)
+	for _, track := range tracks {
+		samplePkt.SSRC = track.SSRC()
+		assert.NoError(t, track.WriteRTP(samplePkt))
+	}
+	// Ping trackRecords to see if any track event not received yet.
+	tooLong := time.After(timeoutDuration)
+	for {
+		remains := tRecs.remains()
+		if remains == 0 {
+			break
+		}
+		t.Log("remain tracks", remains)
+		time.Sleep(pingInterval)
+		select {
+		case <-tooLong:
+			t.Error("unable to receive all track events in time")
+		default:
+		}
+	}
+	close(stopped)
+	assert.NoError(t, offerPC.Close())
+	assert.NoError(t, answerPC.Close())
 }


### PR DESCRIPTION
#### Description
Sometimes track events may not emit.

After tracing this issue, it a deadlock caused by two consecutive reader lock acquisition then a writer lock acquisition in another routine. (see [here](https://stackoverflow.com/a/30549188))

- to fix it, remove the unnecessary reader lock acquisition
- add a test to reproduce it with high probability

#### Reference issue
Fixes #1425 
