### PR TITLE
Don't run OnNegotiationNeeded if handler not set

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -271,6 +271,11 @@ func (pc *PeerConnection) onNegotiationNeeded() {
 }
 
 func (pc *PeerConnection) negotiationNeededOp() {
+	// Don't run NegotiatedNeeded checks if OnNegotiationNeeded is not set
+	if handler := pc.onNegotiationNeededHandler.Load(); handler == nil {
+		return
+	}
+
 	// https://www.w3.org/TR/webrtc/#updating-the-negotiation-needed-flag
 	// Step 2.1
 	if pc.isClosed.get() {


### PR DESCRIPTION
Reduce the amount of code that is running if we don't need this.

Relates to #1494