### PR TITLE
Fix RTPSendParameters.

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1236,10 +1236,12 @@ func (pc *PeerConnection) startRTPSenders(currentTransceivers []*RTPTransceiver)
 	for _, transceiver := range currentTransceivers {
 		if transceiver.Sender() != nil && transceiver.Sender().isNegotiated() && !transceiver.Sender().hasSent() {
 			err := transceiver.Sender().Send(RTPSendParameters{
-				Encodings: RTPEncodingParameters{
-					RTPCodingParameters{
-						SSRC:        transceiver.Sender().ssrc,
-						PayloadType: transceiver.Sender().payloadType,
+				Encodings: []RTPEncodingParameters{
+					{
+						RTPCodingParameters{
+							SSRC:        transceiver.Sender().ssrc,
+							PayloadType: transceiver.Sender().payloadType,
+						},
 					},
 				},
 			})

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -92,8 +92,17 @@ func (r *RTPSender) Transport() *DTLSTransport {
 
 // GetParameters describes the current configuration for the encoding and
 // transmission of media on the sender's track.
-func (r *RTPSender) GetParameters() RTPParameters {
-	return r.api.mediaEngine.getRTPParametersByKind(r.track.Kind(), []RTPTransceiverDirection{RTPTransceiverDirectionSendonly})
+func (r *RTPSender) GetParameters() RTPSendParameters {
+	return RTPSendParameters{
+		Encodings: []RTPEncodingParameters{
+			{
+				RTPCodingParameters: RTPCodingParameters{
+					SSRC:        r.ssrc,
+					PayloadType: r.payloadType,
+				},
+			},
+		},
+	}
 }
 
 // Track returns the RTCRtpTransceiver track, or nil
@@ -148,7 +157,7 @@ func (r *RTPSender) Send(parameters RTPSendParameters) error {
 	r.context = TrackLocalContext{
 		id:          r.id,
 		params:      r.api.mediaEngine.getRTPParametersByKind(r.track.Kind(), []RTPTransceiverDirection{RTPTransceiverDirectionSendonly}),
-		ssrc:        parameters.Encodings.SSRC,
+		ssrc:        parameters.Encodings[0].SSRC,
 		writeStream: writeStream,
 	}
 

--- a/rtpsendparameters.go
+++ b/rtpsendparameters.go
@@ -2,5 +2,5 @@ package webrtc
 
 // RTPSendParameters contains the RTP stack settings used by receivers
 type RTPSendParameters struct {
-	Encodings RTPEncodingParameters
+	Encodings []RTPEncodingParameters
 }


### PR DESCRIPTION
RTPSendParameters contains an array of encodings.
RTPSender.GetParameters returns RTPSendParameters.

#### Description

Both these changes bring us closer to the Javascript API.

#### Reference issue
Fixes #1575.
