### PR TITLE
Fix RtpSender: may block infinite in Read

### DIFF
--- a/srtp_writer_future.go
+++ b/srtp_writer_future.go
@@ -4,6 +4,7 @@ package webrtc
 
 import (
 	"io"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -17,6 +18,8 @@ type srtpWriterFuture struct {
 	rtpSender      *RTPSender
 	rtcpReadStream atomic.Value // *srtp.ReadStreamSRTCP
 	rtpWriteStream atomic.Value // *srtp.WriteStreamSRTP
+	mu             sync.Mutex
+	closed         bool
 }
 
 func (s *srtpWriterFuture) init(returnWhenNoSRTP bool) error {
@@ -34,6 +37,13 @@ func (s *srtpWriterFuture) init(returnWhenNoSRTP bool) error {
 			return io.ErrClosedPipe
 		case <-s.rtpSender.transport.srtpReady:
 		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return io.ErrClosedPipe
 	}
 
 	srtcpSession, err := s.rtpSender.transport.getSRTCPSession()
@@ -62,6 +72,14 @@ func (s *srtpWriterFuture) init(returnWhenNoSRTP bool) error {
 }
 
 func (s *srtpWriterFuture) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+
 	if value := s.rtcpReadStream.Load(); value != nil {
 		return value.(*srtp.ReadStreamSRTCP).Close()
 	}


### PR DESCRIPTION
In RtpSender, if Read has been called and wait for srtpReady,
then if we call Close() immediately after
rtpSender.trasport.srtpReady, that means srtpWriterFuture's Close
may be called when it's init method is executing.

In Read -> init, goroutine may run at:


	rtpWriteStream, err := srtpSession.OpenWriteStream()
	if err != nil {
		return err
	}

	s.rtcpReadStream.Store(rtcpReadStream)
	s.rtpWriteStream.Store(rtpWriteStream)


In Close, goroutine may run at

	if value := s.rtcpReadStream.Load(); value != nil {
		return value.(*srtp.ReadStreamSRTCP).Close()
	}

	return nil



s.rtcpReadStream could be nil in the check at Close, so it
will not be closed.

And in Read method, the init method initiates the stream and
return. Then read at the stream's buffer, and blocked infinite
because the buffer is not closed. And it will not be closed
if you call RtpSender's close method because it is already
closed.

#### Description

#### Reference issue
Fixes #...
