### PR TITLE
Simplify sampleSequenceLocation

### DIFF
--- a/pkg/media/samplebuilder/sampleSequenceLocation.go
+++ b/pkg/media/samplebuilder/sampleSequenceLocation.go
@@ -1,8 +1,6 @@
 // Package samplebuilder provides functionality to reconstruct media frames from RTP packets.
 package samplebuilder
 
-import "math"
-
 type sampleSequenceLocation struct {
 	// head is the first packet in a sequence
 	head uint16
@@ -30,53 +28,23 @@ const (
 	slCompareAfter
 )
 
-func minUint32(x, y uint32) uint32 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-// Distance between two seqnums
-func seqnumDistance32(x, y uint32) uint32 {
-	diff := int32(x - y)
-	if diff < 0 {
-		return uint32(-diff)
-	}
-
-	return uint32(diff)
-}
-
 func (l sampleSequenceLocation) compare(pos uint16) int {
-	if l.empty() {
+	if l.head == l.tail {
 		return slCompareVoid
 	}
 
-	head32 := uint32(l.head)
-	count32 := uint32(l.count())
-	tail32 := head32 + count32
-
-	// pos32 is possibly two values, the normal value or a wrap
-	// around the start value, figure out which it is...
-
-	pos32Normal := uint32(pos)
-	pos32Wrap := uint32(pos) + math.MaxUint16 + 1
-
-	distNormal := minUint32(seqnumDistance32(head32, pos32Normal), seqnumDistance32(tail32, pos32Normal))
-	distWrap := minUint32(seqnumDistance32(head32, pos32Wrap), seqnumDistance32(tail32, pos32Wrap))
-
-	pos32 := pos32Normal
-	if distWrap < distNormal {
-		pos32 = pos32Wrap
+	if l.head < l.tail {
+		if l.head <= pos && pos < l.tail {
+			return slCompareInside
+		}
+	} else {
+		if l.head <= pos || pos < l.tail {
+			return slCompareInside
+		}
 	}
 
-	if pos32 < head32 {
+	if l.head-pos <= pos-l.tail {
 		return slCompareBefore
 	}
-
-	if pos32 >= tail32 {
-		return slCompareAfter
-	}
-
-	return slCompareInside
+	return slCompareAfter
 }

--- a/pkg/media/samplebuilder/sampleSequenceLocation_test.go
+++ b/pkg/media/samplebuilder/sampleSequenceLocation_test.go
@@ -1,0 +1,26 @@
+package samplebuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSampleSequenceLocationCompare(t *testing.T) {
+	s1 := sampleSequenceLocation{32, 42}
+	assert.Equal(t, slCompareBefore, s1.compare(16))
+	assert.Equal(t, slCompareInside, s1.compare(32))
+	assert.Equal(t, slCompareInside, s1.compare(38))
+	assert.Equal(t, slCompareInside, s1.compare(41))
+	assert.Equal(t, slCompareAfter, s1.compare(42))
+	assert.Equal(t, slCompareAfter, s1.compare(0x57))
+
+	s2 := sampleSequenceLocation{0xffa0, 32}
+	assert.Equal(t, slCompareBefore, s2.compare(0xff00))
+	assert.Equal(t, slCompareInside, s2.compare(0xffa0))
+	assert.Equal(t, slCompareInside, s2.compare(0xffff))
+	assert.Equal(t, slCompareInside, s2.compare(0))
+	assert.Equal(t, slCompareInside, s2.compare(31))
+	assert.Equal(t, slCompareAfter, s2.compare(32))
+	assert.Equal(t, slCompareAfter, s2.compare(128))
+}


### PR DESCRIPTION
Before I decided that doing a full rewrite is the simpler option
I had started doing some cleanup on the code.  Although Galene has
now switched to a less broken samplebuilder, I guess I might as well
submit the bits I had already done.
