### PR TITLE
Fixes MediaEngine: codec apt negotiation

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -334,7 +334,7 @@ func (m *MediaEngine) collectStats(collector *statsReportCollector) {
 }
 
 // Look up a codec and enable if it exists
-func (m *MediaEngine) matchRemoteCodec(remoteCodec RTPCodecParameters, typ RTPCodecType) (codecMatchType, error) {
+func (m *MediaEngine) matchRemoteCodec(remoteCodec RTPCodecParameters, typ RTPCodecType, exactMatches, partialMatches []RTPCodecParameters) (codecMatchType, error) {
 	codecs := m.videoCodecs
 	if typ == RTPCodecTypeAudio {
 		codecs = m.audioCodecs
@@ -347,9 +347,33 @@ func (m *MediaEngine) matchRemoteCodec(remoteCodec RTPCodecParameters, typ RTPCo
 			return codecMatchNone, err
 		}
 
-		if _, _, err = m.getCodecByPayload(PayloadType(payloadType)); err != nil {
+		var aptMatch = codecMatchNone
+		for _, codec := range exactMatches {
+			if codec.PayloadType == PayloadType(payloadType) {
+				aptMatch = codecMatchExact
+				break
+			}
+		}
+
+		if aptMatch == codecMatchNone {
+			for _, codec := range partialMatches {
+				if codec.PayloadType == PayloadType(payloadType) {
+					aptMatch = codecMatchPartial
+					break
+				}
+			}
+		}
+
+		if aptMatch == codecMatchNone {
 			return codecMatchNone, nil // not an error, we just ignore this codec we don't support
 		}
+
+		// if apt's media codec is partial match, then apt codec must be partial match too
+		_, matchType := codecParametersFuzzySearch(remoteCodec, codecs)
+		if matchType == codecMatchExact && aptMatch == codecMatchPartial {
+			matchType = codecMatchPartial
+		}
+		return matchType, nil
 	}
 
 	_, matchType := codecParametersFuzzySearch(remoteCodec, codecs)
@@ -416,7 +440,7 @@ func (m *MediaEngine) updateFromRemoteDescription(desc sdp.SessionDescription) e
 		partialMatches := make([]RTPCodecParameters, 0, len(codecs))
 
 		for _, codec := range codecs {
-			matchType, mErr := m.matchRemoteCodec(codec, typ)
+			matchType, mErr := m.matchRemoteCodec(codec, typ, exactMatches, partialMatches)
 			if mErr != nil {
 				return mErr
 			}

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -280,6 +280,72 @@ a=rtpmap:96 VP8/90000
 		_, _, err := m.getCodecByPayload(96)
 		assert.NoError(t, err)
 	})
+
+	t.Run("Matches when rtx apt for exact match codec", func(t *testing.T) {
+		const profileLevels = `v=0
+o=- 4596489990601351948 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=video 60323 UDP/TLS/RTP/SAVPF 94 96 97
+a=rtpmap:94 VP8/90000
+a=rtpmap:96 VP9/90000
+a=fmtp:96 profile-id=2
+a=rtpmap:97 rtx/90000
+a=fmtp:97 apt=96
+`
+		m := MediaEngine{}
+		assert.NoError(t, m.RegisterCodec(RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP8, 90000, 0, "", nil},
+			PayloadType:        94,
+		}, RTPCodecTypeVideo))
+		assert.NoError(t, m.RegisterCodec(RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP9, 90000, 0, "profile-id=2", nil},
+			PayloadType:        96,
+		}, RTPCodecTypeVideo))
+		assert.NoError(t, m.RegisterCodec(RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{"video/rtx", 90000, 0, "apt=96", nil},
+			PayloadType:        97,
+		}, RTPCodecTypeVideo))
+		assert.NoError(t, m.updateFromRemoteDescription(mustParse(profileLevels)))
+
+		assert.True(t, m.negotiatedVideo)
+
+		_, _, err := m.getCodecByPayload(97)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Matches when rtx apt for partial match codec", func(t *testing.T) {
+		const profileLevels = `v=0
+o=- 4596489990601351948 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=video 60323 UDP/TLS/RTP/SAVPF 94 96 97
+a=rtpmap:94 VP8/90000
+a=rtpmap:96 VP9/90000
+a=fmtp:96 profile-id=2
+a=rtpmap:97 rtx/90000
+a=fmtp:97 apt=96
+`
+		m := MediaEngine{}
+		assert.NoError(t, m.RegisterCodec(RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP8, 90000, 0, "", nil},
+			PayloadType:        94,
+		}, RTPCodecTypeVideo))
+		assert.NoError(t, m.RegisterCodec(RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP9, 90000, 0, "profile-id=1", nil},
+			PayloadType:        96,
+		}, RTPCodecTypeVideo))
+		assert.NoError(t, m.RegisterCodec(RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{"video/rtx", 90000, 0, "apt=96", nil},
+			PayloadType:        97,
+		}, RTPCodecTypeVideo))
+		assert.NoError(t, m.updateFromRemoteDescription(mustParse(profileLevels)))
+
+		assert.True(t, m.negotiatedVideo)
+
+		_, _, err := m.getCodecByPayload(97)
+		assert.ErrorIs(t, err, ErrCodecNotFound)
+	})
 }
 
 func TestMediaEngineHeaderExtensionDirection(t *testing.T) {


### PR DESCRIPTION
codec has apt fmtp can't negotiation because it's
apt payloadtype can't be found in negotiation codecs.

rtx codec must be partial match if apt codec is partial.
fix eeb67e1.

#### Description
rtx codec must be partial match if apt codec is partial.

#### Reference issue
Fixes #1785
