### PR TITLE
Disable MediaEngine Copy by Default

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -271,6 +271,16 @@ func (m *MediaEngine) getHeaderExtensionID(extension RTPHeaderExtensionCapabilit
 	return
 }
 
+// copy copies any user modifiable state of the MediaEngine
+// all internal state is reset
+func (m *MediaEngine) copy() *MediaEngine {
+	return &MediaEngine{
+		videoCodecs:      append([]RTPCodecParameters{}, m.videoCodecs...),
+		audioCodecs:      append([]RTPCodecParameters{}, m.audioCodecs...),
+		headerExtensions: append([]mediaEngineHeaderExtension{}, m.headerExtensions...),
+	}
+}
+
 func (m *MediaEngine) getCodecByPayload(payloadType PayloadType) (RTPCodecParameters, RTPCodecType, error) {
 	for _, codec := range m.negotiatedVideoCodecs {
 		if codec.PayloadType == payloadType {

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -105,6 +105,10 @@ func NewPeerConnection(configuration Configuration) (*PeerConnection, error) {
 
 // NewPeerConnection creates a new PeerConnection with the provided configuration against the received API object
 func (api *API) NewPeerConnection(configuration Configuration) (*PeerConnection, error) {
+	if !api.settingEngine.disableMediaEngineCopy {
+		api.mediaEngine = api.mediaEngine.copy()
+	}
+
 	// https://w3c.github.io/webrtc-pc/#constructor (Step #2)
 	// Some variables defined explicitly despite their implicit zero values to
 	// allow better readability to understand what is happening.

--- a/settingengine.go
+++ b/settingengine.go
@@ -59,6 +59,7 @@ type SettingEngine struct {
 	LoggerFactory                             logging.LoggerFactory
 	iceTCPMux                                 ice.TCPMux
 	iceProxyDialer                            proxy.Dialer
+	disableMediaEngineCopy                    bool
 }
 
 // DetachDataChannels enables detaching data channels. When enabled
@@ -254,4 +255,11 @@ func (e *SettingEngine) SetICETCPMux(tcpMux ice.TCPMux) {
 // SetICEProxyDialer sets the proxy dialer interface based on golang.org/x/net/proxy.
 func (e *SettingEngine) SetICEProxyDialer(d proxy.Dialer) {
 	e.iceProxyDialer = d
+}
+
+// DisableMediaEngineCopy stops the MediaEngine from being copied. This allows a user to modify
+// the MediaEngine after the PeerConnection has been constructed. This is useful if you wish to
+// modify codecs after signaling. Make sure not to share MediaEngines between PeerConnections.
+func (e *SettingEngine) DisableMediaEngineCopy(isDisabled bool) {
+	e.disableMediaEngineCopy = isDisabled
 }


### PR DESCRIPTION
If an API is shared between PeerConnections they would use the same
MediaEngine. A MediaEngine contains negotiated PayloadTypes so if the
PeerConnections were answering you would end up in invalid states.

Add DisableMediaEngineCopy to SettingEngine in case user needs old
behavior.

Resolves #1662

#### Description

#### Reference issue
Fixes #...
