### PR TITLE
Added SetReadDeadline to RTPReceiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Suzuki Takeo](https://github.com/BambooTuna)
 * [baiyufei](https://github.com/baiyufei)
 * [pascal-ace](https://github.com/pascal-ace)
+* [Threadnaught](https://github.com/Threadnaught)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pion/sctp v1.7.11
 	github.com/pion/sdp/v3 v3.0.3
 	github.com/pion/srtp/v2 v2.0.0
-	github.com/pion/transport v0.12.0
+	github.com/pion/transport v0.12.1
 	github.com/sclevine/agouti v3.0.0+incompatible
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20201201195509-5d6afe98e0b7

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/pion/transport v0.10.0/go.mod h1:BnHnUipd0rZQyTVB2SBGojFHT9CBt5C5TcsJ
 github.com/pion/transport v0.10.1/go.mod h1:PBis1stIILMiis0PewDw91WJeLJkyIMcEk+DwKOzf4A=
 github.com/pion/transport v0.12.0 h1:UFmOBBZkTZ3LgvLRf/NGrfWdZEubcU6zkLU3PsA9YvU=
 github.com/pion/transport v0.12.0/go.mod h1:N3+vZQD9HlDP5GWkZ85LohxNsDcNgofQmyL6ojX5d8Q=
+github.com/pion/transport v0.12.1 h1:6v8lxQGVZpwSICEZjhl/CCv6aErINZlrm3O5ncFXj/c=
+github.com/pion/transport v0.12.1/go.mod h1:N3+vZQD9HlDP5GWkZ85LohxNsDcNgofQmyL6ojX5d8Q=
 github.com/pion/turn/v2 v2.0.5 h1:iwMHqDfPEDEOFzwWKT56eFmh6DYC6o/+xnLAEzgISbA=
 github.com/pion/turn/v2 v2.0.5/go.mod h1:APg43CFyt/14Uy7heYUOGWdkem/Wu4PhCO/bjyrTqMw=
 github.com/pion/udp v0.1.0 h1:uGxQsNyrqG3GLINv36Ff60covYmfrLoxzwnCsIYspXI=

--- a/rtpreceiver_test.go
+++ b/rtpreceiver_test.go
@@ -1,0 +1,73 @@
+// +build !js
+
+package webrtc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/transport/packetio"
+	"github.com/pion/transport/test"
+	"github.com/pion/webrtc/v3/pkg/media"
+	"github.com/stretchr/testify/assert"
+)
+
+// Assert that SetReadDeadline works as expected
+// This test uses VNet since we must have zero loss
+func Test_RTPSender_SetReadDeadline(t *testing.T) {
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	sender, receiver, wan := createVNetPair(t)
+
+	track, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: "video/vp8"}, "video", "pion")
+	assert.NoError(t, err)
+
+	_, err = sender.AddTrack(track)
+	assert.NoError(t, err)
+
+	seenPacket, seenPacketCancel := context.WithCancel(context.Background())
+	receiver.OnTrack(func(trackRemote *TrackRemote, r *RTPReceiver) {
+		// Set Deadline for both RTP and RTCP Stream
+		assert.NoError(t, r.SetReadDeadline(time.Now().Add(time.Second)))
+		assert.NoError(t, trackRemote.SetReadDeadline(time.Now().Add(time.Second)))
+
+		// First call will not error because we cache for probing
+		_, _, readErr := trackRemote.ReadRTP()
+		assert.NoError(t, readErr)
+
+		_, _, readErr = trackRemote.ReadRTP()
+		assert.Error(t, readErr, packetio.ErrTimeout)
+
+		_, _, readErr = r.ReadRTCP()
+		assert.Error(t, readErr, packetio.ErrTimeout)
+
+		seenPacketCancel()
+	})
+
+	var peerConnectionsConnected sync.WaitGroup
+	peerConnectionsConnected.Add(2)
+
+	hdlr := func(p PeerConnectionState) {
+		if p == PeerConnectionStateConnected {
+			peerConnectionsConnected.Done()
+		}
+	}
+	sender.OnConnectionStateChange(hdlr)
+	receiver.OnConnectionStateChange(hdlr)
+
+	assert.NoError(t, signalPair(sender, receiver))
+
+	peerConnectionsConnected.Wait()
+	assert.NoError(t, track.WriteSample(media.Sample{Data: []byte{0xAA}, Duration: time.Second}))
+
+	<-seenPacket.Done()
+	assert.NoError(t, wan.Stop())
+	assert.NoError(t, sender.Close())
+	assert.NoError(t, receiver.Close())
+}

--- a/track_remote.go
+++ b/track_remote.go
@@ -4,6 +4,7 @@ package webrtc
 
 import (
 	"sync"
+	"time"
 
 	"github.com/pion/interceptor"
 	"github.com/pion/rtp"
@@ -174,4 +175,9 @@ func (t *TrackRemote) peek(b []byte) (n int, a interceptor.Attributes, err error
 	t.peekedAttributes = a
 	t.mu.Unlock()
 	return
+}
+
+// SetReadDeadline sets the max amount of time the RTP stream will block before returning. 0 is forever.
+func (t *TrackRemote) SetReadDeadline(deadline time.Time) error {
+	return t.receiver.setRTPReadDeadline(deadline)
 }

--- a/vnet_test.go
+++ b/vnet_test.go
@@ -44,10 +44,14 @@ func createVNetPair(t *testing.T) (*PeerConnection, *PeerConnection, *vnet.Route
 	// Start the virtual network by calling Start() on the root router
 	assert.NoError(t, wan.Start())
 
-	offerPeerConnection, err := NewAPI(WithSettingEngine(offerSettingEngine)).NewPeerConnection(Configuration{})
+	offerMediaEngine := &MediaEngine{}
+	assert.NoError(t, offerMediaEngine.RegisterDefaultCodecs())
+	offerPeerConnection, err := NewAPI(WithSettingEngine(offerSettingEngine), WithMediaEngine(offerMediaEngine)).NewPeerConnection(Configuration{})
 	assert.NoError(t, err)
 
-	answerPeerConnection, err := NewAPI(WithSettingEngine(answerSettingEngine)).NewPeerConnection(Configuration{})
+	answerMediaEngine := &MediaEngine{}
+	assert.NoError(t, answerMediaEngine.RegisterDefaultCodecs())
+	answerPeerConnection, err := NewAPI(WithSettingEngine(answerSettingEngine), WithMediaEngine(answerMediaEngine)).NewPeerConnection(Configuration{})
 	assert.NoError(t, err)
 
 	return offerPeerConnection, answerPeerConnection, wan


### PR DESCRIPTION
#### Added SetReadDeadline to RTPReceiver

Previously, Reading RTP or RTCP packets from a peer would block until a packet was received, or the connection was terminated. This change allows you to set a deadline, after which the read function will return a timeout error and you can get on with other things.