### PR TITLE
Don't leak ICETransport routines

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -215,4 +215,6 @@ var (
 	errSignalingStateProposedTransitionInvalid = errors.New("invalid proposed signaling state transition")
 
 	errStatsICECandidateStateInvalid = errors.New("cannot convert to StatsICECandidatePairStateSucceeded invalid ice candidate state")
+
+	errICETransportNotInNew = errors.New("ICETransport can only be called in ICETransportStateNew")
 )


### PR DESCRIPTION
We didn't properly pass a context to the ICE Agent. We would leak
routines if closed while connecting.