### PR TITLE
populate TrackRemote with mid when available

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1162,6 +1162,7 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 		receiver.Track().kind = receiver.kind
 		receiver.Track().codec = params.Codecs[0]
 		receiver.Track().params = params
+		receiver.Track().mid = incoming.mid
 		receiver.Track().mu.Unlock()
 
 		pc.onTrack(receiver.Track(), receiver)

--- a/track_remote.go
+++ b/track_remote.go
@@ -23,6 +23,7 @@ type TrackRemote struct {
 	codec       RTPCodecParameters
 	params      RTPParameters
 	rid         string
+	mid         string
 
 	receiver         *RTPReceiver
 	peeked           []byte
@@ -55,6 +56,15 @@ func (t *TrackRemote) RID() string {
 	defer t.mu.RUnlock()
 
 	return t.rid
+}
+
+// Mid gets the Media Stream Id of this Track
+// Not required inside m=video section, but may be present
+func (t *TrackRemote) Mid() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.mid
 }
 
 // PayloadType gets the PayloadType of the track


### PR DESCRIPTION
#### Description
Mid information is handy when available along with Rid information.

Tested with personal project, and got mid 0,1,2 as per SDP.
OnTrack() call back for simulcast will return zero-string "" for mid, but this can
be changed to the mid of the simulcast section.

#### Reference issue
No issue
