### PR TITLE
Remove OPUS default FMTP

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -65,7 +65,7 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 	// Default Pion Audio Codecs
 	for _, codec := range []RTPCodecParameters{
 		{
-			RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 2, "minptime=10;useinbandfec=1", nil},
+			RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 2, "", nil},
 			PayloadType:        111,
 		},
 		{

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -71,7 +71,6 @@ s=-
 t=0 0
 m=audio 9 UDP/TLS/RTP/SAVPF 111
 a=rtpmap:111 opus/48000/2
-a=fmtp:111 minptime=10; useinbandfec=1
 `
 
 		m := MediaEngine{}
@@ -93,7 +92,6 @@ s=-
 t=0 0
 m=audio 9 UDP/TLS/RTP/SAVPF 112
 a=rtpmap:112 opus/48000/2
-a=fmtp:112 minptime=10; useinbandfec=1
 `
 
 		m := MediaEngine{}
@@ -118,7 +116,6 @@ s=-
 t=0 0
 m=audio 9 UDP/TLS/RTP/SAVPF 111
 a=rtpmap:111 OPUS/48000/2
-a=fmtp:111 minptime=10; useinbandfec=1
 `
 
 		m := MediaEngine{}

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -449,7 +449,6 @@ func TestCodecsFromMediaDescription(t *testing.T) {
 			},
 			Attributes: []sdp.Attribute{
 				{Key: "rtpmap", Value: "111 opus/48000/2"},
-				{Key: "fmtp", Value: "111 minptime=10;useinbandfec=1"},
 				{Key: "rtcp-fb", Value: "111 goog-remb"},
 				{Key: "rtcp-fb", Value: "111 ccm fir"},
 			},
@@ -457,7 +456,7 @@ func TestCodecsFromMediaDescription(t *testing.T) {
 
 		assert.Equal(t, codecs, []RTPCodecParameters{
 			{
-				RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 2, "minptime=10;useinbandfec=1", []RTCPFeedback{{"goog-remb", ""}, {"ccm", "fir"}}},
+				RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 2, "", []RTCPFeedback{{"goog-remb", ""}, {"ccm", "fir"}}},
 				PayloadType:        111,
 			},
 		})


### PR DESCRIPTION
User may enable/disable inband FEC and use other frame.

Also, it works around the codec negotiation failure between pion and Firefox. Firefox default OPUS FMTP is `maxplaybackrate=48000;stereo=1;useinbandfec=1`, so they weren't matched by the current codecParametersFuzzySearch().

### Reference issue
Part of #1711
