### PR TITLE
Set the proxy dialer

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -111,6 +111,7 @@ func (g *ICEGatherer) createAgent() error {
 		LocalUfrag:             g.api.settingEngine.candidates.UsernameFragment,
 		LocalPwd:               g.api.settingEngine.candidates.Password,
 		TCPMux:                 g.api.settingEngine.iceTCPMux,
+		ProxyDialer:            g.api.settingEngine.proxyDialer,
 	}
 
 	requestedNetworkTypes := g.api.settingEngine.candidates.ICENetworkTypes

--- a/settingengine.go
+++ b/settingengine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/sdp/v3"
 	"github.com/pion/transport/vnet"
+	"golang.org/x/net/proxy"
 )
 
 // SettingEngine allows influencing behavior in ways that are not
@@ -56,6 +57,7 @@ type SettingEngine struct {
 	vnet                                      *vnet.Net
 	LoggerFactory                             logging.LoggerFactory
 	iceTCPMux                                 ice.TCPMux
+	proxyDialer                               proxy.Dialer
 }
 
 // DetachDataChannels enables detaching data channels. When enabled
@@ -308,4 +310,9 @@ func (e *SettingEngine) getSDPExtensions() map[SDPSectionType][]sdp.ExtMap {
 		}
 	}
 	return e.sdpExtensions
+}
+
+// SetProxyDialer sets the proxy dialer interface based on golang.org/x/net/proxy.
+func (e *SettingEngine) SetProxyDialer(d proxy.Dialer) {
+	e.proxyDialer = d
 }


### PR DESCRIPTION
#### Description
When Running pion webRTC behind a http or https proxy e.g a corporate proxy Dialing to turn server fails. This fix enables user to implement golang.org/x/net/proxy Dial interface and provide it to the ICE package via settingEngine.

#### Reference issue
Fixes #284

