### PR TITLE
Compute the track's MSID to compare with the one in the SDP.

### DIFF
--- a/.github/.ci.conf
+++ b/.github/.ci.conf
@@ -1,4 +1,4 @@
 GO_JS_WASM_EXEC=${PWD}/test-wasm/go_js_wasm_exec
 TEST_EXTRA_ARGS="-tags quic"
 GOLANGCI_LINT_EXRA_ARGS="--build-tags quic"
-EXCLUDED_CONTRIBUTORS=('Josh Bleecher Snyder')
+EXCLUDED_CONTRIBUTORS=('Josh Bleecher Snyder' 'Sidney San Martín')

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Henry](https://github.com/cryptix)
 * [Jeff Tchang](https://github.com/tachang)
 * [JooYoung Lim](https://github.com/DevRockstarZ)
-* [Sidney San Martín](https://github.com/s4y)
+* [Sidney San Martín](https://github.com/s4y)
 * [soolaugust](https://github.com/soolaugust)
 * [Kuzmin Vladimir](https://github.com/tekig)
 * [Alessandro Ros](https://github.com/aler9)

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -354,7 +354,8 @@ func (pc *PeerConnection) checkNegotiationNeeded() bool { //nolint:gocognit
 			// Step 5.3.1
 			if t.Direction() == RTPTransceiverDirectionSendrecv || t.Direction() == RTPTransceiverDirectionSendonly {
 				descMsid, okMsid := m.Attribute(sdp.AttrKeyMsid)
-				if !okMsid || descMsid != t.Sender().Track().StreamID() {
+				track := t.Sender().Track()
+				if !okMsid || descMsid != track.StreamID()+" "+track.ID() {
 					return true
 				}
 			}


### PR DESCRIPTION
#### Description
I noticed that, when using the `OnNegotiationNeeded` callback, I got called back continuously, every time a negotiation finished. As far as I can tell, this is because `checkNegotiationNeeded()` was comparing an MSID against `track.StreamID()`, which isn't quite an MSID, so it never matched.