### PR TITLE
PR1199 redo: Answer with sendonly when remote is recvonly

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1030,9 +1030,21 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 			t, localTransceivers = findByMid(midValue, localTransceivers)
 			if t == nil {
 				t, localTransceivers = satisfyTypeAndDirection(kind, direction, localTransceivers)
-			} else if direction == RTPTransceiverDirectionInactive {
-				if err := t.Stop(); err != nil {
-					return err
+			} else {
+				switch direction {
+				case RTPTransceiverDirectionSendrecv: // remove go-lint warning
+				case RTPTransceiverDirectionInactive:
+					if err := t.Stop(); err != nil {
+						return err
+					}
+				case RTPTransceiverDirectionRecvonly:
+					if t.Direction() == RTPTransceiverDirectionRecvonly {
+						t.setDirection(RTPTransceiverDirectionInactive)
+					}
+				case RTPTransceiverDirectionSendonly:
+					if t.Direction() == RTPTransceiverDirectionSendonly {
+						t.setDirection(RTPTransceiverDirectionInactive)
+					}
 				}
 			}
 

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1062,6 +1062,8 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 					return err
 				}
 				switch direction {
+				case RTPTransceiverDirectionRecvonly:
+					t = pc.newRTPTransceiver(receiver, nil, RTPTransceiverDirectionSendonly, kind)
 				case RTPTransceiverDirectionSendonly, RTPTransceiverDirectionSendrecv:
 					t = pc.newRTPTransceiver(receiver, nil, RTPTransceiverDirectionRecvonly, kind)
 				default:

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1041,8 +1041,13 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 				if err != nil {
 					return err
 				}
-				t = pc.newRTPTransceiver(receiver, nil, RTPTransceiverDirectionRecvonly, kind)
-
+				switch direction {
+				case RTPTransceiverDirectionSendonly, RTPTransceiverDirectionSendrecv:
+					t = pc.newRTPTransceiver(receiver, nil, RTPTransceiverDirectionRecvonly, kind)
+				default:
+					// Inactive for RTPTransceiverDirectionRecvonly or RTPTransceiverDirectionInactive
+					t = pc.newRTPTransceiver(receiver, nil, RTPTransceiverDirectionInactive, kind)
+				}
 				pc.onNegotiationNeeded()
 			}
 			if t.Mid() == "" {

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -142,7 +142,7 @@ func satisfyTypeAndDirection(remoteKind RTPCodecType, remoteDirection RTPTransce
 		case RTPTransceiverDirectionSendrecv:
 			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly, RTPTransceiverDirectionSendrecv}
 		case RTPTransceiverDirectionSendonly:
-			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly, RTPTransceiverDirectionSendrecv}
+			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly}
 		case RTPTransceiverDirectionRecvonly:
 			return []RTPTransceiverDirection{RTPTransceiverDirectionSendonly}
 		default:

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -144,7 +144,7 @@ func satisfyTypeAndDirection(remoteKind RTPCodecType, remoteDirection RTPTransce
 		case RTPTransceiverDirectionSendonly:
 			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly, RTPTransceiverDirectionSendrecv}
 		case RTPTransceiverDirectionRecvonly:
-			return []RTPTransceiverDirection{RTPTransceiverDirectionSendonly, RTPTransceiverDirectionSendrecv}
+			return []RTPTransceiverDirection{RTPTransceiverDirectionSendonly}
 		default:
 			return []RTPTransceiverDirection{}
 		}


### PR DESCRIPTION
This is a re-application of the commits from PR1199, as the author appears busy with other stuff.
But, it was nice of him to figure this out.

The original PR is the best place for the background:
#1199 

The short introduction from original author longsleep  is:

> When receiving a remote offer with a transceiver which is recvonly, the
> answer must not set the transceiver to a receiving mode to avoid Firefox
> from complaining and failing to set the remote description with the
> following error:  **Answer tried to set recv when offer did not set send**
> While Chrome is more forgiving and happily sets remote transceiver which
> include receive even when the offer did not request ist, this needs to
> be changed to get interop with Firefox.
