### PR TITLE
Fix simulcast tracks not stopping on remove

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -992,7 +992,6 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 			}
 
 			t, localTransceivers = findByMid(midValue, localTransceivers)
-			// Fix simulcast tracks removing
 			if t != nil && t.Receiver() != nil && len(t.Receiver().Tracks()) > 1 {
 				switch direction {
 				case RTPTransceiverDirectionInactive:
@@ -1000,10 +999,8 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 						return err
 					}
 				case RTPTransceiverDirectionRecvonly:
-					if recv := t.Receiver(); recv != nil {
-						if err := recv.Stop(); err != nil {
-							return err
-						}
+					if err := t.Receiver().Stop(); err != nil {
+						return err
 					}
 				case RTPTransceiverDirectionSendonly, RTPTransceiverDirectionSendrecv:
 					t.setDirection(RTPTransceiverDirectionRecvonly)


### PR DESCRIPTION
#### Description

This commit fix the case where simulcast tracks are removed, and on the negotiation the receivers are not being stopped.

The transceivers receivers are stopped in the *PeerConnection.startRTP(l:2010) function but currently only supports non-simulcast tracks because it checks that the tracks has been removed by SSRC in SDP, since Simulcast does not use SSRC the only way to check if a track has been removed is to check mid direction.
