### PR TITLE
Found JS Errors when running JS fiddle code examples in safari

### DIFF
--- a/examples/reflect/README.md
+++ b/examples/reflect/README.md
@@ -9,7 +9,7 @@ go get github.com/pion/webrtc/v3/examples/reflect
 ```
 
 ### Open reflect example page
-[jsfiddle.net](https://jsfiddle.net/j3yhron4/) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/9jgukzt1/) you should see two text-areas and a 'Start Session' button.
 
 ### Run reflect, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/rtp-forwarder/README.md
+++ b/examples/rtp-forwarder/README.md
@@ -9,7 +9,7 @@ go get github.com/pion/webrtc/v3/examples/rtp-forwarder
 ```
 
 ### Open rtp-forwarder example page
-[jsfiddle.net](https://jsfiddle.net/sq69370h/) you should see your Webcam, two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/os73epj4/) you should see your Webcam, two text-areas and a 'Start Session' button
 
 ### Run rtp-forwarder, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/rtp-forwarder/jsfiddle/demo.js
+++ b/examples/rtp-forwarder/jsfiddle/demo.js
@@ -13,7 +13,8 @@ var log = msg => {
 
 navigator.mediaDevices.getUserMedia({ video: true, audio: true })
   .then(stream => {
-    pc.addStream(document.getElementById('video1').srcObject = stream)
+    stream.getTracks().forEach(track => pc.addTrack(track, stream));
+    
     pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
   }).catch(log)
 

--- a/examples/save-to-disk/README.md
+++ b/examples/save-to-disk/README.md
@@ -11,7 +11,7 @@ go get github.com/pion/webrtc/v3/examples/save-to-disk
 ```
 
 ### Open save-to-disk example page
-[jsfiddle.net](https://jsfiddle.net/b3d72av1/) you should see your Webcam, two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/vfmcg8rk/1/) you should see your Webcam, two text-areas and a 'Start Session' button
 
 ### Run save-to-disk, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/save-to-disk/jsfiddle/demo.js
+++ b/examples/save-to-disk/jsfiddle/demo.js
@@ -13,7 +13,10 @@ var log = msg => {
 
 navigator.mediaDevices.getUserMedia({ video: true, audio: true })
   .then(stream => {
-    pc.addStream(document.getElementById('video1').srcObject = stream)
+
+    document.getElementById('video1').srcObject = stream
+    stream.getTracks().forEach(track => pc.addTrack(track, stream));
+ 
     pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
   }).catch(log)
 


### PR DESCRIPTION
Logs: TypeError: pc.addStream is not a function. (In 'pc.addStream(displayVideo(stream))', 'pc.addStream' is undefined)
Fixed js error when using safari due to deprecated RTCPeerConnection.addStream() method.

Updated js fiddle examples to use the addTrack() method instead.
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream

#### Description

#### Reference issue
Fixes #...
