### PR TITLE
Issue 1442 codec match case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Mission Liao](https://github.com/mission-liao)
 * [Hanjun Kim](https://github.com/hallazzang)
 * [ZHENK](https://github.com/scorpionknifes)
+* [Rahul Nakre](https://github.com/rahulnakre)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,7 @@ github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYED
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -142,7 +142,7 @@ func (m *MediaEngine) getCodec(payloadType uint8) (*RTPCodec, error) {
 
 func (m *MediaEngine) getCodecSDP(sdpCodec sdp.Codec) (*RTPCodec, error) {
 	for _, codec := range m.codecs {
-		if codec.Name == sdpCodec.Name &&
+		if strings.EqualFold(codec.Name, sdpCodec.Name) &&
 			codec.ClockRate == sdpCodec.ClockRate &&
 			(sdpCodec.EncodingParameters == "" ||
 				strconv.Itoa(int(codec.Channels)) == sdpCodec.EncodingParameters) &&

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -111,6 +111,49 @@ func TestOpusCase(t *testing.T) {
 	assert.NoError(t, pc.Close())
 }
 
+// pion/webrtc#1442
+func TestCaseInsensitive(t *testing.T) {
+	m := MediaEngine{}
+	m.RegisterDefaultCodecs()
+
+	testCases := []struct {
+		nameUpperCase string
+		nameLowerCase string
+		clockrate     uint32
+		fmtp          string
+	}{
+		{strings.ToUpper(Opus), strings.ToLower(Opus), 48000,
+			"minptime=10;useinbandfec=1",
+		},
+		{strings.ToUpper(PCMU), strings.ToLower(PCMU), 8000, ""},
+		{strings.ToUpper(PCMA), strings.ToLower(PCMA), 8000, ""},
+		{strings.ToUpper(G722), strings.ToLower(G722), 8000, ""},
+		{strings.ToUpper(VP8), strings.ToLower(VP8), 90000, ""},
+		{strings.ToUpper(VP9), strings.ToLower(VP9), 90000, ""},
+		{strings.ToUpper(H264), strings.ToLower(H264), 90000,
+			"level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
+		},
+	}
+
+	for _, f := range testCases {
+		upperCase, err := m.getCodecSDP(sdp.Codec{
+			Name:      f.nameUpperCase,
+			ClockRate: f.clockrate,
+			Fmtp:      f.fmtp,
+		})
+		assert.NoError(t, err)
+
+		lowerCase, err := m.getCodecSDP(sdp.Codec{
+			Name:      f.nameLowerCase,
+			ClockRate: f.clockrate,
+			Fmtp:      f.fmtp,
+		})
+		assert.NoError(t, err)
+
+		assert.Equal(t, upperCase, lowerCase)
+	}
+}
+
 func TestGetCodecsByName(t *testing.T) {
 	var cdc *RTPCodec
 	m := MediaEngine{}


### PR DESCRIPTION
#### Description
Codec matching was done in a case sensitive manner. As @cnjeffliu pointed out, it was due to a change in  846257b
#### Reference issue
Fixes #1442 
