### PR TITLE
PeerConnection: more thread-safe

### DIFF
--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -20,6 +20,19 @@ type RTPTransceiver struct {
 	kind    RTPCodecType
 }
 
+func newRTPTransceiver(
+	receiver *RTPReceiver,
+	sender *RTPSender,
+	direction RTPTransceiverDirection,
+	kind RTPCodecType,
+) *RTPTransceiver {
+	t := &RTPTransceiver{kind: kind}
+	t.setReceiver(receiver)
+	t.setSender(sender)
+	t.setDirection(direction)
+	return t
+}
+
 // Sender returns the RTPTransceiver's RTPSender if it has one
 func (t *RTPTransceiver) Sender() *RTPSender {
 	if v := t.sender.Load(); v != nil {


### PR DESCRIPTION
#### Description

now proctected by lock:
- `CreateOffer`
- `CreateAnswer`
- `AddTransceiverFromKind`
- `AddTransceiverFromTrack`

newRTPTransceiver is no longer a PeerConnection method;
pc.`addRTPTransceiver` would fire `onNegotiationNeeded`;
pc.`AddTrack`, pc.`RemoveTrack` now hold lock for the entire function;

