### PR TITLE
Fixes peerconnection: potential deadlock

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1923,8 +1923,11 @@ func (pc *PeerConnection) newRTPTransceiver(
 // by the ICEAgent since the offer or answer was created.
 func (pc *PeerConnection) CurrentLocalDescription() *SessionDescription {
 	pc.mu.Lock()
-	defer pc.mu.Unlock()
-	return populateLocalCandidates(pc.currentLocalDescription, pc.iceGatherer, pc.ICEGatheringState())
+	localDescription := pc.currentLocalDescription
+	iceGather := pc.iceGatherer
+	iceGatheringState := pc.ICEGatheringState()
+	pc.mu.Unlock()
+	return populateLocalCandidates(localDescription, iceGather, iceGatheringState)
 }
 
 // PendingLocalDescription represents a local description that is in the
@@ -1933,8 +1936,11 @@ func (pc *PeerConnection) CurrentLocalDescription() *SessionDescription {
 // PeerConnection is in the stable state, the value is null.
 func (pc *PeerConnection) PendingLocalDescription() *SessionDescription {
 	pc.mu.Lock()
-	defer pc.mu.Unlock()
-	return populateLocalCandidates(pc.pendingLocalDescription, pc.iceGatherer, pc.ICEGatheringState())
+	localDescription := pc.pendingLocalDescription
+	iceGather := pc.iceGatherer
+	iceGatheringState := pc.ICEGatheringState()
+	pc.mu.Unlock()
+	return populateLocalCandidates(localDescription, iceGather, iceGatheringState)
 }
 
 // CurrentRemoteDescription represents the last remote description that was


### PR DESCRIPTION
#### Description
Potential deadlock:
In `CurrentLocalDescription()` or `PendingLocalDescription()`:
when gathering local candidates in `populateLocalCandidates()` (while holding PeerConnection lock),
agent would try submitting a task via `agent.run()`:
```go
	a.chanTask <- task
```
the `chanTask` is consumed by `taskLoop` routine:
```go
	for {
		select {
		case <-a.done:
			return
		case t := <-a.chanTask:
			t.fn(a.context(), a)
			close(t.done)
			after()
		}
	}
```
while there're other routines using the agent, e.g. calling
`agent.updateConnectionState()`
```go
	a.afterRun(func(ctx context.Context) {
		a.chanState <- newState
	})
```
and the submitted task would be run by the `after()` func in
`taskLoop()`, where the `a.chanState` is consumed by
`agent.startOnConnectionStateChangeRoutine()`

this `after()` task may block the `taskLoop` routine when there's ongoing
event handler `agent.onConnectionStateChange()`, which would
eventually call `PeerConnection`'s `onICEConnectionStateChange()`:
```go
	pc.mu.Lock()
	pc.iceConnectionState = cs
	handler := pc.onICEConnectionStateChangeHandler
	pc.mu.Unlock()
```
trying to hold the PeerConnection lock, causing _deadlock_

