### PR TITLE
fix writing rtcp empty arrays

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -147,6 +147,9 @@ var (
 	// ErrSimulcastProbeOverflow indicates that too many Simulcast probe streams are in flight and the requested SSRC was ignored
 	ErrSimulcastProbeOverflow = errors.New("simulcast probe limit has been reached, new SSRC has been discarded")
 
+	// ErrRTCPPacketEmpty indicates that provided rtcp packet array is empty
+	ErrRTCPPacketEmpty = errors.New("rtcp packet is empty")
+
 	errDetachNotEnabled                 = errors.New("enable detaching by calling webrtc.DetachDataChannels()")
 	errDetachBeforeOpened               = errors.New("datachannel not opened yet, try calling Detach from OnOpen")
 	errDtlsTransportNotStarted          = errors.New("the DTLS transport has not started yet")

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1818,6 +1818,9 @@ func (pc *PeerConnection) SetIdentityProvider(provider string) error {
 // WriteRTCP sends a user provided RTCP packet to the connected peer. If no peer is connected the
 // packet is discarded. It also runs any configured interceptors.
 func (pc *PeerConnection) WriteRTCP(pkts []rtcp.Packet) error {
+	if len(pkts) == 0 {
+		return ErrRTCPPacketEmpty
+	}
 	_, err := pc.interceptorRTCPWriter.Write(pkts, make(interceptor.Attributes))
 	return err
 }


### PR DESCRIPTION
#### Description

Fix panic caused when a rtcp array is empty, packet marshal will return an empty byte slice causing and out of range panic

````
panic: runtime error: index out of range [3] with length 0
goroutine 3244 [running]:
encoding/binary.bigEndian.Uint32(...)
c:/go/src/encoding/binary/binary.go:112
github.com/pion/srtp/v2.(*Context).encryptRTCP(0xc00006a8d0, 0x0, 0x0, 0x0, 0xc00166e198, 0x4, 0x8, 0xc0005f7da8, 0x13674b, 0xc00097efc0, ...)
```

