### PR TITLE
Fixes ReplaceTrack

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -110,6 +110,7 @@ OrlandoCo <luisorlando.co@gmail.com>
 Pascal Benoit <pascal.benoit@acemediastools.fr>
 pascal-ace <47424881+pascal-ace@users.noreply.github.com>
 Patrick Lange <mail@langep.com>
+Patryk Rogalski <digitalix4@gmail.com>
 q191201771 <191201771@qq.com>
 Quentin Renard <contact@asticode.com>
 Rafael Viscarra <rafael@viscarra.dev>

--- a/errors.go
+++ b/errors.go
@@ -135,6 +135,9 @@ var (
 	// ErrUnsupportedCodec indicates the remote peer doesn't support the requested codec
 	ErrUnsupportedCodec = errors.New("unable to start track, codec is not supported by remote")
 
+	// ErrRTPSenderNewTrackHasIncorrectKind indicates that the new track is of a different kind than the previous/original
+	ErrRTPSenderNewTrackHasIncorrectKind = errors.New("new track must be of the same kind as previous")
+
 	// ErrUnbindFailed indicates that a TrackLocal was not able to be unbind
 	ErrUnbindFailed = errors.New("failed to unbind TrackLocal from PeerConnection")
 

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -145,6 +145,10 @@ func (r *RTPSender) ReplaceTrack(track TrackLocal) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if track != nil && r.tr.kind != track.Kind() {
+		return ErrRTPSenderNewTrackHasIncorrectKind
+	}
+
 	if r.hasSent() && r.track != nil {
 		if err := r.track.Unbind(r.context); err != nil {
 			return err
@@ -158,7 +162,7 @@ func (r *RTPSender) ReplaceTrack(track TrackLocal) error {
 
 	codec, err := track.Bind(TrackLocalContext{
 		id:          r.context.id,
-		params:      r.api.mediaEngine.getRTPParametersByKind(r.track.Kind(), []RTPTransceiverDirection{RTPTransceiverDirectionSendonly}),
+		params:      r.api.mediaEngine.getRTPParametersByKind(track.Kind(), []RTPTransceiverDirection{RTPTransceiverDirectionSendonly}),
 		ssrc:        r.context.ssrc,
 		writeStream: r.context.writeStream,
 	})


### PR DESCRIPTION
When ReplaceTrack was set previously to nil it would be impossible to ReplaceTrack again with a non-nil value as r.track was set to nil.
