### PR TITLE
Use closePairNow in tests

### DIFF
--- a/datachannel_go_test.go
+++ b/datachannel_go_test.go
@@ -575,6 +575,5 @@ func TestDataChannel_NonStandardSessionDescription(t *testing.T) {
 	assert.NoError(t, offerPC.SetRemoteDescription(*answerPC.LocalDescription()))
 
 	<-onDataChannelCalled
-	assert.NoError(t, offerPC.Close())
-	assert.NoError(t, answerPC.Close())
+	closePairNow(t, offerPC, answerPC)
 }

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -284,8 +284,7 @@ func TestDataChannel_Close(t *testing.T) {
 		dc, err := offerPC.CreateDataChannel(expectedLabel, nil)
 		assert.NoError(t, err)
 
-		assert.NoError(t, offerPC.Close())
-		assert.NoError(t, answerPC.Close())
+		closePairNow(t, offerPC, answerPC)
 		assert.NoError(t, dc.Close())
 	})
 
@@ -297,8 +296,7 @@ func TestDataChannel_Close(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.NoError(t, dc.Close())
-		assert.NoError(t, offerPC.Close())
-		assert.NoError(t, answerPC.Close())
+		closePairNow(t, offerPC, answerPC)
 	})
 }
 

--- a/dtlstransport_test.go
+++ b/dtlstransport_test.go
@@ -102,8 +102,7 @@ func TestPeerConnection_DTLSRoleSettingEngine(t *testing.T) {
 
 		connectionComplete := untilConnectionState(PeerConnectionStateConnected, answerPC)
 		connectionComplete.Wait()
-		assert.NoError(t, offerPC.Close())
-		assert.NoError(t, answerPC.Close())
+		closePairNow(t, offerPC, answerPC)
 	}
 
 	report := test.CheckRoutines(t)

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -102,6 +102,5 @@ func TestPeerConnection_Interceptor(t *testing.T) {
 		}
 	}()
 
-	assert.NoError(t, offerer.Close())
-	assert.NoError(t, answerer.Close())
+	closePairNow(t, offerer, answerer)
 }

--- a/peerconnection_close_test.go
+++ b/peerconnection_close_test.go
@@ -52,8 +52,7 @@ func TestPeerConnection_Close(t *testing.T) {
 
 	<-awaitSetup
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 
 	<-awaitICEClosed
 }

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -374,8 +374,7 @@ func TestPeerConnection_ShutdownNoDTLS(t *testing.T) {
 	})
 
 	<-iceComplete
-	assert.NoError(t, offerPC.Close())
-	assert.NoError(t, answerPC.Close())
+	closePairNow(t, offerPC, answerPC)
 }
 
 func TestPeerConnection_PropertyGetters(t *testing.T) {
@@ -598,8 +597,7 @@ func TestPeerConnection_OfferingLite(t *testing.T) {
 	})
 
 	<-iceComplete
-	assert.NoError(t, offerPC.Close())
-	assert.NoError(t, answerPC.Close())
+	closePairNow(t, offerPC, answerPC)
 }
 
 func TestPeerConnection_AnsweringLite(t *testing.T) {
@@ -637,8 +635,7 @@ func TestPeerConnection_AnsweringLite(t *testing.T) {
 	})
 
 	<-iceComplete
-	assert.NoError(t, offerPC.Close())
-	assert.NoError(t, answerPC.Close())
+	closePairNow(t, offerPC, answerPC)
 }
 
 func TestOnICEGatheringStateChange(t *testing.T) {
@@ -792,8 +789,7 @@ func TestPeerConnectionTrickle(t *testing.T) {
 
 	<-answerPCConnected.Done()
 	<-offerPCConnected.Done()
-	assert.NoError(t, offerPC.Close())
-	assert.NoError(t, answerPC.Close())
+	closePairNow(t, offerPC, answerPC)
 }
 
 // Issue #1121, assert populateLocalCandidates doesn't mutate
@@ -858,8 +854,7 @@ func TestMulticastDNSCandidates(t *testing.T) {
 	})
 	<-onDataChannel.Done()
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestICERestart(t *testing.T) {
@@ -938,8 +933,7 @@ func TestICERestart(t *testing.T) {
 	// Compare ICE Candidates across each run, fail if they haven't changed
 	assert.NotEqual(t, firstOfferCandidates, extractCandidates(offerPC.LocalDescription().SDP))
 	assert.NotEqual(t, firstAnswerCandidates, extractCandidates(answerPC.LocalDescription().SDP))
-	assert.NoError(t, offerPC.Close())
-	assert.NoError(t, answerPC.Close())
+	closePairNow(t, offerPC, answerPC)
 }
 
 // Assert error handling when an Agent is restart
@@ -1043,8 +1037,7 @@ func TestICERestart_Error_Handling(t *testing.T) {
 	assert.Equal(t, testMessage, <-dataChannelMessages)
 
 	assert.NoError(t, wan.Stop())
-	assert.NoError(t, offerPeerConnection.Close())
-	assert.NoError(t, answerPeerConnection.Close())
+	closePairNow(t, offerPeerConnection, answerPeerConnection)
 }
 
 type trackRecords struct {
@@ -1161,8 +1154,7 @@ func TestPeerConnection_MassiveTracks(t *testing.T) {
 		}
 	}
 	close(stopped)
-	assert.NoError(t, offerPC.Close())
-	assert.NoError(t, answerPC.Close())
+	closePairNow(t, offerPC, answerPC)
 }
 
 func TestEmptyCandidate(t *testing.T) {

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -193,8 +193,7 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 	<-awaitRTPRecvClosed
 }
 
