### PR TITLE
SRTP Protection Profiles in SettingEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Tomek](https://github.com/trojek)
 * [Jin Gong](https://github.com/cgojin)
 * [yusuke](https://github.com/yusukem99)
+* [Patryk Rogalski](https://github.com/digitalix)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -301,10 +301,16 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 					PrivateKey:  cert.privateKey,
 				},
 			},
-			SRTPProtectionProfiles: []dtls.SRTPProtectionProfile{dtls.SRTP_AEAD_AES_128_GCM, dtls.SRTP_AES128_CM_HMAC_SHA1_80},
-			ClientAuth:             dtls.RequireAnyClientCert,
-			LoggerFactory:          t.api.settingEngine.LoggerFactory,
-			InsecureSkipVerify:     true,
+			SRTPProtectionProfiles: func() []dtls.SRTPProtectionProfile {
+				if len(t.api.settingEngine.srtpProtectionProfiles) > 0 {
+					return t.api.settingEngine.srtpProtectionProfiles
+				}
+
+				return []dtls.SRTPProtectionProfile{dtls.SRTP_AEAD_AES_128_GCM, dtls.SRTP_AES128_CM_HMAC_SHA1_80}
+			}(),
+			ClientAuth:         dtls.RequireAnyClientCert,
+			LoggerFactory:      t.api.settingEngine.LoggerFactory,
+			InsecureSkipVerify: true,
 		}, nil
 	}
 

--- a/settingengine.go
+++ b/settingengine.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/pion/dtls/v2"
 	"github.com/pion/ice/v2"
 	"github.com/pion/logging"
 	"github.com/pion/transport/packetio"
@@ -61,6 +62,7 @@ type SettingEngine struct {
 	iceUDPMux                                 ice.UDPMux
 	iceProxyDialer                            proxy.Dialer
 	disableMediaEngineCopy                    bool
+	srtpProtectionProfiles                    []dtls.SRTPProtectionProfile
 }
 
 // DetachDataChannels enables detaching data channels. When enabled
@@ -68,6 +70,11 @@ type SettingEngine struct {
 // DataChannel.Detach method.
 func (e *SettingEngine) DetachDataChannels() {
 	e.detach.DataChannels = true
+}
+
+// SetSRTPProtectionProfiles overrides default srtp protection profiles
+func (e *SettingEngine) SetSRTPProtectionProfiles(profiles ...dtls.SRTPProtectionProfile) {
+	e.srtpProtectionProfiles = profiles
 }
 
 // SetICETimeouts sets the behavior around ICE Timeouts


### PR DESCRIPTION
#### Description
Adds option to the SettingEngine to override default SRTP protection profiles.

By default there are always two options enabled SRTP_AEAD_AES_128_GCM and SRTP_AES128_CM_HMAC_SHA1_80 and even when SRTP_AEAD_AES_128_GCM is first chrome will choose SRTP_AES128_CM_HMAC_SHA1_80. This options allows to force SRTP_AEAD_AES_128_GCM.
