### PR TITLE
Fix should renog if msid is missing and sender is nil

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -353,7 +353,7 @@ func (pc *PeerConnection) checkNegotiationNeeded() bool { //nolint:gocognit
 			// Step 5.3.1
 			if t.Direction() == RTPTransceiverDirectionSendrecv || t.Direction() == RTPTransceiverDirectionSendonly {
 				descMsid, okMsid := m.Attribute(sdp.AttrKeyMsid)
-				if !okMsid || (t.Sender() != nil && descMsid != t.Sender().Track().Msid()) {
+				if !okMsid || t.Sender() == nil || descMsid != t.Sender().Track().Msid() {
 					return true
 				}
 			}


### PR DESCRIPTION
#### Description

Fix an issue in renog step 5.3.1 when msid is missing but sender is nil, should renog to not generate an empty msid in sdp.