### PR TITLE
Fix RTPSender's streamInfo miss headerExtensions

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1270,16 +1270,7 @@ func (pc *PeerConnection) startRTPReceivers(incomingTracks []trackDetails, curre
 func (pc *PeerConnection) startRTPSenders(currentTransceivers []*RTPTransceiver) error {
 	for _, transceiver := range currentTransceivers {
 		if transceiver.Sender() != nil && transceiver.Sender().isNegotiated() && !transceiver.Sender().hasSent() {
-			err := transceiver.Sender().Send(RTPSendParameters{
-				Encodings: []RTPEncodingParameters{
-					{
-						RTPCodingParameters{
-							SSRC:        transceiver.Sender().ssrc,
-							PayloadType: transceiver.Sender().payloadType,
-						},
-					},
-				},
-			})
+			err := transceiver.Sender().Send(transceiver.Sender().GetParameters())
 			if err != nil {
 				return err
 			}

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -104,9 +104,7 @@ func (r *RTPSender) Transport() *DTLSTransport {
 	return r.transport
 }
 
-// GetParameters describes the current configuration for the encoding and
-// transmission of media on the sender's track.
-func (r *RTPSender) GetParameters() RTPSendParameters {
+func (r *RTPSender) getParameters() RTPSendParameters {
 	sendParameters := RTPSendParameters{
 		RTPParameters: r.api.mediaEngine.getRTPParametersByKind(
 			r.track.Kind(),
@@ -123,6 +121,14 @@ func (r *RTPSender) GetParameters() RTPSendParameters {
 	}
 	sendParameters.Codecs = r.tr.getCodecs()
 	return sendParameters
+}
+
+// GetParameters describes the current configuration for the encoding and
+// transmission of media on the sender's track.
+func (r *RTPSender) GetParameters() RTPSendParameters {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.getParameters()
 }
 
 // Track returns the RTCRtpTransceiver track, or nil

--- a/track_local.go
+++ b/track_local.go
@@ -50,7 +50,7 @@ func (t *TrackLocalContext) ID() string {
 }
 
 // TrackLocal is an interface that controls how the user can send media
-// The user can provide their own TrackLocal implementatiosn, or use
+// The user can provide their own TrackLocal implementations, or use
 // the implementations in pkg/media
 type TrackLocal interface {
 	// Bind should implement the way how the media data flows from the Track to the PeerConnection


### PR DESCRIPTION
#### Description

This PR fix `transceiver.Sender().Send()` not contain `HeaderExtensions` when `createStreamInfo`, the result is none of HeaderExtensions at interceptor.