### PR TITLE
Fix ice-lite parsing in SDP when whitespaces are present

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1100,8 +1100,10 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 	}
 
 	remoteIsLite := false
-	if liteValue, haveRemoteIs := desc.parsed.Attribute(sdp.AttrKeyICELite); haveRemoteIs && liteValue == sdp.AttrKeyICELite {
-		remoteIsLite = true
+	for _, a := range desc.parsed.Attributes {
+		if strings.TrimSpace(a.Key) == sdp.AttrKeyICELite {
+			remoteIsLite = true
+		}
 	}
 
 	fingerprint, fingerprintHash, err := extractFingerprint(desc.parsed)


### PR DESCRIPTION
#### Description
Created a test that asserts that if pion receives an ice-lite SDP offer, it will assume ice-controlling role.
pion generates full ice answers, so in this exchange of ice-lite vs full ice, the full ice peer should always assume controlling role.
https://tools.ietf.org/html/rfc5245#section-5.2

#### Reference issue
Fixes #...
