### PR TITLE
Fixes for pre-added recvonly transceivers

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1044,7 +1044,8 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 				}
 			}
 
-			if t == nil {
+			switch {
+			case t == nil:
 				receiver, err := pc.api.NewRTPReceiver(kind, pc.dtlsTransport)
 				if err != nil {
 					return err
@@ -1058,9 +1059,13 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 				t = pc.newRTPTransceiver(receiver, nil, localDirection, kind)
 
 				pc.onNegotiationNeeded()
-			} else if direction == RTPTransceiverDirectionRecvonly {
+			case direction == RTPTransceiverDirectionRecvonly:
 				if t.Direction() == RTPTransceiverDirectionSendrecv {
 					t.setDirection(RTPTransceiverDirectionSendonly)
+				}
+			case direction == RTPTransceiverDirectionSendrecv:
+				if t.Direction() == RTPTransceiverDirectionSendonly {
+					t.setDirection(RTPTransceiverDirectionSendrecv)
 				}
 			}
 

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -115,6 +115,12 @@ func (t *RTPTransceiver) setSendingTrack(track TrackLocal) error {
 		t.setDirection(RTPTransceiverDirectionSendonly)
 	case track == nil && t.Direction() == RTPTransceiverDirectionSendrecv:
 		t.setDirection(RTPTransceiverDirectionRecvonly)
+	case track != nil && t.Direction() == RTPTransceiverDirectionSendonly:
+		// Handle the case where a sendonly transceiver was added by a negotiation
+		// initiated by remote peer. For example a remote peer added a transceiver
+		// with direction recvonly.
+	case track != nil && t.Direction() == RTPTransceiverDirectionSendrecv:
+		// Similar to above, but for sendrecv transceiver.
 	case track == nil && t.Direction() == RTPTransceiverDirectionSendonly:
 		t.setDirection(RTPTransceiverDirectionInactive)
 	default:


### PR DESCRIPTION
Which were previously unable to:

1. have a sending track set to them, or
2. receive a track after renegotiation.

I'm not 100% sure if this covers all cases where a track is added and
removed and then added again. BUT IIRC there was a change that did not
allow transceiver reuse after a track was removed from it. Again, not
100% sure.

Fixes #1722.