### PR TITLE
fix: nil sender for send transceiver

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -355,6 +355,13 @@ func (pc *PeerConnection) checkNegotiationNeeded() bool { //nolint:gocognit
 		if !t.stopped && m != nil {
 			// Step 5.3.1
 			if t.Direction() == RTPTransceiverDirectionSendrecv || t.Direction() == RTPTransceiverDirectionSendonly {
+				// non-cannon:
+				// if sender track is nil, transceivers were modified during
+				// current negotiation dont proceed
+				if t.Sender() == nil {
+					return false
+				}
+
 				descMsid, okMsid := m.Attribute(sdp.AttrKeyMsid)
 				if !okMsid || descMsid != t.Sender().Track().Msid() {
 					return true


### PR DESCRIPTION
there is a race condition where a `Send*` transceiver can be mutated during renegotiation to no longer have a sender. In this case, pion will throw. This pr attempts to resolve this. The assumption is that the mutation that triggered the race condition has queued it's own `onNegotiationNeeded`, so we can just end the current one early and let that one proceed

resolves #1494 