### PR TITLE
Fix crash when a PC callback is reset

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -296,7 +296,7 @@ func (pc *PeerConnection) onNegotiationNeeded() {
 
 func (pc *PeerConnection) negotiationNeededOp() {
 	// Don't run NegotiatedNeeded checks if OnNegotiationNeeded is not set
-	if handler := pc.onNegotiationNeededHandler.Load(); handler == nil {
+	if handler, ok := pc.onNegotiationNeededHandler.Load().(func()); !ok || handler == nil {
 		return
 	}
 
@@ -464,8 +464,8 @@ func (pc *PeerConnection) OnICEConnectionStateChange(f func(ICEConnectionState))
 func (pc *PeerConnection) onICEConnectionStateChange(cs ICEConnectionState) {
 	pc.iceConnectionState.Store(cs)
 	pc.log.Infof("ICE connection state changed: %s", cs)
-	if handler := pc.onICEConnectionStateChangeHandler.Load(); handler != nil {
-		handler.(func(ICEConnectionState))(cs)
+	if handler, ok := pc.onICEConnectionStateChangeHandler.Load().(func(ICEConnectionState)); ok && handler != nil {
+		handler(cs)
 	}
 }
 
@@ -478,8 +478,8 @@ func (pc *PeerConnection) OnConnectionStateChange(f func(PeerConnectionState)) {
 func (pc *PeerConnection) onConnectionStateChange(cs PeerConnectionState) {
 	pc.connectionState.Store(cs)
 	pc.log.Infof("peer connection state changed: %s", cs)
-	if handler := pc.onConnectionStateChangeHandler.Load(); handler != nil {
-		go handler.(func(PeerConnectionState))(cs)
+	if handler, ok := pc.onConnectionStateChangeHandler.Load().(func(PeerConnectionState)); ok && handler != nil {
+		go handler(cs)
 	}
 }
 

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -1397,3 +1397,41 @@ func TestPeerConnection_SessionID(t *testing.T) {
 	}
 	closePairNow(t, pcOffer, pcAnswer)
 }
+
+func TestPeerConnectionNilCallback(t *testing.T) {
+	pc, err := NewPeerConnection(Configuration{})
+	if err != nil {
+		t.Fatalf("NewPeerConnection: %v", err)
+	}
+	defer pc.Close()
+
+	pc.onSignalingStateChange(SignalingStateStable)
+	pc.OnSignalingStateChange(func(ss SignalingState) {
+		t.Error("OnSignalingStateChange called")
+	})
+	pc.OnSignalingStateChange(nil)
+	pc.onSignalingStateChange(SignalingStateStable)
+
+	pc.onConnectionStateChange(PeerConnectionStateNew)
+	pc.OnConnectionStateChange(func(pcs PeerConnectionState) {
+		t.Error("OnConnectionStateChange called")
+	})
+	pc.OnConnectionStateChange(nil)
+	pc.onConnectionStateChange(PeerConnectionStateNew)
+
+	pc.onICEConnectionStateChange(ICEConnectionStateNew)
+	pc.OnICEConnectionStateChange(func(ics ICEConnectionState) {
+		t.Error("OnConnectionStateChange called")
+	})
+	pc.OnICEConnectionStateChange(nil)
+	pc.onICEConnectionStateChange(ICEConnectionStateNew)
+
+	pc.onNegotiationNeeded()
+	pc.negotiationNeededOp()
+	pc.OnNegotiationNeeded(func() {
+		t.Error("OnNegotiationNeeded called")
+	})
+	pc.OnNegotiationNeeded(nil)
+	pc.onNegotiationNeeded()
+	pc.negotiationNeededOp()
+}


### PR DESCRIPTION
- Move setting of PC state into separate function
- Avoid crash after a PC callback has been reset

Fixes #1871
