### PR TITLE
Fix typo `Quick` -> `Quic`

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -207,7 +207,4 @@ var (
 	errTrackLocalTrackRead   = errors.New("this is a local track and must not be read from")
 	errTrackLocalTrackWrite  = errors.New("this is a remote track and must not be written to")
 	errTrackSSRCNewTrackZero = errors.New("SSRC supplied to NewTrack() must be non-zero")
-
-	errQuickTransportFingerprintNoMatch      = errors.New("no matching fingerprint")
-	errQuickTransportICEConnectionNotStarted = errors.New("ICE connection not started")
 )

--- a/quictransport.go
+++ b/quictransport.go
@@ -8,6 +8,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"errors"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,11 @@ type QUICTransport struct {
 
 	loggingFactory logging.LoggerFactory
 }
+
+var (
+	errQuicTransportFingerprintNoMatch      = errors.New("no matching fingerprint")
+	errQuicTransportICEConnectionNotStarted = errors.New("ICE connection not started")
+)
 
 // NewQUICTransport creates a new QUICTransport.
 // This constructor is part of the ORTC API. It is not
@@ -154,13 +160,13 @@ func (t *QUICTransport) validateFingerPrint(remoteParameters QUICParameters, rem
 		}
 	}
 
-	return errQuickTransportFingerprintNoMatch
+	return errQuicTransportFingerprintNoMatch
 }
 
 func (t *QUICTransport) ensureICEConn() error {
 	if t.iceTransport == nil ||
 		t.iceTransport.State() == ICETransportStateNew {
-		return errQuickTransportICEConnectionNotStarted
+		return errQuicTransportICEConnectionNotStarted
 	}
 
 	return nil


### PR DESCRIPTION
Fix typo made when updating golangci-lint
