### PR TITLE
Parse and compare FmtpLine on codec select

### DIFF
--- a/fmtp.go
+++ b/fmtp.go
@@ -1,0 +1,37 @@
+package webrtc
+
+import (
+	"strings"
+)
+
+type fmtp map[string]string
+
+// parseFmtp parses fmtp string.
+func parseFmtp(line string) fmtp {
+	f := fmtp{}
+	for _, p := range strings.Split(line, ";") {
+		pp := strings.SplitN(strings.TrimSpace(p), "=", 2)
+		key := strings.ToLower(pp[0])
+		var value string
+		if len(pp) > 1 {
+			value = pp[1]
+		}
+		f[key] = value
+	}
+	return f
+}
+
+// fmtpConsist checks that two FTMP parameters are not inconsistent.
+func fmtpConsist(a, b fmtp) bool {
+	for k, v := range a {
+		if vb, ok := b[k]; ok && !strings.EqualFold(vb, v) {
+			return false
+		}
+	}
+	for k, v := range b {
+		if va, ok := a[k]; ok && !strings.EqualFold(va, v) {
+			return false
+		}
+	}
+	return true
+}

--- a/fmtp_test.go
+++ b/fmtp_test.go
@@ -1,0 +1,107 @@
+package webrtc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseFmtp(t *testing.T) {
+	testCases := map[string]struct {
+		input    string
+		expected fmtp
+	}{
+		"OneParam": {
+			input: "key-name=value",
+			expected: fmtp{
+				"key-name": "value",
+			},
+		},
+		"OneParamWithWhiteSpeces": {
+			input: "\tkey-name=value ",
+			expected: fmtp{
+				"key-name": "value",
+			},
+		},
+		"TwoParams": {
+			input: "key-name=value;key2=value2",
+			expected: fmtp{
+				"key-name": "value",
+				"key2":     "value2",
+			},
+		},
+		"TwoParamsWithWhiteSpeces": {
+			input: "key-name=value;  \n\tkey2=value2 ",
+			expected: fmtp{
+				"key-name": "value",
+				"key2":     "value2",
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			f := parseFmtp(testCase.input)
+			if !reflect.DeepEqual(testCase.expected, f) {
+				t.Errorf("Expected Fmtp params: %v, got: %v", testCase.expected, f)
+			}
+		})
+	}
+}
+
+func TestFmtpConsist(t *testing.T) {
+	consistString := map[bool]string{true: "consist", false: "inconsist"}
+
+	testCases := map[string]struct {
+		a, b    string
+		consist bool
+	}{
+		"Equal": {
+			a:       "key1=value1;key2=value2;key3=value3",
+			b:       "key1=value1;key2=value2;key3=value3",
+			consist: true,
+		},
+		"EqualWithWhitespaceVariants": {
+			a:       "key1=value1;key2=value2;key3=value3",
+			b:       "  key1=value1;  \nkey2=value2;\t\nkey3=value3",
+			consist: true,
+		},
+		"EqualWithCase": {
+			a:       "key1=value1;key2=value2;key3=value3",
+			b:       "key1=value1;key2=Value2;Key3=value3",
+			consist: true,
+		},
+		"OneHasExtraParam": {
+			a:       "key1=value1;key2=value2;key3=value3",
+			b:       "key1=value1;key2=value2;key3=value3;key4=value4",
+			consist: true,
+		},
+		"Inconsistent": {
+			a:       "key1=value1;key2=value2;key3=value3",
+			b:       "key1=value1;key2=different_value;key3=value3",
+			consist: false,
+		},
+		"Inconsistent_OneHasExtraParam": {
+			a:       "key1=value1;key2=value2;key3=value3;key4=value4",
+			b:       "key1=value1;key2=different_value;key3=value3",
+			consist: false,
+		},
+	}
+	for name, testCase := range testCases {
+		testCase := testCase
+		check := func(t *testing.T, a, b string) {
+			c := fmtpConsist(parseFmtp(a), parseFmtp(b))
+			if c != testCase.consist {
+				t.Errorf(
+					"'%s' and '%s' are expected to be %s, but treated as %s",
+					a, b, consistString[testCase.consist], consistString[c],
+				)
+			}
+		}
+		t.Run(name, func(t *testing.T) {
+			check(t, testCase.a, testCase.b)
+		})
+		t.Run(name+"_Reversed", func(t *testing.T) {
+			check(t, testCase.b, testCase.a)
+		})
+	}
+}

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -340,8 +340,9 @@ func (m *MediaEngine) matchRemoteCodec(remoteCodec RTPCodecParameters, typ RTPCo
 		codecs = m.audioCodecs
 	}
 
-	if strings.HasPrefix(remoteCodec.RTPCodecCapability.SDPFmtpLine, "apt=") {
-		payloadType, err := strconv.Atoi(strings.TrimPrefix(remoteCodec.RTPCodecCapability.SDPFmtpLine, "apt="))
+	remoteFmtp := parseFmtp(remoteCodec.RTPCodecCapability.SDPFmtpLine)
+	if apt, hasApt := remoteFmtp["apt"]; hasApt {
+		payloadType, err := strconv.Atoi(apt)
 		if err != nil {
 			return codecMatchNone, err
 		}

--- a/rtpcodec.go
+++ b/rtpcodec.go
@@ -97,19 +97,19 @@ const (
 // Used for lookup up a codec in an existing list to find a match
 // Returns codecMatchExact, codecMatchPartial, or codecMatchNone
 func codecParametersFuzzySearch(needle RTPCodecParameters, haystack []RTPCodecParameters) (RTPCodecParameters, codecMatchType) {
+	needleFmtp := parseFmtp(needle.RTPCodecCapability.SDPFmtpLine)
+
 	// First attempt to match on MimeType + SDPFmtpLine
-	// Exact matches means fmtp line cannot be empty
 	for _, c := range haystack {
 		if strings.EqualFold(c.RTPCodecCapability.MimeType, needle.RTPCodecCapability.MimeType) &&
-			c.RTPCodecCapability.SDPFmtpLine == needle.RTPCodecCapability.SDPFmtpLine {
+			fmtpConsist(needleFmtp, parseFmtp(c.RTPCodecCapability.SDPFmtpLine)) {
 			return c, codecMatchExact
 		}
 	}
 
-	// Fallback to just MimeType if either haystack or needle does not have fmtpline set
+	// Fallback to just MimeType
 	for _, c := range haystack {
-		if strings.EqualFold(c.RTPCodecCapability.MimeType, needle.RTPCodecCapability.MimeType) &&
-			(c.RTPCodecCapability.SDPFmtpLine == "" || needle.RTPCodecCapability.SDPFmtpLine == "") {
+		if strings.EqualFold(c.RTPCodecCapability.MimeType, needle.RTPCodecCapability.MimeType) {
 			return c, codecMatchPartial
 		}
 	}


### PR DESCRIPTION
Exact match if fmtp parameters are not inconsistent.

e.g. default OPUS fmtp of the browsers are:
- Chrome:  `minptime=10;useinbandfec=1`
- Firefox: `maxplaybackrate=48000;stereo=1;useinbandfec=1`

They should be treated as matched.

### Reference issue
#1711
