### PR TITLE
Don't enable RID/MID Extension Headers by default

### DIFF
--- a/examples/simulcast/main.go
+++ b/examples/simulcast/main.go
@@ -24,8 +24,24 @@ func main() {
 			},
 		},
 	}
+
+	// Enable Extension Headers needed for Simulcast
+	m := &webrtc.MediaEngine{}
+	if err := m.RegisterDefaultCodecs(); err != nil {
+		panic(err)
+	}
+	for _, extension := range []string{
+		"urn:ietf:params:rtp-hdrext:sdes:mid",
+		"urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id",
+		"urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id",
+	} {
+		if err := m.RegisterHeaderExtension(webrtc.RTPHeaderExtensionCapability{URI: extension}, webrtc.RTPCodecTypeVideo); err != nil {
+			panic(err)
+		}
+	}
+
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.NewPeerConnection(config)
+	peerConnection, err := webrtc.NewAPI(webrtc.WithMediaEngine(m)).NewPeerConnection(config)
 	if err != nil {
 		panic(err)
 	}

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -86,17 +86,6 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		}
 	}
 
-	// Default Pion Audio Header Extensions
-	for _, extension := range []string{
-		"urn:ietf:params:rtp-hdrext:sdes:mid",
-		"urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id",
-		"urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id",
-	} {
-		if err := m.RegisterHeaderExtension(RTPHeaderExtensionCapability{extension}, RTPCodecTypeAudio); err != nil {
-			return err
-		}
-	}
-
 	videoRTCPFeedback := []RTCPFeedback{{"goog-remb", ""}, {"ccm", "fir"}, {"nack", ""}, {"nack", "pli"}}
 	for _, codec := range []RTPCodecParameters{
 		{
@@ -186,17 +175,6 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 		},
 	} {
 		if err := m.RegisterCodec(codec, RTPCodecTypeVideo); err != nil {
-			return err
-		}
-	}
-
-	// Default Pion Video Header Extensions
-	for _, extension := range []string{
-		"urn:ietf:params:rtp-hdrext:sdes:mid",
-		"urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id",
-		"urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id",
-	} {
-		if err := m.RegisterHeaderExtension(RTPHeaderExtensionCapability{extension}, RTPCodecTypeVideo); err != nil {
 			return err
 		}
 	}

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -150,6 +150,13 @@ a=rtpmap:111 opus/48000/2
 
 		m := MediaEngine{}
 		assert.NoError(t, m.RegisterDefaultCodecs())
+		for _, extension := range []string{
+			"urn:ietf:params:rtp-hdrext:sdes:mid",
+			"urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id",
+		} {
+			assert.NoError(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{URI: extension}, RTPCodecTypeAudio))
+		}
+
 		assert.NoError(t, m.updateFromRemoteDescription(mustParse(headerExtensions)))
 
 		assert.False(t, m.negotiatedVideo)


### PR DESCRIPTION
Chrome is failing to signaling if the remote peer offers RID/MID so
disabling by default.

Relates to pion/example-webrtc-applications#87
