### PR TITLE
Add acknowledged check before opening

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1328,7 +1328,7 @@ func (pc *PeerConnection) startSCTP() {
 
 	var openedDCCount uint32
 	for _, d := range dataChannels {
-		if d.ReadyState() == DataChannelStateConnecting {
+		if d.ReadyState() == DataChannelStateConnecting && d.dataChannel.acknowledged {
 			err := d.open(pc.sctpTransport)
 			if err != nil {
 				pc.log.Warnf("failed to open data channel: %s", err)


### PR DESCRIPTION
#### Description
Hmmm I think maybe we'd want a blocked channel until the channel has been acked, but just checking a variable might be enough? Just thought I would sketch this possible solution out real quick. Makes use of datachannel PR: https://github.com/pion/datachannel/pull/111

#### Reference issue
Fixes #1063
