### PR TITLE
Add  h264reader and test for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [OrlandoCo](https://github.com/OrlandoCo)
 * [Assad Obaid](https://github.com/assadobaid)
 * [Jamie Good](https://github.com/jamiegood) - *Bug fix in jsfiddle example*
+* [Artur Shellunts](https://github.com/ashellunts)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/pkg/media/h264reader/h264reader.go
+++ b/pkg/media/h264reader/h264reader.go
@@ -1,0 +1,166 @@
+package h264reader
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+// H264Reader reads data from stream and constructs h264 nal units
+type H264Reader struct {
+	stream                      io.Reader
+	nalBuffer                   []byte
+	countOfConsecutiveZeroBytes int
+	nalPrefixParsed             bool
+}
+
+var (
+	errNilReader           = errors.New("stream is nil")
+	errReadData            = errors.New("error on data read")
+	errDataIsNotH264Stream = errors.New("data is not a H264 bitstream")
+	errNotEnoughData       = errors.New("not enough data")
+)
+
+// NewReader creates new H264Reader
+func NewReader(in io.Reader) (*H264Reader, error) {
+	if in == nil {
+		return nil, errNilReader
+	}
+
+	reader := &H264Reader{
+		stream:          in,
+		nalBuffer:       make([]byte, 0),
+		nalPrefixParsed: false,
+	}
+
+	return reader, nil
+}
+
+// NAL H.264 Network Abstraction Layer
+type NAL struct {
+	PictureOrderCount uint32
+
+	// NAL header
+	ForbiddenZeroBit bool
+	RefIdc           uint8
+	UnitType         NalUnitType
+
+	Data []byte // header byte + rbsp
+}
+
+func (reader *H264Reader) bitStreamStartsWithH264Prefix() (prefixLength int, e error) {
+	nalPrefix3Bytes := []byte{0, 0, 1}
+	nalPrefix4Bytes := []byte{0, 0, 0, 1}
+
+	prefixBuffer := make([]byte, 4)
+
+	n, err := reader.stream.Read(prefixBuffer)
+
+	if err != nil || n == 0 {
+		return 0, errReadData
+	}
+
+	if n < 3 {
+		return 0, errDataIsNotH264Stream
+	}
+
+	nalPrefix3BytesFound := bytes.Equal(nalPrefix3Bytes, prefixBuffer[:3])
+	if n == 3 {
+		if nalPrefix3BytesFound {
+			return 0, errNotEnoughData
+		}
+		return 0, errDataIsNotH264Stream
+	}
+
+	// n == 4
+	if nalPrefix3BytesFound {
+		reader.nalBuffer = append(reader.nalBuffer, prefixBuffer[3])
+		return 3, nil
+	}
+
+	nalPrefix4BytesFound := bytes.Equal(nalPrefix4Bytes, prefixBuffer)
+	if nalPrefix4BytesFound {
+		return 4, nil
+	}
+	return 0, errDataIsNotH264Stream
+}
+
+func (reader *H264Reader) NextNAL() (*NAL, error) {
+	if !reader.nalPrefixParsed {
+		_, err := reader.bitStreamStartsWithH264Prefix()
+		if err != nil {
+			return nil, err
+		}
+
+		reader.nalPrefixParsed = true
+	}
+
+	for {
+		buffer := make([]byte, 1)
+		n, err := reader.stream.Read(buffer)
+
+		if err != nil || n != 1 {
+			break
+		}
+		readByte := buffer[0]
+		nalFound := reader.processByte(readByte)
+		if nalFound {
+			nal := newNal(reader.nalBuffer)
+			nal.parseHeader()
+			if nal.UnitType == NalUnitTypeSEI {
+				reader.nalBuffer = nil
+				continue
+			} else {
+				break
+			}
+		}
+
+		reader.nalBuffer = append(reader.nalBuffer, readByte)
+	}
+
+	if len(reader.nalBuffer) == 0 {
+		return nil, errNotEnoughData
+	}
+
+	nal := newNal(reader.nalBuffer)
+	reader.nalBuffer = nil
+	nal.parseHeader()
+
+	return nal, nil
+}
+
+func (reader *H264Reader) processByte(readByte byte) (nalFound bool) {
+	nalFound = false
+
+	switch readByte {
+	case 0:
+		reader.countOfConsecutiveZeroBytes++
+	case 1:
+		if reader.countOfConsecutiveZeroBytes >= 2 {
+			countOfConsecutiveZeroBytesInPrefix := 2
+			if reader.countOfConsecutiveZeroBytes > 2 {
+				countOfConsecutiveZeroBytesInPrefix = 3
+			}
+			nalUnitLength := len(reader.nalBuffer) - countOfConsecutiveZeroBytesInPrefix
+			reader.nalBuffer = reader.nalBuffer[0:nalUnitLength]
+			nalFound = true
+		} else {
+			reader.countOfConsecutiveZeroBytes = 0
+		}
+	default:
+		reader.countOfConsecutiveZeroBytes = 0
+	}
+
+	return nalFound
+}
+
+func newNal(data []byte) *NAL {
+	return &NAL{PictureOrderCount: 0, ForbiddenZeroBit: false, RefIdc: 0, UnitType: NalUnitTypeUnspecified, Data: data}
+}
+
+func (h *NAL) parseHeader() {
+	firstByte := h.Data[0]
+	h.ForbiddenZeroBit = (((firstByte & 0x80) >> 7) == 1) // 0x80 = 0b10000000
+	h.RefIdc = (firstByte & 0x60) >> 5                    // 0x60 = 0b01100000
+	h.UnitType = NalUnitType((firstByte & 0x1F) >> 0)     // 0x1F = 0b00011111
+}

--- a/pkg/media/h264reader/h264reader_test.go
+++ b/pkg/media/h264reader/h264reader_test.go
@@ -1,0 +1,205 @@
+package h264reader
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func CreateReader(h264 []byte, assert *assert.Assertions) *H264Reader {
+	reader, err := NewReader(bytes.NewReader(h264))
+
+	assert.Nil(err)
+	assert.NotNil(reader)
+
+	return reader
+}
+
+func TestNoData(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	_, err := reader.NextNAL()
+	assert.NotNil(err)
+}
+
+func TestDataDoesNotStartWithH264Header1(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{2}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Equal(errDataIsNotH264Stream, err)
+	assert.Nil(nal)
+}
+
+func TestDataDoesNotStartWithH264Header2(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0, 2}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Equal(errDataIsNotH264Stream, err)
+	assert.Nil(nal)
+}
+
+func TestDataDoesNotStartWithH264Header3(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0, 0, 2}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Equal(errDataIsNotH264Stream, err)
+	assert.Nil(nal)
+}
+
+func TestDataDoesNotStartWithH264Header4(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0, 0, 2, 0}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Equal(errDataIsNotH264Stream, err)
+	assert.Nil(nal)
+}
+
+func TestDataDoesNotStartWithH264Header5(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0, 0, 0, 2}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Equal(errDataIsNotH264Stream, err)
+	assert.Nil(nal)
+}
+
+func TestParseHeader(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0x0, 0x0, 0x1, 0xAB}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Nil(err)
+
+	assert.Equal(1, len(nal.Data))
+	assert.True(nal.ForbiddenZeroBit)
+	assert.Equal(uint32(0), nal.PictureOrderCount)
+	assert.Equal(uint8(1), nal.RefIdc)
+	assert.Equal(NalUnitTypeEndOfStream, nal.UnitType)
+}
+
+func TestNotEnoughData1(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0, 0, 0, 1}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Equal(errNotEnoughData, err)
+	assert.Nil(nal)
+}
+
+func TestNotEnoughData2(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0, 0, 1}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Equal(errNotEnoughData, err)
+	assert.Nil(nal)
+}
+
+func TestTwoPrefixes1(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0x0, 0x0, 0x1, 0xAB, 0x0, 0x0, 0x1}
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Nil(err)
+	assert.Equal(1, len(nal.Data))
+}
+
+func TestTwoPrefixes3(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0x0, 0x0, 0x0, 0x1, 0xAB, 0x0, 0x0, 0x0, 0x01}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Nil(err)
+	assert.Equal(1, len(nal.Data))
+}
+
+func TestStreamEnd1(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0x0, 0x0, 0x0, 0x1, 0xAB}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Nil(err)
+	assert.Equal(1, len(nal.Data))
+
+	nal, err = reader.NextNAL()
+	assert.Equal(errNotEnoughData, err)
+	assert.Nil(nal)
+}
+
+func TestStreamEnd2(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0x0, 0x0, 0x0, 0x1, 0xAB, 0x0, 0x0, 0x1}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Nil(err)
+	assert.Equal(1, len(nal.Data))
+
+	nal, err = reader.NextNAL()
+	assert.Equal(errNotEnoughData, err)
+	assert.Nil(nal)
+}
+
+func Test2NALs(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{0x0, 0x0, 0x1, 0xAA, 0x0, 0x0, 0x1, 0xAB}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Nil(err)
+	assert.Equal(1, len(nal.Data))
+
+	nal, err = reader.NextNAL()
+	assert.Nil(err)
+	assert.Equal(1, len(nal.Data))
+}
+
+func TestSkipSEI(t *testing.T) {
+	assert := assert.New(t)
+	h264Bytes := []byte{
+		0x0, 0x0, 0x1, 0xAA,
+		0x0, 0x0, 0x1, 0x6,
+		0x0, 0x0, 0x1, 0xAB,
+	}
+
+	reader := CreateReader(h264Bytes, assert)
+
+	nal, err := reader.NextNAL()
+	assert.Nil(err)
+	assert.Equal(byte(0xAA), nal.Data[0])
+
+	nal, err = reader.NextNAL()
+	assert.Nil(err)
+	assert.Equal(byte(0xAB), nal.Data[0])
+}

