### PR TITLE
Certificate serialization to a pem formatted string

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -191,7 +191,7 @@ func CertificateFromPEM(pems string) (*Certificate, error) {
 	// decode & parse the certificate
 	block, more := pem.Decode([]byte(pems))
 	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, errCertificateFileFormatError
+		return nil, errCertificatePEMFormatError
 	}
 	certBytes := make([]byte, base64.StdEncoding.DecodedLen(len(block.Bytes)))
 	n, err := base64.StdEncoding.Decode(certBytes, block.Bytes)
@@ -205,7 +205,7 @@ func CertificateFromPEM(pems string) (*Certificate, error) {
 	// decode & parse the private key
 	block, _ = pem.Decode(more)
 	if block == nil || block.Type != "PRIVATE KEY" {
-		return nil, errCertificateFileFormatError
+		return nil, errCertificatePEMFormatError
 	}
 	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {

--- a/certificate.go
+++ b/certificate.go
@@ -78,7 +78,8 @@ func GetOrCreateCertificate(filename string) (*Certificate, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse private key: %w", err)
 	}
-	return NewCertificate(privateKey, *cert)
+	r := CertificateFromX509(privateKey, cert)
+	return &r, nil
 }
 
 // NewCertificate generates a new x509 compliant Certificate to be used

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -9,7 +9,10 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -98,4 +101,19 @@ func TestGenerateCertificateExpires(t *testing.T) {
 	x509Cert := CertificateFromX509(sk, &x509.Certificate{})
 	assert.NotNil(t, x509Cert)
 	assert.Contains(t, x509Cert.statsID, "certificate")
+}
+
+func TestGetOrCreateCertificate(t *testing.T) {
+	randBytes := make([]byte, 16)
+	n, err := rand.Read(randBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, n, 16)
+	fn := filepath.Join(os.TempDir(), hex.EncodeToString(randBytes))
+	cert1, err := GetOrCreateCertificate(fn)
+	assert.NoError(t, err)
+	cert2, err := GetOrCreateCertificate(fn)
+	assert.NoError(t, err)
+	assert.True(t, cert1.privateKeyEquals(*cert2))
+	assert.True(t, cert1.Equals(*cert2))
+	_ = os.Remove(fn)
 }

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -9,10 +9,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/pem"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -103,17 +100,17 @@ func TestGenerateCertificateExpires(t *testing.T) {
 	assert.Contains(t, x509Cert.statsID, "certificate")
 }
 
-func TestGetOrCreateCertificate(t *testing.T) {
-	randBytes := make([]byte, 16)
-	n, err := rand.Read(randBytes)
-	assert.NoError(t, err)
-	assert.Equal(t, n, 16)
-	fn := filepath.Join(os.TempDir(), hex.EncodeToString(randBytes))
-	cert1, err := GetOrCreateCertificate(fn)
-	assert.NoError(t, err)
-	cert2, err := GetOrCreateCertificate(fn)
-	assert.NoError(t, err)
-	assert.True(t, cert1.privateKeyEquals(*cert2))
-	assert.True(t, cert1.Equals(*cert2))
-	_ = os.Remove(fn)
+func TestPEM(t *testing.T) {
+	sk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.Nil(t, err)
+	cert, err := GenerateCertificate(sk)
+	assert.Nil(t, err)
+
+	pem, err := cert.PEM()
+	assert.Nil(t, err)
+	cert2, err := CertificateFromPEM(pem)
+	assert.Nil(t, err)
+	pem2, err := cert2.PEM()
+	assert.Nil(t, err)
+	assert.Equal(t, pem, pem2)
 }

--- a/errors.go
+++ b/errors.go
@@ -217,4 +217,6 @@ var (
 	errStatsICECandidateStateInvalid = errors.New("cannot convert to StatsICECandidatePairStateSucceeded invalid ice candidate state")
 
 	errICETransportNotInNew = errors.New("ICETransport can only be called in ICETransportStateNew")
+
+	errCertificateFileFormatError = errors.New("Certificate file format error")
 )

--- a/errors.go
+++ b/errors.go
@@ -218,5 +218,5 @@ var (
 
 	errICETransportNotInNew = errors.New("ICETransport can only be called in ICETransportStateNew")
 
-	errCertificateFileFormatError = errors.New("Certificate file format error")
+	errCertificatePEMFormatError = errors.New("bad Certificate PEM format")
 )


### PR DESCRIPTION
This PR  Replaces #1738  and adds function to serialize a certificate into a pem string and to create a certificate from a pem string.

This is useful for preserving consistency across session, allowing programs to save the certificate to a file.