### PR TITLE
Fix updateHeaderExtension for cloned MediaEngine

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -284,11 +284,15 @@ func (m *MediaEngine) getHeaderExtensionID(extension RTPHeaderExtensionCapabilit
 // copy copies any user modifiable state of the MediaEngine
 // all internal state is reset
 func (m *MediaEngine) copy() *MediaEngine {
-	return &MediaEngine{
+	cloned := &MediaEngine{
 		videoCodecs:      append([]RTPCodecParameters{}, m.videoCodecs...),
 		audioCodecs:      append([]RTPCodecParameters{}, m.audioCodecs...),
 		headerExtensions: append([]mediaEngineHeaderExtension{}, m.headerExtensions...),
 	}
+	if len(m.headerExtensions) > 0 {
+		cloned.negotiatedHeaderExtensions = map[int]mediaEngineHeaderExtension{}
+	}
+	return cloned
 }
 
 func (m *MediaEngine) getCodecByPayload(payloadType PayloadType) (RTPCodecParameters, RTPCodecType, error) {


### PR DESCRIPTION
#### Description
It addresses the issue that unable to updateHeaderExtension for cloned
MediaEngine, which is resulted from previous commit:

c8b7aa386a92100a0377fd32660c810d6e4e7e28

#### Reference issue
Fixes a possible(?) side-effect from the PR for #1662 
