### PR TITLE
Avoid acquiring two reader privilege of a lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Thomas Miller](https://github.com/tmiv)
 * [yoko(q191201771)](https://github.com/q191201771)
 * [Joshua Obasaju](https://github.com/obasajujoshua31)
+* [Mission Liao](https://github.com/mission-liao)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -422,8 +422,12 @@ func (pc *PeerConnection) onTrack(t *Track, r *RTPReceiver) {
 	pc.mu.RUnlock()
 
 	pc.log.Debugf("got new track: %+v", t)
-	if handler != nil && t != nil {
-		go handler(t, r)
+	if t != nil {
+		if handler != nil {
+			go handler(t, r)
+		} else {
+			pc.log.Warnf("OnTrack unset, unable to handle incoming media streams")
+		}
 	}
 }
 
@@ -1111,9 +1115,6 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 			return
 		}
 
-		pc.mu.RLock()
-		defer pc.mu.RUnlock()
-
 		codec, err := pc.api.mediaEngine.getCodec(receiver.Track().PayloadType())
 		if err != nil {
 			pc.log.Warnf("no codec could be found for payloadType %d", receiver.Track().PayloadType())
@@ -1125,11 +1126,7 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 		receiver.Track().codec = codec
 		receiver.Track().mu.Unlock()
 
-		if pc.onTrackHandler != nil {
-			pc.onTrack(receiver.Track(), receiver)
-		} else {
-			pc.log.Warnf("OnTrack unset, unable to handle incoming media streams")
-		}
+		pc.onTrack(receiver.Track(), receiver)
 	}()
 }
 


### PR DESCRIPTION
It's an anti-pattern when using sync.RWMutex in golang.
After acquiring two reader privilege of a rwlock, it will deadlock if
another routine tries to acquire a writer lock.

In pion/webrtc, this calling sequence might happen when calling
GetTransceivers during track events.

Resolves #1425
