### PR TITLE
avoid allocation in write

### DIFF
--- a/track_local_static.go
+++ b/track_local_static.go
@@ -103,21 +103,39 @@ func (s *TrackLocalStaticRTP) Codec() RTPCodecCapability {
 	return s.codec
 }
 
+// packetPool is a pool of packets used by WriteRTP and Write below
+var packetPool = sync.Pool {
+	New: func() interface{} {
+		return &rtp.Packet{}
+	},
+}
+
 // WriteRTP writes a RTP Packet to the TrackLocalStaticRTP
 // If one PeerConnection fails the packets will still be sent to
 // all PeerConnections. The error message will contain the ID of the failed
 // PeerConnections so you can remove them
 func (s *TrackLocalStaticRTP) WriteRTP(p *rtp.Packet) error {
+	ipacket := packetPool.Get()
+	packet := ipacket.(*rtp.Packet)
+	defer func() {
+		*packet = rtp.Packet{}
+		packetPool.Put(ipacket)
+	}()
+	*packet = *p
+	return s.writeRTP(packet)
+}
+
+// writeRTP is like WriteRTP, except that it may modify the packet p
+func (s *TrackLocalStaticRTP) writeRTP(p *rtp.Packet) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	writeErrs := []error{}
-	outboundPacket := *p
 
 	for _, b := range s.bindings {
-		outboundPacket.Header.SSRC = uint32(b.ssrc)
-		outboundPacket.Header.PayloadType = uint8(b.payloadType)
-		if _, err := b.writeStream.WriteRTP(&outboundPacket.Header, outboundPacket.Payload); err != nil {
+		p.Header.SSRC = uint32(b.ssrc)
+		p.Header.PayloadType = uint8(b.payloadType)
+		if _, err := b.writeStream.WriteRTP(&p.Header, p.Payload); err != nil {
 			writeErrs = append(writeErrs, err)
 		}
 	}
@@ -130,12 +148,18 @@ func (s *TrackLocalStaticRTP) WriteRTP(p *rtp.Packet) error {
 // all PeerConnections. The error message will contain the ID of the failed
 // PeerConnections so you can remove them
 func (s *TrackLocalStaticRTP) Write(b []byte) (n int, err error) {
-	packet := &rtp.Packet{}
+	ipacket := packetPool.Get()
+	packet := ipacket.(*rtp.Packet)
+	defer func() {
+		*packet = rtp.Packet{}
+		packetPool.Put(ipacket)
+	}()
+
 	if err = packet.Unmarshal(b); err != nil {
 		return 0, err
 	}
 
-	return len(b), s.WriteRTP(packet)
+	return len(b), s.writeRTP(packet)
 }
 
 // TrackLocalStaticSample is a TrackLocal that has a pre-set codec and accepts Samples.


### PR DESCRIPTION
This reduces allocations in Galène by roughly 20%.
```
name               old time/op    new time/op     delta
TrackLocalWrite-8     104ns ± 1%       47ns ± 2%   -55.02%  (p=0.029 n=4+4)

name               old speed      new speed       delta
TrackLocalWrite-8  9.78GB/s ± 1%  21.78GB/s ± 2%  +122.70%  (p=0.029 n=4+4)

name               old alloc/op   new alloc/op    delta
TrackLocalWrite-8      144B ± 0%         0B       -100.00%  (p=0.029 n=4+4)

name               old allocs/op  new allocs/op   delta
TrackLocalWrite-8      1.00 ± 0%       0.00       -100.00%  (p=0.029 n=4+4)
```