### PR TITLE
SCTPTransport: add getAssociation

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -104,12 +104,7 @@ func (api *API) newDataChannel(params *DataChannelParameters, log logging.Levele
 
 // open opens the datachannel over the sctp transport
 func (d *DataChannel) open(sctpTransport *SCTPTransport) error {
-	if sctpTransport == nil {
-		return errSCTPNotEstablished
-	}
-	sctpTransport.lock.RLock()
-	association := sctpTransport.association
-	sctpTransport.lock.RUnlock()
+	association := sctpTransport.association()
 	if association == nil {
 		return errSCTPNotEstablished
 	}

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -338,11 +338,7 @@ func TestPeerConnection_Media_Disconnected(t *testing.T) {
 			// Assert that DTLS is done by pull remote certificate, don't tear down the PC early
 			for {
 				if len(vp8Sender.Transport().GetRemoteCertificate()) != 0 {
-					pcAnswer.sctpTransport.lock.RLock()
-					haveAssociation := pcAnswer.sctpTransport.association != nil
-					pcAnswer.sctpTransport.lock.RUnlock()
-
-					if haveAssociation {
+					if pcAnswer.sctpTransport.association() != nil {
 						break
 					}
 				}

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -41,7 +41,7 @@ type SCTPTransport struct {
 
 	onErrorHandler func(error)
 
-	association                *sctp.Association
+	sctpAssociation            *sctp.Association
 	onDataChannelHandler       func(*DataChannel)
 	onDataChannelOpenedHandler func(*DataChannel)
 
@@ -112,7 +112,7 @@ func (r *SCTPTransport) Start(remoteCaps SCTPCapabilities) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	r.association = sctpAssociation
+	r.sctpAssociation = sctpAssociation
 	r.state = SCTPTransportStateConnected
 
 	go r.acceptDataChannels(sctpAssociation)
@@ -124,15 +124,15 @@ func (r *SCTPTransport) Start(remoteCaps SCTPCapabilities) error {
 func (r *SCTPTransport) Stop() error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.association == nil {
+	if r.sctpAssociation == nil {
 		return nil
 	}
-	err := r.association.Close()
+	err := r.sctpAssociation.Close()
 	if err != nil {
 		return err
 	}
 
-	r.association = nil
+	r.sctpAssociation = nil
 	r.state = SCTPTransportStateClosed
 
 	return nil
@@ -320,10 +320,6 @@ func (r *SCTPTransport) State() SCTPTransportState {
 }
 
 func (r *SCTPTransport) collectStats(collector *statsReportCollector) {
-	r.lock.Lock()
-	association := r.association
-	r.lock.Unlock()
-
 	collector.Collecting()
 
 	stats := TransportStats{
@@ -332,6 +328,7 @@ func (r *SCTPTransport) collectStats(collector *statsReportCollector) {
 		ID:        "sctpTransport",
 	}
 
+	association := r.association()
 	if association != nil {
 		stats.BytesSent = association.BytesSent()
 		stats.BytesReceived = association.BytesReceived()
@@ -368,4 +365,14 @@ func (r *SCTPTransport) generateAndSetDataChannelID(dtlsRole DTLSRole, idOut **u
 	}
 
 	return &rtcerr.OperationError{Err: ErrMaxDataChannelID}
+}
+
+func (r *SCTPTransport) association() *sctp.Association {
+	if r == nil {
+		return nil
+	}
+	r.lock.RLock()
+	association := r.sctpAssociation
+	r.lock.RUnlock()
+	return association
 }


### PR DESCRIPTION
#### Description
Use assocation() instead of accessing private struct member

member variable `association` in SCTPTransport renamed to `sctpAssociation`

This is a follow-up commit to #1747