### PR TITLE
Fix H264Reader buffer overflow

### DIFF
--- a/pkg/media/h264reader/h264reader.go
+++ b/pkg/media/h264reader/h264reader.go
@@ -167,8 +167,10 @@ func (reader *H264Reader) processByte(readByte byte) (nalFound bool) {
 				countOfConsecutiveZeroBytesInPrefix = 3
 			}
 			nalUnitLength := len(reader.nalBuffer) - countOfConsecutiveZeroBytesInPrefix
-			reader.nalBuffer = reader.nalBuffer[0:nalUnitLength]
-			nalFound = true
+			if nalUnitLength > 0 {
+				reader.nalBuffer = reader.nalBuffer[0:nalUnitLength]
+				nalFound = true
+			}
 		} else {
 			reader.countOfConsecutiveZeroBytes = 0
 		}

--- a/pkg/media/h264reader/h264reader_test.go
+++ b/pkg/media/h264reader/h264reader_test.go
@@ -98,3 +98,24 @@ func TestSkipSEI(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(byte(0xAB), nal.Data[0])
 }
+
+func TestIssue1734_NextNal(t *testing.T) {
+	tt := [...][]byte{
+		[]byte("\x00\x00\x010\x00\x00\x01\x00\x00\x01"),
+		[]byte("\x00\x00\x00\x01\x00\x00\x01"),
+	}
+
+	for _, cur := range tt {
+		r, err := NewReader(bytes.NewReader(cur))
+		assert.NoError(t, err)
+
+		// Just make sure it doesn't crash
+		for {
+			nal, err := r.NextNAL()
+
+			if err != nil || nal == nil {
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
There was a buffer overflow in H264Reader, it is now fixed.

Fixes #1734
