### PR TITLE
Fixes peerconnection: AddTrack on Sendonly transceiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [donotanswer](https://github.com/f-viktor)
 * [Reese](https://github.com/figadore)
 * [David Zhao](https://github.com/davidzhao)
+* [Markus Tzoe](https://github.com/zyxar)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1052,7 +1052,8 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 
 				localDirection := RTPTransceiverDirectionRecvonly
 				if direction == RTPTransceiverDirectionRecvonly {
-					localDirection = RTPTransceiverDirectionSendonly
+					// new transceiver: set to inactive instead of sendonly since no track added
+					localDirection = RTPTransceiverDirectionInactive
 				}
 
 				t = pc.newRTPTransceiver(receiver, nil, localDirection, kind)
@@ -1060,7 +1061,11 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 				pc.onNegotiationNeeded()
 			} else if direction == RTPTransceiverDirectionRecvonly {
 				if t.Direction() == RTPTransceiverDirectionSendrecv {
-					t.setDirection(RTPTransceiverDirectionSendonly)
+					if t.Sender() != nil { // set to sendonly since track added already
+						t.setDirection(RTPTransceiverDirectionSendonly)
+					} else { // otherwise set to inactive
+						t.setDirection(RTPTransceiverDirectionInactive)
+					}
 				}
 			}
 


### PR DESCRIPTION
#### Description
After #1689, transceiver direction on answerer side is set to `sendonly` if offerer specifies `recvonly`.  However this causes regression on `AddTrack()`: when adding a track on the transceiver it would simply throw out an error:

```go
	switch {
	case track != nil && t.Direction() == RTPTransceiverDirectionRecvonly:
		t.setDirection(RTPTransceiverDirectionSendrecv)
	case track != nil && t.Direction() == RTPTransceiverDirectionInactive:
		t.setDirection(RTPTransceiverDirectionSendonly)
	case track == nil && t.Direction() == RTPTransceiverDirectionSendrecv:
		t.setDirection(RTPTransceiverDirectionRecvonly)
	case track == nil && t.Direction() == RTPTransceiverDirectionSendonly:
		t.setDirection(RTPTransceiverDirectionInactive)
	default:
		return errRTPTransceiverSetSendingInvalidState
	}
``` 

in `setSendingTrack()` only `recvonly` or `inactive` transceivers can be used, but for answerer the `sendonly` transceiver is the right one to *send* stream to offerer.


This sets correct local direction for the case:
if transceiver has track already => set direction to `sendonly`; otherwise set to `inactive`.

#### Reference issue
Fixes #1689, #1700


#### Discussion
Seems currently there is no appropriate way for adding track on a particular transceiver? Say, if I want to skip `recvonly` (local) transceivers and only add track on `sendonly` or `sendrecv` transceivers, I need either
1. extend `AddTrack` method or added an alternative one to simply accept an selecting function as input parameter on choosing a proper transceiver, or
2. choose a transceiver on ranging `pc.GetTransceivers()` and then call `SetSender()` method on that transceiver, which however requires an `RTPSender`; but `NewRTPSender()` or `dtlsTransport` are not exposed for creating an `RTPSender` manually.

Or am I missing something? Please correct me.