### PR TITLE
Fix receiver close stream race close #1471

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Hanjun Kim](https://github.com/hallazzang)
 * [ZHENK](https://github.com/scorpionknifes)
 * [Rahul Nakre](https://github.com/rahulnakre)
+* [OrlandoCo](https://github.com/OrlandoCo)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -167,11 +167,15 @@ func (r *RTPReceiver) Stop() error {
 	select {
 	case <-r.received:
 		for i := range r.tracks {
-			if err := r.tracks[i].rtcpReadStream.Close(); err != nil {
-				return err
+			if r.tracks[i].rtcpReadStream != nil {
+				if err := r.tracks[i].rtcpReadStream.Close(); err != nil {
+					return err
+				}
 			}
-			if err := r.tracks[i].rtpReadStream.Close(); err != nil {
-				return err
+			if r.tracks[i].rtpReadStream != nil {
+				if err := r.tracks[i].rtpReadStream.Close(); err != nil {
+					return err
+				}
 			}
 		}
 	default:


### PR DESCRIPTION
#### Description
Fix a race on simulcast, where track or peer is removed before tracks are received.
#### Reference issue
Fixes #1471 

