### PR TITLE
Don't drop a packet at the beginning of a new track.

### DIFF
--- a/track.go
+++ b/track.go
@@ -34,6 +34,7 @@ type Track struct {
 	receiver         *RTPReceiver
 	activeSenders    []*RTPSender
 	totalSenderCount int // count of all senders (accounts for senders that have not been started yet)
+	peeked           []byte
 }
 
 // ID gets the ID of the track
@@ -109,10 +110,43 @@ func (t *Track) Read(b []byte) (n int, err error) {
 		t.mu.RUnlock()
 		return 0, errTrackLocalTrackRead
 	}
+	peeked := t.peeked != nil
 	t.mu.RUnlock()
+
+	if peeked {
+		t.mu.Lock()
+		data := t.peeked
+		t.peeked = nil
+		t.mu.Unlock()
+		// someone else may have stolen our packet when we
+		// released the lock.  Deal with it.
+		if data != nil {
+			n = copy(b, data)
+			return
+		}
+	}
 
 	return r.readRTP(b, t)
 }
+
+// peek is like Read, but it doesn't discard the packet read
+func (t *Track) peek(b []byte) (n int, err error) {
+	n, err = t.Read(b)
+	if err != nil {
+		return
+	}
+
+	t.mu.Lock()
+	// this might overwrite data if somebody peeked between the Read
+	// and us getting the lock.  Oh well, we'll just drop a packet in
+	// that case.
+	data := make([]byte, n)
+	n = copy(data, b[:n])
+	t.peeked = data
+	t.mu.Unlock()
+	return
+}
+
 
 // ReadRTP is a convenience method that wraps Read and unmarshals for you
 func (t *Track) ReadRTP() (*rtp.Packet, error) {
@@ -212,8 +246,13 @@ func NewTrack(payloadType uint8, ssrc uint32, id, label string, codec *RTPCodec)
 // determinePayloadType blocks and reads a single packet to determine the PayloadType for this Track
 // this is useful if we are dealing with a remote track and we can't announce it to the user until we know the payloadType
 func (t *Track) determinePayloadType() error {
-	r, err := t.ReadRTP()
+	b := make([]byte, receiveMTU)
+	n, err := t.peek(b)
 	if err != nil {
+		return err
+	}
+	r := rtp.Packet{}
+	if err := r.Unmarshal(b[:n]); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Dropping a packet at the beginning of every track is bad, since
it corrupts the first keyframe of each video track.  This works
by adding a peek method to Track, and using it in NewTrack.

The peeked data is protected by the RWLock already associated
with the track.  We check for its presence with the reader lock
taken, which avoids taking the writer lock (or doing an atomic read)
in the common case (no peeked data).

#### Description

#### Reference issue
Fixes #1001
