### PR TITLE
Fix the default value for previousTimestamp.

### DIFF
--- a/pkg/media/oggwriter/oggwriter.go
+++ b/pkg/media/oggwriter/oggwriter.go
@@ -182,7 +182,7 @@ func (i *OggWriter) WriteRTP(packet *rtp.Packet) error {
 	payload := opusPacket.Payload[0:]
 
 	// Should be equivalent to sampleRate * duration
-	if i.previousTimestamp != 0 {
+	if i.previousTimestamp != 1 {
 		increment := packet.Timestamp - i.previousTimestamp
 		i.previousGranulePosition += uint64(increment)
 	}


### PR DESCRIPTION
#### Description
The default value for previousTimestamp is 1 instead of 0. The playback time of the ogg file created by it is supposed to be strange.

The following is where the initial value is substituted
https://github.com/BambooTuna/webrtc/blob/512b2c5fdbd8fa8734ae8f56962c007632e222b9/pkg/media/oggwriter/oggwriter.go#L73

Is this how to issue a modified PR?

#### Reference issue
Fixes #1537 
