### PR TITLE
Fix RTPReceiver getParameters

### DIFF
--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -78,7 +78,9 @@ func (r *RTPReceiver) Transport() *DTLSTransport {
 
 func (r *RTPReceiver) getParameters() RTPParameters {
 	parameters := r.api.mediaEngine.getRTPParametersByKind(r.kind, []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly})
-	parameters.Codecs = r.tr.getCodecs()
+	if r.tr != nil {
+		parameters.Codecs = r.tr.getCodecs()
+	}
 	return parameters
 }
 


### PR DESCRIPTION
Modifications included in https://github.com/pion/webrtc/commit/f524fea32aadec9e1b6b06b886181ae67d32ea17 made https://github.com/pion/webrtc/pull/1831 useless:  when used in ORTC context, `tr` might stay `nil`, and a call to `getParameters` would result in a crash in that case.