### PR TITLE
Fixed deadlock in peerconnection.go

### DIFF
--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -384,17 +384,17 @@ func TestPeerConnection_PropertyGetters(t *testing.T) {
 		currentRemoteDescription: &SessionDescription{},
 		pendingRemoteDescription: &SessionDescription{},
 		signalingState:           SignalingStateHaveLocalOffer,
-		iceConnectionState:       ICEConnectionStateChecking,
-		connectionState:          PeerConnectionStateConnecting,
 	}
+	pc.iceConnectionState.Store(ICEConnectionStateChecking)
+	pc.connectionState.Store(PeerConnectionStateConnecting)
 
 	assert.Equal(t, pc.currentLocalDescription, pc.CurrentLocalDescription(), "should match")
 	assert.Equal(t, pc.pendingLocalDescription, pc.PendingLocalDescription(), "should match")
 	assert.Equal(t, pc.currentRemoteDescription, pc.CurrentRemoteDescription(), "should match")
 	assert.Equal(t, pc.pendingRemoteDescription, pc.PendingRemoteDescription(), "should match")
 	assert.Equal(t, pc.signalingState, pc.SignalingState(), "should match")
-	assert.Equal(t, pc.iceConnectionState, pc.ICEConnectionState(), "should match")
-	assert.Equal(t, pc.connectionState, pc.ConnectionState(), "should match")
+	assert.Equal(t, pc.iceConnectionState.Load(), pc.ICEConnectionState(), "should match")
+	assert.Equal(t, pc.connectionState.Load(), pc.ConnectionState(), "should match")
 }
 
 func TestPeerConnection_AnswerWithoutOffer(t *testing.T) {


### PR DESCRIPTION
#### Description

In some rare cases during the ice connection stage change may result in deadlock. This fix makes iceConnectionState and connectionState atomic which should prevent deadlock.

Before this fix, some of the tests would randomly timeout, after this, I'm unable to reproduce the issue.
Also, I believe this is the same problem as described in https://github.com/pion/webrtc/issues/1809.

#### Reference issue
Fixes https://github.com/pion/webrtc/issues/1809