--- a/pkg/media/h264reader/nalunittype.go
+++ b/pkg/media/h264reader/nalunittype.go
@@ -1,0 +1,66 @@
+package h264reader
+
+import "strconv"
+
+type NalUnitType uint8
+
+const (
+	NalUnitTypeUnspecified              NalUnitType = 0  // Unspecified
+	NalUnitTypeCodedSliceNonIdr         NalUnitType = 1  // Coded slice of a non-IDR picture
+	NalUnitTypeCodedSliceDataPartitionA NalUnitType = 2  // Coded slice data partition A
+	NalUnitTypeCodedSliceDataPartitionB NalUnitType = 3  // Coded slice data partition B
+	NalUnitTypeCodedSliceDataPartitionC NalUnitType = 4  // Coded slice data partition C
+	NalUnitTypeCodedSliceIdr            NalUnitType = 5  // Coded slice of an IDR picture
+	NalUnitTypeSEI                      NalUnitType = 6  // Supplemental enhancement information (SEI)
+	NalUnitTypeSPS                      NalUnitType = 7  // Sequence parameter set
+	NalUnitTypePPS                      NalUnitType = 8  // Picture parameter set
+	NalUnitTypeAUD                      NalUnitType = 9  // Access unit delimiter
+	NalUnitTypeEndOfSequence            NalUnitType = 10 // End of sequence
+	NalUnitTypeEndOfStream              NalUnitType = 11 // End of stream
+	NalUnitTypeFiller                   NalUnitType = 12 // Filler data
+	NalUnitTypeSpsExt                   NalUnitType = 13 // Sequence parameter set extension
+	NalUnitTypeCodedSliceAux            NalUnitType = 19 // Coded slice of an auxiliary coded picture without partitioning
+	// 14..18                                            // Reserved
+	// 20..23                                            // Reserved
+	// 24..31                                            // Unspecified
+)
+
+func (n *NalUnitType) String() string {
+	var str string
+	switch *n {
+	case 0:
+		str = "Unspecified"
+	case 1:
+		str = "CodedSliceNonIdr"
+	case 2:
+		str = "CodedSliceDataPartitionA"
+	case 3:
+		str = "CodedSliceDataPartitionB"
+	case 4:
+		str = "CodedSliceDataPartitionC"
+	case 5:
+		str = "CodedSliceIdr"
+	case 6:
+		str = "SEI"
+	case 7:
+		str = "SPS"
+	case 8:
+		str = "PPS"
+	case 9:
+		str = "AUD"
+	case 10:
+		str = "EndOfSequence"
+	case 11:
+		str = "EndOfStream"
+	case 12:
+		str = "Filler"
+	case 13:
+		str = "SpsExt"
+	case 19:
+		str = "NalUnitTypeCodedSliceAux"
+	default:
+		str = "Unknown"
+	}
+	str = str + "(" + strconv.FormatInt(int64(*n), 10) + ")"
+	return str
+}


### PR DESCRIPTION
Continuing work started by @chertov in https://github.com/pion/webrtc/pull/976

Moved h264reader from examples to inside library. And adapted little bit code to look like ivfreader.
For a moment it reads all frames in 1 call. It should be improved in later PRs.