### PR TITLE
Export mime types

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -14,13 +14,27 @@ import (
 )
 
 const (
-	mimeTypeH264 = "video/h264"
-	mimeTypeOpus = "audio/opus"
-	mimeTypeVP8  = "video/vp8"
-	mimeTypeVP9  = "video/vp9"
-	mimeTypeG722 = "audio/G722"
-	mimeTypePCMU = "audio/PCMU"
-	mimeTypePCMA = "audio/PCMA"
+	// MimeTypeH264 H264 MIME type.
+	// Note: Matching should be case insensitive.
+	MimeTypeH264 = "video/h264"
+	// MimeTypeOpus Opus MIME type
+	// Note: Matching should be case insensitive.
+	MimeTypeOpus = "audio/opus"
+	// MimeTypeVP8 VP8 MIME type
+	// Note: Matching should be case insensitive.
+	MimeTypeVP8 = "video/vp8"
+	// MimeTypeVP9 VP9 MIME type
+	// Note: Matching should be case insensitive.
+	MimeTypeVP9 = "video/vp9"
+	// MimeTypeG722 G722 MIME type
+	// Note: Matching should be case insensitive.
+	MimeTypeG722 = "audio/G722"
+	// MimeTypePCMU PCMU MIME type
+	// Note: Matching should be case insensitive.
+	MimeTypePCMU = "audio/PCMU"
+	// MimeTypePCMA PCMA MIME type
+	// Note: Matching should be case insensitive.
+	MimeTypePCMA = "audio/PCMA"
 )
 
 type mediaEngineHeaderExtension struct {
@@ -51,19 +65,19 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 	// Default Pion Audio Codecs
 	for _, codec := range []RTPCodecParameters{
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeOpus, 48000, 2, "minptime=10;useinbandfec=1", nil},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 2, "minptime=10;useinbandfec=1", nil},
 			PayloadType:        111,
 		},
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeG722, 8000, 0, "", nil},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeG722, 8000, 0, "", nil},
 			PayloadType:        9,
 		},
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypePCMU, 8000, 0, "", nil},
+			RTPCodecCapability: RTPCodecCapability{MimeTypePCMU, 8000, 0, "", nil},
 			PayloadType:        0,
 		},
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypePCMA, 8000, 0, "", nil},
+			RTPCodecCapability: RTPCodecCapability{MimeTypePCMA, 8000, 0, "", nil},
 			PayloadType:        8,
 		},
 	} {
@@ -86,7 +100,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 	videoRTCPFeedback := []RTCPFeedback{{"goog-remb", ""}, {"ccm", "fir"}, {"nack", ""}, {"nack", "pli"}}
 	for _, codec := range []RTPCodecParameters{
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeVP8, 90000, 0, "", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP8, 90000, 0, "", videoRTCPFeedback},
 			PayloadType:        96,
 		},
 		{
@@ -95,7 +109,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeVP9, 90000, 0, "profile-id=0", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP9, 90000, 0, "profile-id=0", videoRTCPFeedback},
 			PayloadType:        98,
 		},
 		{
@@ -104,7 +118,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeVP9, 90000, 0, "profile-id=1", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP9, 90000, 0, "profile-id=1", videoRTCPFeedback},
 			PayloadType:        100,
 		},
 		{
@@ -113,7 +127,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f", videoRTCPFeedback},
 			PayloadType:        102,
 		},
 		{
@@ -122,7 +136,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f", videoRTCPFeedback},
 			PayloadType:        127,
 		},
 		{
@@ -131,7 +145,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f", videoRTCPFeedback},
 			PayloadType:        125,
 		},
 		{
@@ -140,7 +154,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f", videoRTCPFeedback},
 			PayloadType:        108,
 		},
 		{
@@ -149,7 +163,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f", videoRTCPFeedback},
 			PayloadType:        127,
 		},
 		{
@@ -158,7 +172,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 
 		{
-			RTPCodecCapability: RTPCodecCapability{mimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032", videoRTCPFeedback},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeH264, 90000, 0, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032", videoRTCPFeedback},
 			PayloadType:        123,
 		},
 		{
@@ -480,17 +494,17 @@ func (m *MediaEngine) getRTPParametersByPayloadType(payloadType PayloadType) (RT
 
 func payloaderForCodec(codec RTPCodecCapability) (rtp.Payloader, error) {
 	switch strings.ToLower(codec.MimeType) {
-	case mimeTypeH264:
+	case MimeTypeH264:
 		return &codecs.H264Payloader{}, nil
-	case mimeTypeOpus:
+	case MimeTypeOpus:
 		return &codecs.OpusPayloader{}, nil
-	case mimeTypeVP8:
+	case MimeTypeVP8:
 		return &codecs.VP8Payloader{}, nil
-	case mimeTypeVP9:
+	case MimeTypeVP9:
 		return &codecs.VP9Payloader{}, nil
-	case mimeTypeG722:
+	case MimeTypeG722:
 		return &codecs.G722Payloader{}, nil
-	case mimeTypePCMU, mimeTypePCMA:
+	case MimeTypePCMU, MimeTypePCMA:
 		return &codecs.G711Payloader{}, nil
 	default:
 		return nil, ErrNoPayloaderForCodec

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -66,7 +66,7 @@ a=fmtp:111 minptime=10; useinbandfec=1
 
 		opusCodec, _, err := m.getCodecByPayload(111)
 		assert.NoError(t, err)
-		assert.Equal(t, opusCodec.MimeType, mimeTypeOpus)
+		assert.Equal(t, opusCodec.MimeType, MimeTypeOpus)
 	})
 
 	t.Run("Change Payload Type", func(t *testing.T) {
@@ -91,7 +91,7 @@ a=fmtp:112 minptime=10; useinbandfec=1
 
 		opusCodec, _, err := m.getCodecByPayload(112)
 		assert.NoError(t, err)
-		assert.Equal(t, opusCodec.MimeType, mimeTypeOpus)
+		assert.Equal(t, opusCodec.MimeType, MimeTypeOpus)
 	})
 
 	t.Run("Case Insensitive", func(t *testing.T) {
@@ -134,7 +134,7 @@ a=rtpmap:111 opus/48000/2
 
 		opusCodec, _, err := m.getCodecByPayload(111)
 		assert.NoError(t, err)
-		assert.Equal(t, opusCodec.MimeType, mimeTypeOpus)
+		assert.Equal(t, opusCodec.MimeType, MimeTypeOpus)
 	})
 
 	t.Run("Header Extensions", func(t *testing.T) {
@@ -174,7 +174,7 @@ func TestMediaEngineHeaderExtensionDirection(t *testing.T) {
 	registerCodec := func(m *MediaEngine) {
 		assert.NoError(t, m.RegisterCodec(
 			RTPCodecParameters{
-				RTPCodecCapability: RTPCodecCapability{mimeTypeOpus, 48000, 0, "", nil},
+				RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 0, "", nil},
 				PayloadType:        111,
 			}, RTPCodecTypeAudio))
 	}

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -434,7 +434,7 @@ func TestCodecsFromMediaDescription(t *testing.T) {
 
 		assert.Equal(t, codecs, []RTPCodecParameters{
 			{
-				RTPCodecCapability: RTPCodecCapability{mimeTypeOpus, 48000, 2, "", []RTCPFeedback{}},
+				RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 2, "", []RTCPFeedback{}},
 				PayloadType:        111,
 			},
 		})
@@ -457,7 +457,7 @@ func TestCodecsFromMediaDescription(t *testing.T) {
 
 		assert.Equal(t, codecs, []RTPCodecParameters{
 			{
-				RTPCodecCapability: RTPCodecCapability{mimeTypeOpus, 48000, 2, "minptime=10;useinbandfec=1", []RTCPFeedback{{"goog-remb", ""}, {"ccm", "fir"}}},
+				RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 2, "minptime=10;useinbandfec=1", []RTCPFeedback{{"goog-remb", ""}, {"ccm", "fir"}}},
 				PayloadType:        111,
 			},
 		})


### PR DESCRIPTION
Export mime types from media engine for matching. Helpful when trying to get codec from a track