### PR TITLE
Allow use custom ext maps values

### DIFF
--- a/sdp.go
+++ b/sdp.go
@@ -583,7 +583,11 @@ func answerExtMaps(remoteExtMaps map[SDPSectionType]map[int]sdp.ExtMap, localMap
 			// add remote ext that match locally available ones
 			for _, extMap := range localMaps[mediaType] {
 				if extMap.URI.String() == extItem.URI.String() {
-					ret[mediaType] = append(ret[mediaType], extItem)
+					if extMap.Value == 0 {
+						ret[mediaType] = append(ret[mediaType], extItem)
+					} else {
+						ret[mediaType] = append(ret[mediaType], extMap)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description

This commit will allow to set custom values for ext maps. If the SettingEngine local ext map values are not defined (zero value), Pion will use offered ext map values, if they are set Pion will offer an answer with predefined ext values.

