### PR TITLE
Use rtp.Packet instead of *rtp.Packet in APIs

### DIFF
--- a/track_local_static.go
+++ b/track_local_static.go
@@ -107,10 +107,12 @@ func (s *TrackLocalStaticRTP) WriteRTP(p *rtp.Packet) error {
 	defer s.mu.RUnlock()
 
 	writeErrs := []error{}
+	outboundPacket := *p
+
 	for _, b := range s.bindings {
-		p.Header.SSRC = uint32(b.ssrc)
-		p.Header.PayloadType = uint8(b.payloadType)
-		if _, err := b.writeStream.WriteRTP(&p.Header, p.Payload); err != nil {
+		outboundPacket.Header.SSRC = uint32(b.ssrc)
+		outboundPacket.Header.PayloadType = uint8(b.payloadType)
+		if _, err := b.writeStream.WriteRTP(&outboundPacket.Header, outboundPacket.Payload); err != nil {
 			writeErrs = append(writeErrs, err)
 		}
 	}


### PR DESCRIPTION
Reduce a sharp edge in the public API. Before we would keep a reference
internally. Users would be suprised when values on the passed
*rtp.Packet would change.

TODO write Benchmark