### PR TITLE
Fix check for unchanged transceivers in CreateOffer

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -561,18 +561,16 @@ func (pc *PeerConnection) getStatsID() string {
 	return pc.statsID
 }
 
-func (pc *PeerConnection) hasLocalDescriptionChanged(desc *SessionDescription) bool {
-	for _, t := range pc.GetTransceivers() {
-		m := getByMid(t.Mid(), desc)
-		if m == nil {
-			return true
-		}
-
-		if getPeerDirection(m) != t.Direction() {
+func (pc *PeerConnection) hasLocalDescriptionChanged(old []*RTPTransceiver) bool {
+	transceivers := pc.GetTransceivers()
+	if len(transceivers) != len(old) {
+		return true
+	}
+	for i, t := range transceivers {
+		if t != old[i] {
 			return true
 		}
 	}
-
 	return false
 }
 
@@ -670,7 +668,7 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 
 		// Verify local media hasn't changed during offer
 		// generation. Recompute if necessary
-		if isPlanB || !pc.hasLocalDescriptionChanged(&offer) {
+		if isPlanB || !pc.hasLocalDescriptionChanged(currentTransceivers) {
 			break
 		}
 	}


### PR DESCRIPTION
This makes the check in CreateOffer more conservative but also less
fragile.  It works around #1656, but I'm not sure it's the underlying
cause (the SDP quoted in that issue looks broken to my untrained eyes).
