### PR TITLE
Minimize unused memory allocated in DataChannel.readLoop.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           go test \
           -coverprofile=cover.out -covermode=atomic \
+          -bench=. \
           -tags quic \
           -v -race ${TEST_PACKAGES}
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Artur Shellunts](https://github.com/ashellunts)
 * [Sean Knight](https://github.com/SeanKnight)
 * [o0olele](https://github.com/o0olele)
+* [Bo Shi](https://github.com/bshimc)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
See https://github.com/pion/webrtc/issues/1516

This patch preserves the semantics of the OnMessage handler and is more safe
but less efficient than the patch first described in #1516.

As expected, when run with GOMAXPROCS=1 there is opportunity for re-use and
syn.Pool is pure overhead.  As allocs/op increases due to sync.Pool overhead
but B/op and ns/op improve drastically.

    $ git co datachannel.go && \
      got test -bench=DataChannelSend -run=XXX \
      -benchmem -cpu=1,2,4,8 -count=10 > original.txt
    $ git co datachannel.go && git apply pool.patch && \
      go test -bench=DataChannelSend -run=XXX \
    	-benchmem -cpu=1,2,4,8 -count=10 > patched.txt

    $ benchstat original.txt patched.txt
    name               old time/op    new time/op    delta
    DataChannelSend      1.45µs ±35%    1.24µs ±40%      ~     (p=0.211 n=9+10)
    DataChannelSend-2     885ns ±14%    2221ns ±44%  +150.87%  (p=0.000 n=10+9)
    DataChannelSend-4    5.19µs ±15%    3.27µs ±16%   -37.13%  (p=0.000 n=9+10)
    DataChannelSend-8    8.07µs ±22%    3.97µs ± 4%   -50.78%  (p=0.000 n=10+8)

    name               old alloc/op   new alloc/op   delta
    DataChannelSend      1.67kB ±72%    0.31kB ±12%   -81.55%  (p=0.000 n=9+10)
    DataChannelSend-2    1.80kB ±21%    0.34kB ±14%   -81.14%  (p=0.000 n=10+8)
    DataChannelSend-4    1.47kB ±14%    1.40kB ± 0%    -4.39%  (p=0.031 n=10+8)
    DataChannelSend-8    2.18kB ±14%    1.45kB ± 0%   -33.57%  (p=0.000 n=9+8)

    name               old allocs/op  new allocs/op  delta
    DataChannelSend        6.00 ± 0%      6.80 ±18%   +13.33%  (p=0.008 n=8+10)
    DataChannelSend-2      6.00 ± 0%      8.11 ±36%   +35.19%  (p=0.000 n=10+9)
    DataChannelSend-4      7.00 ± 0%     37.00 ± 0%  +428.57%  (p=0.000 n=10+10)
    DataChannelSend-8      7.70 ± 9%     39.00 ± 0%  +406.49%  (p=0.000 n=10+7)

#### Description

#### Reference issue
Fixes #...
