### PR TITLE
Export SSRC for RTPSender and RTPReceiver.

### DIFF
--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -69,6 +69,19 @@ func (r *RTPReceiver) GetParameters() RTPParameters {
 	return r.api.mediaEngine.getRTPParametersByKind(r.kind, []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly})
 }
 
+// SSRC returns the SSRC used by the receiver.  If the receiver is doing
+// simulcast, then this returns 0.
+// This is not available in WASM.
+func (r *RTPReceiver) SSRC() SSRC {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.tracks) != 1 {
+		return 0
+	}
+	return r.tracks[0].track.ssrc
+}
+
 // Track returns the RtpTransceiver TrackRemote
 func (r *RTPReceiver) Track() *TrackRemote {
 	r.mu.RLock()

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -96,6 +96,12 @@ func (r *RTPSender) GetParameters() RTPParameters {
 	return r.api.mediaEngine.getRTPParametersByKind(r.track.Kind(), []RTPTransceiverDirection{RTPTransceiverDirectionSendonly})
 }
 
+// SSRC returns the SSRC used by the sender.
+// This is not available in WASM.
+func (r *RTPSender) SSRC() SSRC {
+	return r.ssrc
+}
+
 // Track returns the RTCRtpTransceiver track, or nil
 func (r *RTPSender) Track() TrackLocal {
 	r.mu.RLock()


### PR DESCRIPTION
This allows retrieving the SSRC for RTPSender and RTPReceiver
in the non-simulcast case.

#### Description

Issues to discuss:
 * what is the right thing to do in the simulcast case?  I'm currently returning 0, which is not a legal SSID if memory serves.
 * what should be done in the WASM case?  Currently, the method is not defined; the alternative would be to return 0.
#### Reference issue
Fixes #1575.
