### PR TITLE
Support PayloadTypes changing a TrackRemote

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -24,6 +24,8 @@ const (
 	mediaSectionApplication = "application"
 
 	rtpOutboundMTU = 1200
+
+	rtpPayloadTypeBitmask = 0x7F
 )
 
 func defaultSrtpProtectionProfiles() []dtls.SRTPProtectionProfile {

--- a/errors.go
+++ b/errors.go
@@ -219,4 +219,6 @@ var (
 	errICETransportNotInNew = errors.New("ICETransport can only be called in ICETransportStateNew")
 
 	errCertificatePEMFormatError = errors.New("bad Certificate PEM format")
+
+	errRTPTooShort = errors.New("not long enough to be a RTP Packet")
 )


### PR DESCRIPTION
If the PayloadType changes for a SSRC update the codec on the
TrackRemote.

Resolves #1850