### PR TITLE
Update mediaengine.go // Fixe the mimeType like PCMU

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -504,7 +504,7 @@ func payloaderForCodec(codec RTPCodecCapability) (rtp.Payloader, error) {
 		return &codecs.VP9Payloader{}, nil
 	case strings.ToLower(MimeTypeG722):
 		return &codecs.G722Payloader{}, nil
-	case strings.ToLower(MimeTypePCMU, MimeTypePCMA):
+		case strings.ToLower(MimeTypePCMU), strings.ToLower(MimeTypePCMA):
 		return &codecs.G711Payloader{}, nil
 	default:
 		return nil, ErrNoPayloaderForCodec

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -494,17 +494,17 @@ func (m *MediaEngine) getRTPParametersByPayloadType(payloadType PayloadType) (RT
 
 func payloaderForCodec(codec RTPCodecCapability) (rtp.Payloader, error) {
 	switch strings.ToLower(codec.MimeType) {
-	case MimeTypeH264:
+	case  strings.ToLower(MimeTypeH264):
 		return &codecs.H264Payloader{}, nil
-	case MimeTypeOpus:
+	case strings.ToLower(MimeTypeOpus):
 		return &codecs.OpusPayloader{}, nil
-	case MimeTypeVP8:
+	case strings.ToLower(MimeTypeVP8):
 		return &codecs.VP8Payloader{}, nil
-	case MimeTypeVP9:
+	case strings.ToLower(MimeTypeVP9):
 		return &codecs.VP9Payloader{}, nil
-	case MimeTypeG722:
+	case strings.ToLower(MimeTypeG722):
 		return &codecs.G722Payloader{}, nil
-	case MimeTypePCMU, MimeTypePCMA:
+	case strings.ToLower(MimeTypePCMU, MimeTypePCMA):
 		return &codecs.G711Payloader{}, nil
 	default:
 		return nil, ErrNoPayloaderForCodec

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -504,7 +504,7 @@ func payloaderForCodec(codec RTPCodecCapability) (rtp.Payloader, error) {
 		return &codecs.VP9Payloader{}, nil
 	case strings.ToLower(MimeTypeG722):
 		return &codecs.G722Payloader{}, nil
-		case strings.ToLower(MimeTypePCMU), strings.ToLower(MimeTypePCMA):
+	case strings.ToLower(MimeTypePCMU), strings.ToLower(MimeTypePCMA):
 		return &codecs.G711Payloader{}, nil
 	default:
 		return nil, ErrNoPayloaderForCodec


### PR DESCRIPTION
#### Description
Compares lowercase to lowercase because even if we use your mimetypes, it compares "audio/pcmu" to "audio/PCMU".

