### PR TITLE
Rename SettingEngine mDNS Config option

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -82,9 +82,10 @@ func (g *ICEGatherer) createAgent() error {
 		nat1To1CandiTyp = ice.CandidateTypeUnspecified
 	}
 
-	var multicastDNSMode ice.MulticastDNSMode
-	if g.api.settingEngine.candidates.GenerateMulticastDNSCandidates {
-		multicastDNSMode = ice.MulticastDNSModeQueryAndGather
+	mDNSMode := g.api.settingEngine.candidates.MulticastDNSMode
+	if mDNSMode != ice.MulticastDNSModeDisabled && mDNSMode != ice.MulticastDNSModeQueryAndGather {
+		// If enum is in state we don't recognized default to MulticastDNSModeQueryOnly
+		mDNSMode = ice.MulticastDNSModeQueryOnly
 	}
 
 	config := &ice.AgentConfig{
@@ -105,7 +106,7 @@ func (g *ICEGatherer) createAgent() error {
 		NAT1To1IPs:             g.api.settingEngine.candidates.NAT1To1IPs,
 		NAT1To1IPCandidateType: nat1To1CandiTyp,
 		Net:                    g.api.settingEngine.vnet,
-		MulticastDNSMode:       multicastDNSMode,
+		MulticastDNSMode:       mDNSMode,
 		MulticastDNSHostName:   g.api.settingEngine.candidates.MulticastDNSHostName,
 		LocalUfrag:             g.api.settingEngine.candidates.UsernameFragment,
 		LocalPwd:               g.api.settingEngine.candidates.Password,

--- a/icegatherer_test.go
+++ b/icegatherer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/ice/v2"
 	"github.com/pion/transport/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -77,7 +78,7 @@ func TestICEGather_mDNSCandidateGathering(t *testing.T) {
 	defer report()
 
 	s := SettingEngine{}
-	s.GenerateMulticastDNSCandidates(true)
+	s.SetICEMulticastDNSMode(ice.MulticastDNSModeQueryAndGather)
 
 	gatherer, err := NewAPI(WithSettingEngine(s)).NewICEGatherer(ICEGatherOptions{})
 	if err != nil {

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -838,7 +838,7 @@ func TestMulticastDNSCandidates(t *testing.T) {
 	defer report()
 
 	s := SettingEngine{}
-	s.GenerateMulticastDNSCandidates(true)
+	s.SetICEMulticastDNSMode(ice.MulticastDNSModeQueryAndGather)
 
 	pcOffer, pcAnswer, err := NewAPI(WithSettingEngine(s)).newPair(Configuration{})
 	assert.NoError(t, err)

--- a/settingengine.go
+++ b/settingengine.go
@@ -32,15 +32,15 @@ type SettingEngine struct {
 		ICERelayAcceptanceMinWait *time.Duration
 	}
 	candidates struct {
-		ICELite                        bool
-		ICENetworkTypes                []NetworkType
-		InterfaceFilter                func(string) bool
-		NAT1To1IPs                     []string
-		NAT1To1IPCandidateType         ICECandidateType
-		GenerateMulticastDNSCandidates bool
-		MulticastDNSHostName           string
-		UsernameFragment               string
-		Password                       string
+		ICELite                bool
+		ICENetworkTypes        []NetworkType
+		InterfaceFilter        func(string) bool
+		NAT1To1IPs             []string
+		NAT1To1IPCandidateType ICECandidateType
+		MulticastDNSMode       ice.MulticastDNSMode
+		MulticastDNSHostName   string
+		UsernameFragment       string
+		Password               string
 	}
 	replayProtection struct {
 		DTLS  *uint
@@ -181,9 +181,9 @@ func (e *SettingEngine) SetVNet(vnet *vnet.Net) {
 	e.vnet = vnet
 }
 
-// GenerateMulticastDNSCandidates instructs pion/ice to generate host candidates with mDNS hostnames instead of IP Addresses
-func (e *SettingEngine) GenerateMulticastDNSCandidates(generateMulticastDNSCandidates bool) {
-	e.candidates.GenerateMulticastDNSCandidates = generateMulticastDNSCandidates
+// SetICEMulticastDNSMode controls if pion/ice queries and generates mDNS ICE Candidates
+func (e *SettingEngine) SetICEMulticastDNSMode(multicastDNSMode ice.MulticastDNSMode) {
+	e.candidates.MulticastDNSMode = multicastDNSMode
 }
 
 // SetMulticastDNSHostName sets a static HostName to be used by pion/ice instead of generating one on startup


### PR DESCRIPTION
GenerateMulticastDNSCandidates -> SetICEMulticastDNSMode.
Before a user wasn't able to disable mDNS. By changing it we can
do more with this API.