### PR TITLE
Fix register the same codec

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -182,6 +182,16 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 	return nil
 }
 
+// addCodec will append codec if it not exists
+func (m *MediaEngine) addCodec(codecs []RTPCodecParameters, codec RTPCodecParameters) []RTPCodecParameters {
+	for _, c := range codecs {
+		if c.MimeType == codec.MimeType && c.PayloadType == codec.PayloadType {
+			return codecs
+		}
+	}
+	return append(codecs, codec)
+}
+
 // RegisterCodec adds codec to the MediaEngine
 // These are the list of codecs supported by this PeerConnection.
 // RegisterCodec is not safe for concurrent use.
@@ -189,9 +199,9 @@ func (m *MediaEngine) RegisterCodec(codec RTPCodecParameters, typ RTPCodecType) 
 	codec.statsID = fmt.Sprintf("RTPCodec-%d", time.Now().UnixNano())
 	switch typ {
 	case RTPCodecTypeAudio:
-		m.audioCodecs = append(m.audioCodecs, codec)
+		m.audioCodecs = m.addCodec(m.audioCodecs, codec)
 	case RTPCodecTypeVideo:
-		m.videoCodecs = append(m.videoCodecs, codec)
+		m.videoCodecs = m.addCodec(m.videoCodecs, codec)
 	default:
 		return ErrUnknownType
 	}
@@ -328,9 +338,9 @@ func (m *MediaEngine) updateCodecParameters(remoteCodec RTPCodecParameters, typ 
 
 	pushCodec := func(codec RTPCodecParameters) error {
 		if typ == RTPCodecTypeAudio {
-			m.negotiatedAudioCodecs = append(m.negotiatedAudioCodecs, codec)
+			m.negotiatedAudioCodecs = m.addCodec(m.negotiatedAudioCodecs, codec)
 		} else if typ == RTPCodecTypeVideo {
-			m.negotiatedVideoCodecs = append(m.negotiatedVideoCodecs, codec)
+			m.negotiatedVideoCodecs = m.addCodec(m.negotiatedVideoCodecs, codec)
 		}
 		return nil
 	}

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -242,3 +242,22 @@ func TestMediaEngineHeaderExtensionDirection(t *testing.T) {
 		assert.Error(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirection(0)), ErrRegisterHeaderExtensionInvalidDirection)
 	})
 }
+
+// If a user attempts to register a codec twice we should just discard duplicate calls
+func TestMediaEngineDoubleRegister(t *testing.T) {
+	m := MediaEngine{}
+
+	assert.NoError(t, m.RegisterCodec(
+		RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 0, "", nil},
+			PayloadType:        111,
+		}, RTPCodecTypeAudio))
+
+	assert.NoError(t, m.RegisterCodec(
+		RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 0, "", nil},
+			PayloadType:        111,
+		}, RTPCodecTypeAudio))
+
+	assert.Equal(t, len(m.audioCodecs), 1)
+}


### PR DESCRIPTION

#### Description
Fix register the same codec, otherwise addTransceiverSDP will add duplicate codec sdp
Otherwise addTransceiverSDP will add duplicate codec sdp

#### Reference issue
Fix https://github.com/pion/ion-sfu/issues/425
```
v=0
o=- 5454648987554646034 1613488747 IN IP4 0.0.0.0
s=-
t=0 0
a=fingerprint:sha-256 56:62:E1:01:34:08:29:A2:72:E2:0E:28:4E:C6:C4:48:C9:C2:18:72:06:CF:A3:C9:2A:49:30:4F:6E:90:C9:89
a=group:BUNDLE 0 1 2 3 4
m=audio 9 UDP/TLS/RTP/SAVPF 111 111
c=IN IP4 0.0.0.0
a=setup:actpass
a=mid:0
a=ice-ufrag:KObOgVaHjOnnAtdX
a=ice-pwd:FMuiwaSPGdKPtXpjVLBaNoEMUjpKOson
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:111 opus/48000/2
a=fmtp:111 minptime=10;useinbandfec=1
a=rtpmap:111 opus/48000/2
a=fmtp:111 minptime=10;useinbandfec=1
a=ssrc:2193652934 cname:webm_0xc000163b80
a=ssrc:2193652934 msid:webm_0xc000163b80 audio
a=ssrc:2193652934 mslabel:webm_0xc000163b80
a=ssrc:2193652934 label:audio
a=msid:webm_0xc000163b80 audio
a=sendonly
m=video 9 UDP/TLS/RTP/SAVPF 96 96
c=IN IP4 0.0.0.0
a=setup:actpass
a=mid:1
a=ice-ufrag:KObOgVaHjOnnAtdX
a=ice-pwd:FMuiwaSPGdKPtXpjVLBaNoEMUjpKOson
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:96 vp8/90000
a=rtcp-fb:96 goog-remb
a=rtcp-fb:96 ccm fir
a=rtcp-fb:96 nack
a=rtcp-fb:96 nack pli
a=rtpmap:96 vp8/90000
a=rtcp-fb:96 goog-remb
a=rtcp-fb:96 ccm fir
a=rtcp-fb:96 nack
a=rtcp-fb:96 nack pli
a=ssrc:2498583866 cname:webm_0xc000163b80
a=ssrc:2498583866 msid:webm_0xc000163b80 video
a=ssrc:2498583866 mslabel:webm_0xc000163b80
a=ssrc:2498583866 label:video
a=msid:webm_0xc000163b80 video
a=sendonly
m=audio 9 UDP/TLS/RTP/SAVPF 111 111
c=IN IP4 0.0.0.0
a=setup:actpass
a=mid:2
a=ice-ufrag:KObOgVaHjOnnAtdX
a=ice-pwd:FMuiwaSPGdKPtXpjVLBaNoEMUjpKOson
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:111 opus/48000/2
a=fmtp:111 minptime=10;useinbandfec=1
a=rtpmap:111 opus/48000/2
a=fmtp:111 minptime=10;useinbandfec=1
a=ssrc:1801454766 cname:webm_0xc000162000
a=ssrc:1801454766 msid:webm_0xc000162000 audio
a=ssrc:1801454766 mslabel:webm_0xc000162000
a=ssrc:1801454766 label:audio
a=msid:webm_0xc000162000 audio
a=sendonly
m=video 9 UDP/TLS/RTP/SAVPF 96 96
c=IN IP4 0.0.0.0
a=setup:actpass
a=mid:3
a=ice-ufrag:KObOgVaHjOnnAtdX
a=ice-pwd:FMuiwaSPGdKPtXpjVLBaNoEMUjpKOson
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:96 vp8/90000
a=rtcp-fb:96 goog-remb
a=rtcp-fb:96 ccm fir
a=rtcp-fb:96 nack
a=rtcp-fb:96 nack pli
a=rtpmap:96 vp8/90000
a=rtcp-fb:96 goog-remb
a=rtcp-fb:96 ccm fir
a=rtcp-fb:96 nack
a=rtcp-fb:96 nack pli
a=ssrc:2963805140 cname:webm_0xc000162000
a=ssrc:2963805140 msid:webm_0xc000162000 video
a=ssrc:2963805140 mslabel:webm_0xc000162000
a=ssrc:2963805140 label:video
a=msid:webm_0xc000162000 video
a=sendonly
m=application 9 UDP/DTLS/SCTP webrtc-datachannel
c=IN IP4 0.0.0.0
a=setup:actpass
a=mid:4
a=sendrecv
a=sctp-port:5000
a=ice-ufrag:KObOgVaHjOnnAtdX
a=ice-pwd:FMuiwaSPGdKPtXpjVLBaNoEMUjpKOson
```
