### PR TITLE
Avoid crash in samplebuilder.PopWithTimestamp

### DIFF
--- a/pkg/media/samplebuilder/samplebuilder.go
+++ b/pkg/media/samplebuilder/samplebuilder.go
@@ -300,6 +300,9 @@ func (s *SampleBuilder) Pop() *media.Sample {
 // no sample is compiled).
 func (s *SampleBuilder) PopWithTimestamp() (*media.Sample, uint32) {
 	sample := s.Pop()
+	if sample == nil {
+		return nil, 0
+	}
 	return sample, sample.PacketTimestamp
 }
 


### PR DESCRIPTION
If sample is null, PopWithTimestamp will crash with SIGSEGV.

```
goroutine 259 [running]:
github.com/pion/webrtc/v3/pkg/media/samplebuilder.(*SampleBuilder).PopWithTimestamp(...)
        /home/jch/go/pkg/mod/github.com/pion/webrtc/v3@v3.0.29/pkg/media/samplebuilder/samplebuilder.go:285
github.com/jech/galene/diskwriter.(*diskTrack).Write(0xc0003c8000, 0xc00041cc00, 0x35f, 0x5e0, 0x0, 0x0, 0x0)
        /home/jch/go/src/github.com/jech/galene/diskwriter/diskwriter.go:477 +0x27f
github.com/jech/galene/rtpconn.sendKeyframe(0xc0000900c0, 0x3, 0x3, 0xa413d8, 0xc0003c8000, 0xc0000f6000)
        /home/jch/go/src/github.com/jech/galene/rtpconn/rtpwriter.go:218 +0xe9
created by github.com/jech/galene/rtpconn.rtpWriterLoop
        /home/jch/go/src/github.com/jech/galene/rtpconn/rtpwriter.go:263 +0x69b
exit status 2
```