### PR TITLE
FAIL: Add certificate save & load

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -78,7 +78,8 @@ func GetOrCreateCertificate(filename string) (*Certificate, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse private key: %w", err)
 	}
-	return NewCertificate(privateKey, *cert)
+	r := CertificateFromX509(privateKey, cert)
+	return &r, nil
 }
 
 // NewCertificate generates a new x509 compliant Certificate to be used

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -9,7 +9,10 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -98,4 +101,19 @@ func TestGenerateCertificateExpires(t *testing.T) {
 	x509Cert := CertificateFromX509(sk, &x509.Certificate{})
 	assert.NotNil(t, x509Cert)
 	assert.Contains(t, x509Cert.statsID, "certificate")
+}
+
+func TestGetOrCreateCertificate(t *testing.T) {
+	randBytes := make([]byte, 16)
+	n, err := rand.Read(randBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, n, 16)
+	fn := filepath.Join(os.TempDir(), hex.EncodeToString(randBytes))
+	cert1, err := GetOrCreateCertificate(fn)
+	assert.NoError(t, err)
+	cert2, err := GetOrCreateCertificate(fn)
+	assert.NoError(t, err)
+	assert.True(t, cert1.privateKeyEquals(*cert2))
+	assert.True(t, cert1.Equals(*cert2))
+	_ = os.Remove(fn)
 }

--- a/errors.go
+++ b/errors.go
@@ -217,4 +217,6 @@ var (
 	errStatsICECandidateStateInvalid = errors.New("cannot convert to StatsICECandidatePairStateSucceeded invalid ice candidate state")
 
 	errICETransportNotInNew = errors.New("ICETransport can only be called in ICETransportStateNew")
+
+	errCertificateFileFormatError = errors.New("Certificate file format error")
 )


### PR DESCRIPTION
This PR adds `GetOrCreateCertificat('cert.pem')` letting programs keep a consistent certificate.

#### Description

Sorry for sending a failed PR as my first, but i'm stuck.

This PR includes the function and it creates a pem file, writes the certificate and private key as blocks, reads it back and parses it. The code seems to be working fine and the test verifies the private key is properly stored and loaded. I just can't get the certificate to be equal. I suspect it has to do with some dark x509 magic and I need a pro.
