### PR TITLE
Improve documentation of NewPeerConnection

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pion/rtp"
 )
 
-// RegisterDefaultInterceptors will register some useful interceptors. If you want to customize which interceptors are loaded,
-// you should copy the code from this method and remove unwanted interceptors.
+// RegisterDefaultInterceptors will register some useful interceptors.
+// This is currently limited to sending and responding to NACKs.
 func RegisterDefaultInterceptors(mediaEngine *MediaEngine, interceptorRegistry *interceptor.Registry) error {
 	if err := ConfigureNack(mediaEngine, interceptorRegistry); err != nil {
 		return err

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -81,8 +81,12 @@ type PeerConnection struct {
 	interceptorRTCPWriter interceptor.RTCPWriter
 }
 
-// NewPeerConnection creates a peerconnection with the default
-// codecs. See API.NewPeerConnection for details.
+// NewPeerConnection creates a PeerConnection with the default codecs and
+// interceptors.  See RegisterDefaultCodecs and RegisterDefaultInterceptors.
+//
+// If you wish to customise the set of available codecs or the set of
+// active interceptors, create a MediaEngine and call api.NewPeerConnection
+// instead of this function.
 func NewPeerConnection(configuration Configuration) (*PeerConnection, error) {
 	m := &MediaEngine{}
 	if err := m.RegisterDefaultCodecs(); err != nil {


### PR DESCRIPTION
It is important to mention that, unlike API.NewPeerConnection, this
registers default interceptors.

#### Description

This is an incompatible change in v3, make sure it is documented.
