### PR TITLE
PeerConnection: make AddTrack thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Reese](https://github.com/figadore)
 * [David Zhao](https://github.com/davidzhao)
 * [Nam V. Do](https://github.com/namvdo)
+* [Markus Tzoe](https://github.com/zyxar)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -1081,3 +1081,51 @@ func TestPeerConnection_CreateOffer_InfiniteLoop(t *testing.T) {
 
 	assert.NoError(t, pc.Close())
 }
+
+// Assert that AddTrack is thread-safe
+func TestPeerConnection_RaceReplaceTrack(t *testing.T) {
+	pc, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	addTrack := func() *TrackLocalStaticSample {
+		track, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: "video/vp8"}, "foo", "bar")
+		assert.NoError(t, err)
+		_, err = pc.AddTrack(track)
+		assert.NoError(t, err)
+		return track
+	}
+
+	for i := 0; i < 10; i++ {
+		addTrack()
+	}
+	for _, tr := range pc.GetTransceivers() {
+		assert.NoError(t, pc.RemoveTrack(tr.Sender()))
+	}
+
+	var wg sync.WaitGroup
+	tracks := make([]*TrackLocalStaticSample, 10)
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func(j int) {
+			tracks[j] = addTrack()
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+
+	for _, track := range tracks {
+		have := false
+		for _, t := range pc.GetTransceivers() {
+			if t.Sender() != nil && t.Sender().Track() == track {
+				have = true
+				break
+			}
+		}
+		if !have {
+			t.Errorf("track was added but not found on senders")
+		}
+	}
+
+	assert.NoError(t, pc.Close())
+}

--- a/sdp.go
+++ b/sdp.go
@@ -400,13 +400,13 @@ func populateSDP(d *sdp.SessionDescription, isPlanB bool, dtlsFingerprints []DTL
 		}
 
 		shouldAddID := true
-		shouldAddCanidates := i == 0
+		shouldAddCandidates := i == 0
 		if m.data {
-			if err = addDataMediaSection(d, shouldAddCanidates, mediaDtlsFingerprints, m.id, iceParams, candidates, connectionRole, iceGatheringState); err != nil {
+			if err = addDataMediaSection(d, shouldAddCandidates, mediaDtlsFingerprints, m.id, iceParams, candidates, connectionRole, iceGatheringState); err != nil {
 				return nil, err
 			}
 		} else {
-			shouldAddID, err = addTransceiverSDP(d, isPlanB, shouldAddCanidates, mediaDtlsFingerprints, mediaEngine, m.id, iceParams, candidates, connectionRole, iceGatheringState, m)
+			shouldAddID, err = addTransceiverSDP(d, isPlanB, shouldAddCandidates, mediaDtlsFingerprints, mediaEngine, m.id, iceParams, candidates, connectionRole, iceGatheringState, m)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
#### Description
Use fine granularity lock to protect `rtpTransceivers` in  `PeerConnection` which shall make `AddTrack()` and `RemoveTrack()` thread-safe.

#### Reference issue
Fixes #1574


Note: 
- the added test `TestPeerConnection_RaceReplaceTrack` is from #1574
- not quite sure about the remaining `GetTransceivers()` callings in `peerconnection.go`; seems they are used as snapshots or cache, may still have data race in this PR.
- previously the coarse lock `mu` is used almost everywhere for exclusive access in `PeerConnection`; changing to a separated lock for `rtpTransceivers` might have implicit conflicts, which I'm not 100% sure by far.

