### PR TITLE
Fixes DataChannel panic on sctp transport race

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -96,12 +96,13 @@ func (r *SCTPTransport) Start(remoteCaps SCTPCapabilities) error {
 	}
 	r.isStarted = true
 
-	if err := r.ensureDTLS(); err != nil {
-		return err
+	dtlsTransport := r.Transport()
+	if dtlsTransport == nil || dtlsTransport.conn == nil {
+		return errSCTPTransportDTLS
 	}
 
 	sctpAssociation, err := sctp.Client(sctp.Config{
-		NetConn:       r.Transport().conn,
+		NetConn:       dtlsTransport.conn,
 		LoggerFactory: r.api.settingEngine.LoggerFactory,
 	})
 	if err != nil {
@@ -133,15 +134,6 @@ func (r *SCTPTransport) Stop() error {
 
 	r.association = nil
 	r.state = SCTPTransportStateClosed
-
-	return nil
-}
-
-func (r *SCTPTransport) ensureDTLS() error {
-	dtlsTransport := r.Transport()
-	if dtlsTransport == nil || dtlsTransport.conn == nil {
-		return errSCTPTransportDTLS
-	}
 
 	return nil
 }


### PR DESCRIPTION
#### Description
`DataChannel.open` would panic during which if `PeerConnection` is closed,
stopping underlying `SCTPTransport` which sets association to `nil`;

`DataChannel.ensureSCTP` method doesn't guarantee `SCTPTransport`'s availability out of it's own scope.

Also fix similar issue in `SCTPTransport.Start`.

#### Reference issue
Fixes #1730
