### PR TITLE
setDescription was incorrectly discarding errors

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -881,7 +881,7 @@ func (pc *PeerConnection) setDescription(sd *SessionDescription, op stateChangeO
 			return nextState, &rtcerr.OperationError{Err: fmt.Errorf("%w: %q", errPeerConnStateChangeUnhandled, op)}
 		}
 
-		return nextState, nil
+		return nextState, err
 	}()
 
 	if err == nil {

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -636,3 +636,19 @@ func TestGatherOnSetLocalDescription(t *testing.T) {
 	assert.NoError(t, pcOffer.Close())
 	assert.NoError(t, pcAnswer.Close())
 }
+
+// Assert that SetRemoteDescription handles invalid states
+func TestSetRemoteDescriptionInvalid(t *testing.T) {
+	t.Run("local-offer+SetRemoteDescription(Offer)", func(t *testing.T) {
+		pc, err := NewPeerConnection(Configuration{})
+		assert.NoError(t, err)
+
+		offer, err := pc.CreateOffer(nil)
+		assert.NoError(t, err)
+
+		assert.NoError(t, pc.SetLocalDescription(offer))
+		assert.Error(t, pc.SetRemoteDescription(offer))
+
+		assert.NoError(t, pc.Close())
+	})
+}


### PR DESCRIPTION
SetRemoteDescription was not properly returning errors. Fix and add test
to make sure we don't regress again in the future.

Resolves #1210
Resolves #1473
