### PR TITLE
Handle errors properly in mux readLoop

### DIFF
--- a/examples/rtp-to-webrtc/README.md
+++ b/examples/rtp-to-webrtc/README.md
@@ -35,13 +35,13 @@ gst-launch-1.0 videotestsrc ! video/x-raw,width=640,height=480,format=I420 ! vp8
 
 #### ffmpeg
 ```
-ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec libvpx -cpu-used 5 -deadline 1 -g 10 -error-resilient 1 -auto-alt-ref 1 -f rtp rtp://127.0.0.1:5004
+ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec libvpx -cpu-used 5 -deadline 1 -g 10 -error-resilient 1 -auto-alt-ref 1 -f rtp rtp://127.0.0.1:5004?pkt_size=1200
 ```
 
 If you wish to send audio replace both occurrences of `vp8` in `main.go` then run
 
 ```
-ffmpeg -f lavfi -i "sine=frequency=1000" -c:a libopus -b:a 48000 -sample_fmt s16p -ssrc 1 -payload_type 111 -f rtp -max_delay 0 -application lowdelay rtp:/127.0.0.1:5004
+ffmpeg -f lavfi -i "sine=frequency=1000" -c:a libopus -b:a 48000 -sample_fmt s16p -ssrc 1 -payload_type 111 -f rtp -max_delay 0 -application lowdelay rtp:/127.0.0.1:5004?pkt_size=1200
 ```
 
 ### Input rtp-to-webrtc's SessionDescription into your browser

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -108,8 +108,7 @@ func (m *Mux) readLoop() {
 			return
 		}
 
-		err = m.dispatch(buf[:n])
-		if err != nil {
+		if err = m.dispatch(buf[:n]); err != nil {
 			return
 		}
 	}

--- a/internal/mux/muxfunc.go
+++ b/internal/mux/muxfunc.go
@@ -13,11 +13,6 @@ func MatchAll(b []byte) bool {
 	return true
 }
 
-// MatchNone always returns false
-func MatchNone(b []byte) bool {
-	return false
-}
-
 // MatchRange is a MatchFunc that accepts packets with the first byte in [lower..upper]
 func MatchRange(lower, upper byte) MatchFunc {
 	return func(buf []byte) bool {
@@ -43,28 +38,10 @@ func MatchRange(lower, upper byte) MatchFunc {
 //              |    [128..191] -+--> forward to RTP/RTCP
 //              +----------------+
 
-// MatchSTUN is a MatchFunc that accepts packets with the first byte in [0..3]
-// as defied in RFC7983
-func MatchSTUN(b []byte) bool {
-	return MatchRange(0, 3)(b)
-}
-
-// MatchZRTP is a MatchFunc that accepts packets with the first byte in [16..19]
-// as defied in RFC7983
-func MatchZRTP(b []byte) bool {
-	return MatchRange(16, 19)(b)
-}
-
 // MatchDTLS is a MatchFunc that accepts packets with the first byte in [20..63]
 // as defied in RFC7983
 func MatchDTLS(b []byte) bool {
 	return MatchRange(20, 63)(b)
-}
-
-// MatchTURN is a MatchFunc that accepts packets with the first byte in [64..79]
-// as defied in RFC7983
-func MatchTURN(b []byte) bool {
-	return MatchRange(64, 79)(b)
 }
 
 // MatchSRTPOrSRTCP is a MatchFunc that accepts packets with the first byte in [128..191]


### PR DESCRIPTION
Before io.ErrShortBuffer and packetio.ErrTimeout would incorrectly end
the read loop. Now they are only printed.

Resolves #1720
