### PR TITLE
Fix docker file

### DIFF
--- a/examples/pion-to-pion/answer/Dockerfile
+++ b/examples/pion-to-pion/answer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 ENV GO111MODULE=on
 RUN go get -u github.com/pion/webrtc/v3/examples/pion-to-pion/answer

--- a/examples/pion-to-pion/docker-compose.yml
+++ b/examples/pion-to-pion/docker-compose.yml
@@ -6,8 +6,7 @@ services:
     hostname: answer
     restart: always   
     ports:
-      - 50000:50000
-    network_mode: "host"      
+      - 50000:50000    
       
   offer:
     depends_on:  
@@ -16,4 +15,3 @@ services:
     build: ./offer
     hostname: offer
     restart: always
-    network_mode: "host"

--- a/examples/pion-to-pion/offer/Dockerfile
+++ b/examples/pion-to-pion/offer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 ENV GO111MODULE=on
 RUN go get -u github.com/pion/webrtc/v3/examples/pion-to-pion/offer


### PR DESCRIPTION
1. Removes "host" network_mode 

Steps to reproduce:
$ cd examples/pion-to-pion
$ docker-compose up
  ERROR: for answer  "host" network_mode is incompatible with port_bindings


2. Fix undefined os.ErrDeadlineExceeded

Steps to reproduce:
$ cd examples/pion-to-pion
$ docker-compose up
  #4 13.95 pkg/mod/github.com/pion/ice/v2@v2.1.2/udp_mux.go:242:22: undefined: os.ErrDeadlineExceeded

