### PR TITLE
Add set custom ext map callback

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2117,7 +2117,14 @@ func (pc *PeerConnection) generateUnmatchedSDP(transceivers []*RTPTransceiver, u
 		return nil, err
 	}
 
-	return populateSDP(d, isPlanB, dtlsFingerprints, pc.api.settingEngine.sdpMediaLevelFingerprints, pc.api.settingEngine.candidates.ICELite, pc.api.mediaEngine, connectionRoleFromDtlsRole(defaultDtlsRoleOffer), candidates, iceParams, mediaSections, pc.ICEGatheringState(), pc.api.settingEngine.getSDPExtensions())
+	var unmatchedSDPMap map[SDPSectionType][]sdp.ExtMap
+	if pc.getMapExt != nil {
+		unmatchedSDPMap = pc.getMapExt()
+	} else {
+		unmatchedSDPMap = pc.api.settingEngine.sdpExtensions
+	}
+
+	return populateSDP(d, isPlanB, dtlsFingerprints, pc.api.settingEngine.sdpMediaLevelFingerprints, pc.api.settingEngine.candidates.ICELite, pc.api.mediaEngine, connectionRoleFromDtlsRole(defaultDtlsRoleOffer), candidates, iceParams, mediaSections, pc.ICEGatheringState(), unmatchedSDPMap)
 }
 
 // generateMatchedSDP generates a SDP and takes the remote state into account

--- a/sdp.go
+++ b/sdp.go
@@ -321,7 +321,11 @@ func addTransceiverSDP(d *sdp.SessionDescription, isPlanB, shouldAddCandidates b
 	}
 
 	// Add extmaps
-	if maps, ok := extMaps[SDPSectionType(t.kind.String())]; ok {
+	if maps, ok := extMaps[SDPSectionType(t.Mid())]; ok {
+		for _, m := range maps {
+			media.WithExtMap(m)
+		}
+	} else if maps, ok := extMaps[SDPSectionType(t.kind.String())]; ok {
 		for _, m := range maps {
 			media.WithExtMap(m)
 		}


### PR DESCRIPTION
#### Description

This PR will allow to se custom ext map headers per mid for transceivers, this way it support offering ext maps if not previously offer was given, it also allow to set map from different browsers if they are ordered different.

If the callback is not set it will fallback to default behaviour.