### PR TITLE
Fix interceptorTrackLocalWriter.WriteRTP cast

### DIFF
--- a/interceptor_track_local.go
+++ b/interceptor_track_local.go
@@ -19,11 +19,9 @@ func (i *interceptorTrackLocalWriter) setRTPWriter(writer interceptor.RTPWriter)
 }
 
 func (i *interceptorTrackLocalWriter) WriteRTP(header *rtp.Header, payload []byte) (int, error) {
-	writer := i.rtpWriter.Load().(interceptor.RTPWriter)
-
-	if writer == nil {
-		return 0, nil
+	if writer, ok := i.rtpWriter.Load().(interceptor.RTPWriter); ok && writer != nil {
+		return writer.Write(&rtp.Packet{Header: *header, Payload: payload}, make(interceptor.Attributes))
 	}
 
-	return writer.Write(&rtp.Packet{Header: *header, Payload: payload}, make(interceptor.Attributes))
+	return 0, nil
 }


### PR DESCRIPTION
Before we would panic if atomic was nil. Add a type assert as well so
that we handle gracefully.

Resolves #1585
