### PR TITLE
Implemented RTPReceiver SetRTPParameters for ORTC

### DIFF
--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -114,7 +114,7 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 			track: newTrackRemote(
 				r.kind,
 				parameters.Encodings[0].SSRC,
-				"",
+				parameters.Encodings[0].RID,
 				r,
 			),
 		}

--- a/rtpreceiver_go.go
+++ b/rtpreceiver_go.go
@@ -1,0 +1,32 @@
+// +build !js
+
+package webrtc
+
+import "github.com/pion/interceptor"
+
+// SetRTPParameters applies provided RTPParameters the RTPReceiver's tracks.
+//
+// This method is part of the ORTC API. It is not
+// meant to be used together with the basic WebRTC API.
+//
+// The amount of provided codecs must match the number of tracks on the receiver.
+func (r *RTPReceiver) SetRTPParameters(params RTPParameters) {
+	headerExtensions := make([]interceptor.RTPHeaderExtension, 0, len(params.HeaderExtensions))
+	for _, h := range params.HeaderExtensions {
+		headerExtensions = append(headerExtensions, interceptor.RTPHeaderExtension{ID: h.ID, URI: h.URI})
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for ndx, codec := range params.Codecs {
+		currentTrack := r.tracks[ndx].track
+
+		r.tracks[ndx].streamInfo.RTPHeaderExtensions = headerExtensions
+
+		currentTrack.mu.Lock()
+		currentTrack.codec = codec
+		currentTrack.params = params
+		currentTrack.mu.Unlock()
+	}
+}

--- a/rtpreceiver_go_test.go
+++ b/rtpreceiver_go_test.go
@@ -1,0 +1,67 @@
+// +build !js
+
+package webrtc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v3/pkg/media"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetRTPParameters(t *testing.T) {
+	sender, receiver, wan := createVNetPair(t)
+
+	outgoingTrack, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: "video/vp8"}, "video", "pion")
+	assert.NoError(t, err)
+
+	_, err = sender.AddTrack(outgoingTrack)
+	assert.NoError(t, err)
+
+	// Those parameters wouldn't make sense in a real application,
+	// but for the sake of the test we just need different values.
+	p := RTPParameters{
+		Codecs: []RTPCodecParameters{
+			{
+				RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 2, "minptime=10;useinbandfec=1", []RTCPFeedback{{"nack", ""}}},
+				PayloadType:        111,
+			},
+		},
+		HeaderExtensions: []RTPHeaderExtensionParameter{
+			{URI: "urn:ietf:params:rtp-hdrext:sdes:mid"},
+			{URI: "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"},
+			{URI: "urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id"},
+		},
+	}
+
+	seenPacket, seenPacketCancel := context.WithCancel(context.Background())
+	receiver.OnTrack(func(trackRemote *TrackRemote, r *RTPReceiver) {
+		r.SetRTPParameters(p)
+
+		incomingTrackCodecs := r.Track().Codec()
+
+		assert.EqualValues(t, p.HeaderExtensions, r.Track().params.HeaderExtensions)
+
+		assert.EqualValues(t, p.Codecs[0].MimeType, incomingTrackCodecs.MimeType)
+		assert.EqualValues(t, p.Codecs[0].ClockRate, incomingTrackCodecs.ClockRate)
+		assert.EqualValues(t, p.Codecs[0].Channels, incomingTrackCodecs.Channels)
+		assert.EqualValues(t, p.Codecs[0].SDPFmtpLine, incomingTrackCodecs.SDPFmtpLine)
+		assert.EqualValues(t, p.Codecs[0].RTCPFeedback, incomingTrackCodecs.RTCPFeedback)
+		assert.EqualValues(t, p.Codecs[0].PayloadType, incomingTrackCodecs.PayloadType)
+
+		seenPacketCancel()
+	})
+
+	peerConnectionsConnected := untilConnectionState(PeerConnectionStateConnected, sender, receiver)
+
+	assert.NoError(t, signalPair(sender, receiver))
+
+	peerConnectionsConnected.Wait()
+	assert.NoError(t, outgoingTrack.WriteSample(media.Sample{Data: []byte{0xAA}, Duration: time.Second}))
+
+	<-seenPacket.Done()
+	assert.NoError(t, wan.Stop())
+	closePairNow(t, sender, receiver)
+}


### PR DESCRIPTION
See discussion with @OrlandoCo https://gophers.slack.com/archives/CAK2124AG/p1623504625397700

- RID is now set on remote tracks, if provided.
- Adds SetRTPParameters which can be used in ORTC to set codec information about the remote track.

I'm not sure if this is the best way to implement this, as the track will still miss the `id` and `streamID` + I'm not a big fan of adding public method for edge cases. 
Maybe it'd be better to  refacto `RTPReceiver.Receive()` to look more like `RTPSender.Send()`?