### PR TITLE
Fix AddTrack transceiver reuse per W3C specs

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1197,7 +1197,7 @@ func (pc *PeerConnection) AddTrack(track *Track) (*RTPSender, error) {
 
 	var transceiver *RTPTransceiver
 	for _, t := range pc.GetTransceivers() {
-		if !t.stopped && t.kind == track.Kind() && t.Sender() == nil {
+		if !t.stopped && t.kind == track.Kind() && t.Sender() == nil && t.usedToSend.Load() != true {
 			transceiver = t
 			break
 		}

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -14,6 +14,8 @@ type RTPTransceiver struct {
 	receiver  atomic.Value // *RTPReceiver
 	direction atomic.Value // RTPTransceiverDirection
 
+	usedToSend atomic.Value // track if direction has never had a value of "sendrecv" or "sendonly"
+
 	stopped bool
 	kind    RTPCodecType
 }
@@ -89,6 +91,9 @@ func (t *RTPTransceiver) setReceiver(r *RTPReceiver) {
 }
 
 func (t *RTPTransceiver) setDirection(d RTPTransceiverDirection) {
+	if d == RTPTransceiverDirectionSendrecv || d == RTPTransceiverDirectionSendonly {
+		t.usedToSend.Store(true)
+	}
 	t.direction.Store(d)
 }
 


### PR DESCRIPTION
According to W3C specifications, the transceiver can be reused if "The sender has never been used to send. More precisely, the [[CurrentDirection]] slot of the RTCRtpTransceiver associated with the sender has never had a value of "sendrecv" or "sendonly"".
Current implementation does not have CurrentDirection slot, so the flag usedToSend is set on setDirection change.
This fixes #1843 and maybe other issues (for us it fixes other two issues when reusing transceiver, eg clients going and coming back to a conference).
This has been done on the v2 branch because we currently don't have the resources to switch our software to v3 and test it there. Looking at the source (master) seems this kind of issue is still there.
