### PR TITLE
Fix Simulcast routine leak

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -15,5 +15,11 @@ const (
 	// mid and rid values
 	simulcastProbeCount = 10
 
+	// simulcastMaxProbeRoutines is how many active routines can be used to probe
+	// If the total amount of incoming SSRCes exceeds this new requests will be ignored
+	simulcastMaxProbeRoutines = 25
+
 	mediaSectionApplication = "application"
+
+	rtpOutboundMTU = 1200
 )

--- a/errors.go
+++ b/errors.go
@@ -144,6 +144,9 @@ var (
 	// ErrRegisterHeaderExtensionInvalidDirection indicates that a extension was registered with a direction besides `sendonly` or `recvonly`
 	ErrRegisterHeaderExtensionInvalidDirection = errors.New("a header extension must be registered as 'recvonly', 'sendonly' or both")
 
+	// ErrSimulcastProbeOverflow indicates that too many Simulcast probe streams are in flight and the requested SSRC was ignored
+	ErrSimulcastProbeOverflow = errors.New("simulcast probe limit has been reached, new SSRC has been discarded")
+
 	errDetachNotEnabled                 = errors.New("enable detaching by calling webrtc.DetachDataChannels()")
 	errDetachBeforeOpened               = errors.New("datachannel not opened yet, try calling Detach from OnOpen")
 	errDtlsTransportNotStarted          = errors.New("the DTLS transport has not started yet")

--- a/webrtc.go
+++ b/webrtc.go
@@ -15,7 +15,3 @@ type SSRC uint32
 //
 // https://tools.ietf.org/html/rfc3550#section-3
 type PayloadType uint8
-
-const (
-	rtpOutboundMTU = 1200
-)


### PR DESCRIPTION
When a new SSRC is seen we start a Read loop for the packets. However if
we only see one packet this loop will just sit forever. If a user
doesn't send us enough packets to finish probing it will prevent any
subsequent streams from being probed.

Relates to #1345