@@ -292,8 +291,7 @@ func TestPeerConnection_Media_Shutdown(t *testing.T) {
 		}
 	}
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 
 	onTrackFiredLock.Lock()
 	if onTrackFired {
@@ -463,8 +461,7 @@ func TestUndeclaredSSRC(t *testing.T) {
 	}()
 
 	<-onTrackFired
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestAddTransceiverFromTrackSendOnly(t *testing.T) {
@@ -847,8 +844,7 @@ func TestPlanBMediaExchange(t *testing.T) {
 			}
 		}()
 
-		assert.NoError(t, pcOffer.Close())
-		assert.NoError(t, pcAnswer.Close())
+		closePairNow(t, pcOffer, pcAnswer)
 	}
 
 	lim := test.TimeOut(time.Second * 30)
@@ -997,8 +993,7 @@ func TestPeerConnection_Start_Right_Receiver(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, started, "transceiver with mid 2 should be started")
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 // Assert that failed Simulcast probing doesn't cause
@@ -1055,8 +1050,7 @@ func TestPeerConnection_Simulcast_Probe(t *testing.T) {
 
 	<-seenFiveStreams.Done()
 
-	assert.NoError(t, answerer.Close())
-	assert.NoError(t, offerer.Close())
+	closePairNow(t, offerer, answerer)
 	close(testFinished)
 }
 

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -126,8 +126,7 @@ func TestPeerConnection_Renegotiation_AddTrack(t *testing.T) {
 
 	sendVideoUntilDone(onTrackFired.Done(), t, []*TrackLocalStaticSample{vp8Track})
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 // Assert that adding tracks across multiple renegotiations performs as expected
@@ -174,8 +173,7 @@ func TestPeerConnection_Renegotiation_AddTrack_Multiple(t *testing.T) {
 		sendVideoUntilDone(onTrackChan, t, outboundTracks)
 	}
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 
 	assert.Equal(t, onTrackCount[trackIDs[0]], 1)
 	assert.Equal(t, onTrackCount[trackIDs[1]], 1)
@@ -229,8 +227,7 @@ func TestPeerConnection_Renegotiation_AddTrack_Rename(t *testing.T) {
 
 	sendVideoUntilDone(onTrackFired.Done(), t, []*TrackLocalStaticSample{vp8Track})
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 
 	remoteTrack, ok := atomicRemoteTrack.Load().(*TrackRemote)
 	require.True(t, ok)
@@ -326,8 +323,7 @@ func TestPeerConnection_Transceiver_Mid(t *testing.T) {
 	assert.True(t, sdpMidHasSsrc(offer, "0", sender3.ssrc), "Expected mid %q with ssrc %d, offer.sdp: %s", "0", sender3.ssrc, offer.SDP)
 	assert.True(t, sdpMidHasSsrc(offer, "1", sender2.ssrc), "Expected mid %q with ssrc %d, offer.sdp: %s", "1", sender2.ssrc, offer.SDP)
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestPeerConnection_Renegotiation_CodecChange(t *testing.T) {
@@ -418,8 +414,7 @@ func TestPeerConnection_Renegotiation_CodecChange(t *testing.T) {
 	assert.Equal(t, "video2", remoteTrack2.ID())
 	assert.Equal(t, "pion2", remoteTrack2.StreamID())
 
-	require.NoError(t, pcOffer.Close())
-	require.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestPeerConnection_Renegotiation_RemoveTrack(t *testing.T) {
@@ -464,8 +459,7 @@ func TestPeerConnection_Renegotiation_RemoveTrack(t *testing.T) {
 	assert.NoError(t, signalPair(pcOffer, pcAnswer))
 
 	<-trackClosed.Done()
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestPeerConnection_RoleSwitch(t *testing.T) {
@@ -501,8 +495,7 @@ func TestPeerConnection_RoleSwitch(t *testing.T) {
 	assert.NoError(t, signalPair(pcSecondOfferer, pcFirstOfferer))
 	sendVideoUntilDone(onTrackFired.Done(), t, []*TrackLocalStaticSample{vp8Track})
 
-	assert.NoError(t, pcFirstOfferer.Close())
-	assert.NoError(t, pcSecondOfferer.Close())
+	closePairNow(t, pcFirstOfferer, pcSecondOfferer)
 }
 
 // Assert that renegotiation doesn't attempt to gather ICE twice
@@ -572,8 +565,7 @@ func TestPeerConnection_Renegotiation_Trickle(t *testing.T) {
 	pcAnswer.ops.Done()
 	wg.Wait()
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestPeerConnection_Renegotiation_SetLocalDescription(t *testing.T) {
@@ -628,8 +620,7 @@ func TestPeerConnection_Renegotiation_SetLocalDescription(t *testing.T) {
 
 	sendVideoUntilDone(onTrackFired.Done(), t, []*TrackLocalStaticSample{localTrack})
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 // Issue #346, don't start the SCTP Subsystem if the RemoteDescription doesn't contain one
@@ -699,8 +690,7 @@ func TestPeerConnection_Renegotiation_NoApplication(t *testing.T) {
 	assert.Equal(t, pcOffer.SCTP().State(), SCTPTransportStateConnecting)
 	assert.Equal(t, pcAnswer.SCTP().State(), SCTPTransportStateConnecting)
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestAddDataChannelDuringRenegotation(t *testing.T) {
@@ -763,8 +753,7 @@ func TestAddDataChannelDuringRenegotation(t *testing.T) {
 	assert.NoError(t, signalPair(pcOffer, pcAnswer))
 
 	<-onDataChannelFired.Done()
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 // Assert that CreateDataChannel fires OnNegotiationNeeded
@@ -847,8 +836,7 @@ func TestNegotiationNeededRemoveTrack(t *testing.T) {
 
 	wg.Wait()
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestNegotiationNeededStressOneSided(t *testing.T) {
@@ -877,8 +865,7 @@ func TestNegotiationNeededStressOneSided(t *testing.T) {
 	pcA.ops.Done()
 
 	assert.Equal(t, expectedTrackCount, len(pcB.GetTransceivers()))
-	assert.NoError(t, pcA.Close())
-	assert.NoError(t, pcB.Close())
+	closePairNow(t, pcA, pcB)
 }
 
 // TestPeerConnection_Renegotiation_DisableTrack asserts that if a remote track is set inactive
@@ -922,6 +909,5 @@ func TestPeerConnection_Renegotiation_DisableTrack(t *testing.T) {
 	assert.Equal(t, strings.Count(answer.SDP, "a=recvonly"), 1)
 	assert.Equal(t, strings.Count(answer.SDP, "a=inactive"), 1)
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -307,8 +307,7 @@ func TestCreateOfferAnswer(t *testing.T) {
 	_, err = answerPeerConn.CreateAnswer(nil)
 	assert.Error(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
 
-	assert.NoError(t, offerPeerConn.Close())
-	assert.NoError(t, answerPeerConn.Close())
+	closePairNow(t, offerPeerConn, answerPeerConn)
 }
 
 func TestPeerConnection_EventHandlers(t *testing.T) {
@@ -406,8 +405,7 @@ func TestPeerConnection_EventHandlers(t *testing.T) {
 		t.Fatalf("timed out waiting for one or more events handlers to be called (these *were* called: %+v)", wasCalled)
 	}
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func TestMultipleOfferAnswer(t *testing.T) {
@@ -437,8 +435,7 @@ func TestMultipleOfferAnswer(t *testing.T) {
 		t.Errorf("Second Offer: got error: %v", err)
 	}
 
-	assert.NoError(t, firstPeerConn.Close())
-	assert.NoError(t, secondPeerConn.Close())
+	closePairNow(t, firstPeerConn, secondPeerConn)
 }
 
 func TestNoFingerprintInFirstMediaIfSetRemoteDescription(t *testing.T) {
@@ -564,8 +561,7 @@ func TestMultipleCreateChannel(t *testing.T) {
 
 	wg.Wait()
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 // Assert that candidates are gathered by calling SetLocalDescription, not SetRemoteDescription
@@ -636,8 +632,7 @@ func TestGatherOnSetLocalDescription(t *testing.T) {
 		t.Error(err.Error())
 	}
 	<-pcAnswerGathered
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 // Assert that SetRemoteDescription handles invalid states

--- a/rtpreceiver_test.go
+++ b/rtpreceiver_test.go
@@ -58,6 +58,5 @@ func Test_RTPReceiver_SetReadDeadline(t *testing.T) {
 
 	<-seenPacket.Done()
 	assert.NoError(t, wan.Stop())
-	assert.NoError(t, sender.Close())
-	assert.NoError(t, receiver.Close())
+	closePairNow(t, sender, receiver)
 }

--- a/rtpsender_test.go
+++ b/rtpsender_test.go
@@ -110,8 +110,7 @@ func Test_RTPSender_ReplaceTrack(t *testing.T) {
 			}
 		}()
 
-		assert.NoError(t, sender.Close())
-		assert.NoError(t, receiver.Close())
+		closePairNow(t, sender, receiver)
 	})
 
 	t.Run("Invalid Codec Change", func(t *testing.T) {
@@ -147,8 +146,7 @@ func Test_RTPSender_ReplaceTrack(t *testing.T) {
 
 		assert.True(t, errors.Is(rtpSender.ReplaceTrack(trackB), ErrUnsupportedCodec))
 
-		assert.NoError(t, sender.Close())
-		assert.NoError(t, receiver.Close())
+		closePairNow(t, sender, receiver)
 	})
 }
 
@@ -172,8 +170,7 @@ func Test_RTPSender_GetParameters(t *testing.T) {
 	assert.Equal(t, 1, len(parameters.Encodings))
 	assert.Equal(t, rtpTransceiver.Sender().ssrc, parameters.Encodings[0].SSRC)
 
-	assert.NoError(t, offerer.Close())
-	assert.NoError(t, answerer.Close())
+	closePairNow(t, offerer, answerer)
 }
 
 func Test_RTPSender_SetReadDeadline(t *testing.T) {
@@ -202,6 +199,5 @@ func Test_RTPSender_SetReadDeadline(t *testing.T) {
 	assert.Error(t, err, packetio.ErrTimeout)
 
 	assert.NoError(t, wan.Stop())
-	assert.NoError(t, sender.Close())
-	assert.NoError(t, receiver.Close())
+	closePairNow(t, sender, receiver)
 }

--- a/sdpsemantics_test.go
+++ b/sdpsemantics_test.go
@@ -129,8 +129,7 @@ func TestSDPSemantics_PlanBOfferTransceivers(t *testing.T) {
 	mdNames = getMdNames(answer.parsed)
 	assert.ObjectsAreEqual(mdNames, []string{"video", "audio", "data"})
 
-	assert.NoError(t, apc.Close())
-	assert.NoError(t, opc.Close())
+	closePairNow(t, apc, opc)
 }
 
 func TestSDPSemantics_PlanBAnswerSenders(t *testing.T) {
@@ -223,8 +222,7 @@ func TestSDPSemantics_PlanBAnswerSenders(t *testing.T) {
 		}
 	}
 
-	assert.NoError(t, apc.Close())
-	assert.NoError(t, opc.Close())
+	closePairNow(t, apc, opc)
 }
 
 func TestSDPSemantics_UnifiedPlanWithFallback(t *testing.T) {
@@ -331,6 +329,5 @@ func TestSDPSemantics_UnifiedPlanWithFallback(t *testing.T) {
 		}
 	}
 
-	assert.NoError(t, apc.Close())
-	assert.NoError(t, opc.Close())
+	closePairNow(t, apc, opc)
 }

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -163,8 +163,7 @@ func TestSettingEngine_SetDisableMediaEngineCopy(t *testing.T) {
 		assert.True(t, offerer.api.mediaEngine.negotiatedVideo)
 		assert.NotEmpty(t, offerer.api.mediaEngine.negotiatedVideoCodecs)
 
-		assert.NoError(t, offerer.Close())
-		assert.NoError(t, answerer.Close())
+		closePairNow(t, offerer, answerer)
 
 		newOfferer, newAnswerer, err := api.newPair(Configuration{})
 		assert.NoError(t, err)
@@ -177,8 +176,7 @@ func TestSettingEngine_SetDisableMediaEngineCopy(t *testing.T) {
 		assert.False(t, newOfferer.api.mediaEngine.negotiatedVideo)
 		assert.Empty(t, newAnswerer.api.mediaEngine.negotiatedVideoCodecs)
 
-		assert.NoError(t, newOfferer.Close())
-		assert.NoError(t, newAnswerer.Close())
+		closePairNow(t, newOfferer, newAnswerer)
 	})
 
 	t.Run("No Copy", func(t *testing.T) {
@@ -202,8 +200,7 @@ func TestSettingEngine_SetDisableMediaEngineCopy(t *testing.T) {
 		assert.True(t, m.negotiatedVideo)
 		assert.NotEmpty(t, m.negotiatedVideoCodecs)
 
-		assert.NoError(t, offerer.Close())
-		assert.NoError(t, answerer.Close())
+		closePairNow(t, offerer, answerer)
 
 		offerer, answerer, err = api.newPair(Configuration{})
 		assert.NoError(t, err)
@@ -212,7 +209,6 @@ func TestSettingEngine_SetDisableMediaEngineCopy(t *testing.T) {
 		assert.True(t, offerer.api.mediaEngine.negotiatedVideo)
 		assert.NotEmpty(t, offerer.api.mediaEngine.negotiatedVideoCodecs)
 
-		assert.NoError(t, offerer.Close())
-		assert.NoError(t, answerer.Close())
+		closePairNow(t, offerer, answerer)
 	})
 }

--- a/stats_go_test.go
+++ b/stats_go_test.go
@@ -332,8 +332,7 @@ func TestPeerConnection_GetStats(t *testing.T) {
 		assert.NotEmpty(t, getCertificateStats(t, reportPCOffer, &certificates[i]))
 	}
 
-	assert.NoError(t, offerPC.Close())
-	assert.NoError(t, answerPC.Close())
+	closePairNow(t, offerPC, answerPC)
 }
 
 func TestPeerConnection_GetStats_Closed(t *testing.T) {

--- a/track_local_static_test.go
+++ b/track_local_static_test.go
@@ -37,8 +37,7 @@ func Test_TrackLocalStatic_NoCodecIntersection(t *testing.T) {
 
 		assert.True(t, errors.Is(signalPair(pc, noCodecPC), ErrUnsupportedCodec))
 
-		assert.NoError(t, noCodecPC.Close())
-		assert.NoError(t, pc.Close())
+		closePairNow(t, noCodecPC, pc)
 	})
 
 	t.Run("Answerer", func(t *testing.T) {
@@ -62,8 +61,7 @@ func Test_TrackLocalStatic_NoCodecIntersection(t *testing.T) {
 
 		assert.True(t, errors.Is(signalPair(vp9OnlyPC, pc), ErrUnsupportedCodec))
 
-		assert.NoError(t, vp9OnlyPC.Close())
-		assert.NoError(t, pc.Close())
+		closePairNow(t, vp9OnlyPC, pc)
 	})
 
 	t.Run("Local", func(t *testing.T) {
@@ -77,8 +75,7 @@ func Test_TrackLocalStatic_NoCodecIntersection(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, errors.Is(signalPair(offerer, answerer), ErrUnsupportedCodec))
-		assert.NoError(t, offerer.Close())
-		assert.NoError(t, answerer.Close())
+		closePairNow(t, offerer, answerer)
 	})
 }
 
@@ -108,8 +105,7 @@ func Test_TrackLocalStatic_Closed(t *testing.T) {
 
 	assert.Equal(t, len(vp8Writer.bindings), 1, "binding should exist after signaling")
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 
 	assert.Equal(t, len(vp8Writer.bindings), 0, "No binding should exist after close")
 }
@@ -160,8 +156,7 @@ func Test_TrackLocalStatic_PayloadType(t *testing.T) {
 
 	sendVideoUntilDone(onTrackFired.Done(), t, []*TrackLocalStaticSample{track})
 
-	assert.NoError(t, offerer.Close())
-	assert.NoError(t, answerer.Close())
+	closePairNow(t, offerer, answerer)
 }
 
 // Assert that writing to a Track doesn't modify the input
@@ -190,8 +185,7 @@ func Test_TrackLocalStatic_Mutate_Input(t *testing.T) {
 	assert.Equal(t, pkt.Header.SSRC, uint32(1))
 	assert.Equal(t, pkt.Header.PayloadType, uint8(1))
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 // Assert that writing to a Track that has Binded (but not connected)
@@ -227,8 +221,7 @@ func Test_TrackLocalStatic_Binding_NonBlocking(t *testing.T) {
 	_, err = vp8Writer.Write(make([]byte, 20))
 	assert.NoError(t, err)
 
-	assert.NoError(t, pcOffer.Close())
-	assert.NoError(t, pcAnswer.Close())
+	closePairNow(t, pcOffer, pcAnswer)
 }
 
 func BenchmarkTrackLocalWrite(b *testing.B) {


### PR DESCRIPTION
Instead of explicitly closing each PeerConnection use helper.
No change in test behavior, just makes code more consistent.
