### PR TITLE
Fix: infinite loop possible in sample builder

### DIFF
--- a/pkg/media/samplebuilder/samplebuilder_test.go
+++ b/pkg/media/samplebuilder/samplebuilder_test.go
@@ -328,6 +328,20 @@ func TestSampleBuilderCleanReference(t *testing.T) {
 	}
 }
 
+func TestSampleBuilderPushMaxZero(t *testing.T) {
+	// Test packets released via 'maxLate' of zero.
+	pkts := []rtp.Packet{
+		{Header: rtp.Header{SequenceNumber: 0, Timestamp: 0, Marker: true}, Payload: []byte{0x01}},
+	}
+	s := New(0, &fakeDepacketizer{}, 1, WithPartitionHeadChecker(
+		&fakePartitionHeadChecker{headBytes: []byte{0x01}},
+	))
+	s.Push(&pkts[0])
+	if sample := s.Pop(); sample == nil {
+		t.Error("Should expect a popped sample")
+	}
+}
+
 func TestSampleBuilderWithPacketReleaseHandler(t *testing.T) {
 	var released []*rtp.Packet
 	fakePacketReleaseHandler := func(p *rtp.Packet) {


### PR DESCRIPTION
Active becomes "empty" after consuming the packets, but instead of the
"filled" getting purged by "purgeConsumedBuffers", it doesn't because
active is now empty and empty buffers cannot cause any purging. So the
solution is to purge the "consumed" area first, then "active".

#### Description

#### Reference issue
Fixes #1810
