### PR TITLE
Fix sender nil on negotiation check step 5.3.1

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -353,7 +353,7 @@ func (pc *PeerConnection) checkNegotiationNeeded() bool { //nolint:gocognit
 			// Step 5.3.1
 			if t.Direction() == RTPTransceiverDirectionSendrecv || t.Direction() == RTPTransceiverDirectionSendonly {
 				descMsid, okMsid := m.Attribute(sdp.AttrKeyMsid)
-				if !okMsid || descMsid != t.Sender().Track().Msid() {
+				if !okMsid || (t.Sender() != nil && descMsid != t.Sender().Track().Msid()) {
 					return true
 				}
 			}


### PR DESCRIPTION
#### Description
Fix race where negotiation check sender track, while sender still not created.
#### Reference issue
Fixes #1411
