### PR TITLE
Add examples/ice-single-port-mode

### DIFF
--- a/examples/ice-single-port/README.md
+++ b/examples/ice-single-port/README.md
@@ -1,0 +1,28 @@
+# ice-single-port
+ice-single-port demonstrates Pion WebRTC's ability to serve many PeerConnections on a single port.
+
+Pion WebRTC has no global state, so by default ports can't be shared between two PeerConnections.
+Using the SettingEngine a developer can manually share state between many PeerConnections and allow
+multiple to use the same port
+
+## Instructions
+
+### Download ice-single-port
+This example requires you to clone the repo since it is serving static HTML.
+
+```
+mkdir -p $GOPATH/src/github.com/pion
+cd $GOPATH/src/github.com/pion
+git clone https://github.com/pion/webrtc.git
+cd webrtc/examples/ice-single-port
+```
+
+### Run ice-single-port
+Execute `go run *.go`
+
+### Open the Web UI
+Open [http://localhost:8080](http://localhost:8080). This will automatically open 5 PeerConnections. This page will print
+a Local/Remote line for each PeerConnection. Note that all 10 PeerConnections have different ports for their Local port.
+However for the remote they all will be using port 8443.
+
+Congrats, you have used Pion WebRTC! Now start building something cool

--- a/examples/ice-single-port/index.html
+++ b/examples/ice-single-port/index.html
@@ -1,0 +1,52 @@
+<html>
+  <head>
+    <title>ice-single-port</title>
+  </head>
+
+  <body>
+    <h3> ICE Selected Pairs </h3>
+    <div id="iceSelectedPairs"></div> <br />
+  </body>
+
+  <script>
+    let createPeerConnection = () => {
+      let pc = new RTCPeerConnection()
+      let dc = pc.createDataChannel('data')
+
+      dc.onopen = () => {
+        let el = document.createElement('template')
+        let selectedPair = pc.sctp.transport.iceTransport.getSelectedCandidatePair()
+
+        el.innerHTML = `<div>
+          <ul>
+             <li> <i> Local</i> - ${selectedPair.local.candidate}</li>
+             <li> <i> Remote</i> - ${selectedPair.remote.candidate} </li>
+          </ul>
+        </div>`
+
+        document.getElementById('iceSelectedPairs').appendChild(el.content.firstChild);
+      }
+
+      pc.createOffer()
+        .then(offer => {
+          pc.setLocalDescription(offer)
+
+          return fetch(`/doSignaling`, {
+            method: 'post',
+            headers: {
+              'Accept': 'application/json, text/plain, */*',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(offer)
+          })
+        })
+        .then(res => res.json())
+        .then(res => pc.setRemoteDescription(res))
+        .catch(alert)
+    }
+
+    for (i = 0; i < 10; i++) {
+      createPeerConnection()
+    }
+  </script>
+</html>

--- a/examples/ice-single-port/main.go
+++ b/examples/ice-single-port/main.go
@@ -1,0 +1,104 @@
+// +build !js
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/pion/webrtc/v3"
+)
+
+var api *webrtc.API //nolint
+
+// Everything below is the Pion WebRTC API! Thanks for using it ❤️.
+func doSignaling(w http.ResponseWriter, r *http.Request) {
+	peerConnection, err := api.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		panic(err)
+	}
+
+	// Set the handler for ICE connection state
+	// This will notify you when the peer has connected/disconnected
+	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
+		fmt.Printf("ICE Connection State has changed: %s\n", connectionState.String())
+	})
+
+	// Send the current time via a DataChannel to the remote peer every 3 seconds
+	peerConnection.OnDataChannel(func(d *webrtc.DataChannel) {
+		d.OnOpen(func() {
+			for range time.Tick(time.Second * 3) {
+				if err = d.SendText(time.Now().String()); err != nil {
+					panic(err)
+				}
+			}
+		})
+	})
+
+	var offer webrtc.SessionDescription
+	if err = json.NewDecoder(r.Body).Decode(&offer); err != nil {
+		panic(err)
+	}
+
+	if err = peerConnection.SetRemoteDescription(offer); err != nil {
+		panic(err)
+	}
+
+	// Create channel that is blocked until ICE Gathering is complete
+	gatherComplete := webrtc.GatheringCompletePromise(peerConnection)
+
+	answer, err := peerConnection.CreateAnswer(nil)
+	if err != nil {
+		panic(err)
+	} else if err = peerConnection.SetLocalDescription(answer); err != nil {
+		panic(err)
+	}
+
+	// Block until ICE Gathering is complete, disabling trickle ICE
+	// we do this because we only can exchange one signaling message
+	// in a production application you should exchange ICE Candidates via OnICECandidate
+	<-gatherComplete
+
+	response, err := json.Marshal(*peerConnection.LocalDescription())
+	if err != nil {
+		panic(err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(response); err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	// Listen on UDP Port 8443, will be used for all WebRTC traffic
+	udpListener, err := net.ListenUDP("udp", &net.UDPAddr{
+		IP:   net.IP{0, 0, 0, 0},
+		Port: 8443,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Listening for WebRTC traffic at %s\n", udpListener.LocalAddr())
+
+	// Create a SettingEngine, this allows non-standard WebRTC behavior
+	settingEngine := webrtc.SettingEngine{}
+
+	// Configure our SettingEngine to use our UDPMux. By default a PeerConnection has
+	// no global state. The API+SettingEngine allows the user to share state between them.
+	// In this case we are sharing our listening port across many.
+	settingEngine.SetICEUDPMux(webrtc.NewICEUDPMux(nil, udpListener))
+
+	// Create a new API using our SettingEngine
+	api = webrtc.NewAPI(webrtc.WithSettingEngine(settingEngine))
+
+	http.Handle("/", http.FileServer(http.Dir(".")))
+	http.HandleFunc("/doSignaling", doSignaling)
+
+	fmt.Println("Open http://localhost:8080 to access this demo")
+	panic(http.ListenAndServe(":8080", nil))
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/gomega v1.11.0 // indirect
 	github.com/pion/datachannel v1.4.21
 	github.com/pion/dtls/v2 v2.0.9
-	github.com/pion/ice/v2 v2.1.2
+	github.com/pion/ice/v2 v2.1.4
 	github.com/pion/interceptor v0.0.12
 	github.com/pion/logging v0.2.2
 	github.com/pion/randutil v0.1.0
@@ -19,6 +19,5 @@ require (
 	github.com/pion/transport v0.12.3
 	github.com/sclevine/agouti v3.0.0+incompatible
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.0.0-20210414194228-064579744ee0
-	golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0 // indirect
+	golang.org/x/net v0.0.0-20210420210106-798c2154c571
 )

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/pion/datachannel v1.4.21 h1:3ZvhNyfmxsAqltQrApLPQMhSFNA+aT87RqyCq4OXm
 github.com/pion/datachannel v1.4.21/go.mod h1:oiNyP4gHx2DIwRzX/MFyH0Rz/Gz05OgBlayAI2hAWjg=
 github.com/pion/dtls/v2 v2.0.9 h1:7Ow+V++YSZQMYzggI0P9vLJz/hUFcffsfGMfT/Qy+u8=
 github.com/pion/dtls/v2 v2.0.9/go.mod h1:O0Wr7si/Zj5/EBFlDzDd6UtVxx25CE1r7XM7BQKYQho=
-github.com/pion/ice/v2 v2.1.2 h1:hnZrg7jZyclNdfrIOyU/MGmIftXxqEP0hCrRXt6r6lY=
-github.com/pion/ice/v2 v2.1.2/go.mod h1:kV4EODVD5ux2z8XncbLHIOtcXKtYXVgLVCeVqnpoeP0=
+github.com/pion/ice/v2 v2.1.4 h1:ABtU8cncApRGERYiTdtagTzVs5oRqL9gUF8sJeXI8EA=
+github.com/pion/ice/v2 v2.1.4/go.mod h1:kV4EODVD5ux2z8XncbLHIOtcXKtYXVgLVCeVqnpoeP0=
 github.com/pion/interceptor v0.0.12 h1:eC1iVneBIAQJEfaNAfDqAncJWhMDAnaXPRCJsltdokE=
 github.com/pion/interceptor v0.0.12/go.mod h1:qzeuWuD/ZXvPqOnxNcnhWfkCZ2e1kwwslicyyPnhoK4=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=
@@ -101,8 +101,8 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210414194228-064579744ee0 h1:iqW3Mjl/6IP9cHJC/wdiIu3lyBDMUfDElRMyFlqbtiQ=
-golang.org/x/net v0.0.0-20210414194228-064579744ee0/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
+golang.org/x/net v0.0.0-20210420210106-798c2154c571 h1:Q6Bg8xzKzpFPU4Oi1sBnBTHBwlMsLeEXpu4hYBY8rAg=
+golang.org/x/net v0.0.0-20210420210106-798c2154c571/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -117,8 +117,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0 h1:g9s1Ppvvun/fI+BptTMj909BBIcGrzQ32k9FNlcevOE=
-golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe h1:WdX7u8s3yOigWAhHEaDl8r9G+4XwFQEQFtBMYyN+kXQ=
+golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/icemux.go
+++ b/icemux.go
@@ -16,3 +16,12 @@ func NewICETCPMux(logger logging.LeveledLogger, listener net.Listener, readBuffe
 		ReadBufferSize: readBufferSize,
 	})
 }
+
+// NewICEUDPMux creates a new instance of ice.UDPMuxDefault. It allows many PeerConnections to be served
+// by a single UDP Port.
+func NewICEUDPMux(logger logging.LeveledLogger, udpConn *net.UDPConn) ice.UDPMux {
+	return ice.NewUDPMuxDefault(ice.UDPMuxParams{
+		UDPConn: udpConn,
+		Logger:  logger,
+	})
+}


### PR DESCRIPTION
Demonstrate how using the new ICEUDPMux multiple PeerConnections
can be served via a single port.
