### PR TITLE
Add SessionDescription Unmarshal helper

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -964,8 +964,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 
 	isRenegotation := pc.currentRemoteDescription != nil
 
-	desc.parsed = &sdp.SessionDescription{}
-	if err := desc.parsed.Unmarshal([]byte(desc.SDP)); err != nil {
+	if _, err := desc.Unmarshal(); err != nil {
 		return err
 	}
 	if err := pc.setDescription(&desc, stateChangeOpSetRemote); err != nil {

--- a/sessiondescription.go
+++ b/sessiondescription.go
@@ -12,3 +12,14 @@ type SessionDescription struct {
 	// This will never be initialized by callers, internal use only
 	parsed *sdp.SessionDescription
 }
+
+// Unmarshal is a helper to deserialize the sdp, and re-use it internally
+// if required
+func (sd *SessionDescription) Unmarshal() (*sdp.SessionDescription, error) {
+	if sd.parsed != nil {
+		return sd.parsed, nil
+	}
+	sd.parsed = &sdp.SessionDescription{}
+	err := sd.parsed.Unmarshal([]byte(sd.SDP))
+	return sd.parsed, err
+}

--- a/sessiondescription_test.go
+++ b/sessiondescription_test.go
@@ -57,3 +57,23 @@ func TestSessionDescription_JSON(t *testing.T) {
 		)
 	}
 }
+
+func TestSessionDescription_Unmarshal(t *testing.T) {
+	pc, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+	offer, err := pc.CreateOffer(nil)
+	assert.NoError(t, err)
+	desc := SessionDescription{
+		Type: offer.Type,
+		SDP:  offer.SDP,
+	}
+	assert.Nil(t, desc.parsed)
+	parsed, err := desc.Unmarshal()
+	assert.NotNil(t, parsed)
+	assert.NotNil(t, desc.parsed)
+	assert.NoError(t, err)
+	parsed, err = desc.Unmarshal()
+	assert.NotNil(t, parsed)
+	assert.NoError(t, err)
+	pc.Close()
+}


### PR DESCRIPTION
#### Description

This will allow to re-use the internally parsed sdp, and prevent parsing multiple times and save some cpu cycles.