### PR TITLE
Resolve a caching issue when reusing session descriptions.

### DIFF
--- a/sessiondescription.go
+++ b/sessiondescription.go
@@ -13,12 +13,8 @@ type SessionDescription struct {
 	parsed *sdp.SessionDescription
 }
 
-// Unmarshal is a helper to deserialize the sdp, and re-use it internally
-// if required
+// Unmarshal is a helper to deserialize the sdp
 func (sd *SessionDescription) Unmarshal() (*sdp.SessionDescription, error) {
-	if sd.parsed != nil {
-		return sd.parsed, nil
-	}
 	sd.parsed = &sdp.SessionDescription{}
 	err := sd.parsed.Unmarshal([]byte(sd.SDP))
 	return sd.parsed, err

--- a/sessiondescription_test.go
+++ b/sessiondescription_test.go
@@ -2,6 +2,7 @@ package webrtc
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,12 +69,15 @@ func TestSessionDescription_Unmarshal(t *testing.T) {
 		SDP:  offer.SDP,
 	}
 	assert.Nil(t, desc.parsed)
-	parsed, err := desc.Unmarshal()
-	assert.NotNil(t, parsed)
+	parsed1, err := desc.Unmarshal()
+	assert.NotNil(t, parsed1)
 	assert.NotNil(t, desc.parsed)
 	assert.NoError(t, err)
-	parsed, err = desc.Unmarshal()
-	assert.NotNil(t, parsed)
-	assert.NoError(t, err)
+	parsed2, err2 := desc.Unmarshal()
+	assert.NotNil(t, parsed2)
+	assert.NoError(t, err2)
 	assert.NoError(t, pc.Close())
+
+	// check if the two parsed results _really_ match, could be affected by internal caching
+	assert.True(t, reflect.DeepEqual(parsed1, parsed2))
 }


### PR DESCRIPTION
#### Description
This resolves a relatively small issue which would return a cached session description despite it being changed. It can be safely cached for internal usage, but should always be updated when requested.

This solution was proposed by Sean DuBois in the #pion slack channel.