### PR TITLE
Check for nil transceivers on get parameters

### DIFF
--- a/ortc_datachannel_test.go
+++ b/ortc_datachannel_test.go
@@ -1,0 +1,64 @@
+// +build !js
+
+package webrtc
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/pion/transport/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataChannel_ORTCE2E(t *testing.T) {
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	stackA, stackB, err := newORTCPair()
+	assert.NoError(t, err)
+
+	awaitSetup := make(chan struct{})
+	awaitString := make(chan struct{})
+	awaitBinary := make(chan struct{})
+	stackB.sctp.OnDataChannel(func(d *DataChannel) {
+		close(awaitSetup)
+
+		d.OnMessage(func(msg DataChannelMessage) {
+			if msg.IsString {
+				close(awaitString)
+			} else {
+				close(awaitBinary)
+			}
+		})
+	})
+
+	assert.NoError(t, signalORTCPair(stackA, stackB))
+
+	var id uint16 = 1
+	dcParams := &DataChannelParameters{
+		Label: "Foo",
+		ID:    &id,
+	}
+	channelA, err := stackA.api.NewDataChannel(stackA.sctp, dcParams)
+	assert.NoError(t, err)
+
+	<-awaitSetup
+
+	assert.NoError(t, channelA.SendText("ABC"))
+	assert.NoError(t, channelA.Send([]byte("ABC")))
+
+	<-awaitString
+	<-awaitBinary
+
+	assert.NoError(t, stackA.close())
+	assert.NoError(t, stackB.close())
+
+	// attempt to send when channel is closed
+	assert.Error(t, channelA.Send([]byte("ABC")), io.ErrClosedPipe)
+	assert.Error(t, channelA.SendText("test"), io.ErrClosedPipe)
+	assert.Error(t, channelA.ensureOpen(), io.ErrClosedPipe)
+}

--- a/ortc_media_test.go
+++ b/ortc_media_test.go
@@ -1,0 +1,68 @@
+// +build !js
+
+package webrtc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pion/transport/test"
+	"github.com/pion/webrtc/v3/pkg/media"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ORTC_Media(t *testing.T) {
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	stackA, stackB, err := newORTCPair()
+	assert.NoError(t, err)
+
+	assert.NoError(t, stackA.api.mediaEngine.RegisterDefaultCodecs())
+	assert.NoError(t, stackB.api.mediaEngine.RegisterDefaultCodecs())
+
+	assert.NoError(t, signalORTCPair(stackA, stackB))
+
+	track, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+	assert.NoError(t, err)
+
+	rtpSender, err := stackA.api.NewRTPSender(track, stackA.dtls)
+	assert.NoError(t, err)
+	assert.NoError(t, rtpSender.Send(rtpSender.GetParameters()))
+
+	rtpReceiver, err := stackB.api.NewRTPReceiver(RTPCodecTypeVideo, stackB.dtls)
+	assert.NoError(t, err)
+	assert.NoError(t, rtpReceiver.Receive(RTPReceiveParameters{Encodings: []RTPDecodingParameters{
+		{RTPCodingParameters: rtpSender.GetParameters().Encodings[0].RTPCodingParameters},
+	}}))
+
+	seenPacket, seenPacketCancel := context.WithCancel(context.Background())
+	go func() {
+		track := rtpReceiver.Track()
+		_, _, err := track.ReadRTP()
+		assert.NoError(t, err)
+
+		seenPacketCancel()
+	}()
+
+	func() {
+		for range time.Tick(time.Millisecond * 20) {
+			select {
+			case <-seenPacket.Done():
+				return
+			default:
+				assert.NoError(t, track.WriteSample(media.Sample{Data: []byte{0xAA}, Duration: time.Second}))
+			}
+		}
+	}()
+
+	assert.NoError(t, rtpSender.Stop())
+	assert.NoError(t, rtpReceiver.Stop())
+
+	assert.NoError(t, stackA.close())
+	assert.NoError(t, stackB.close())
+}

--- a/rtpsender_test.go
+++ b/rtpsender_test.go
@@ -228,7 +228,7 @@ func Test_RTPSender_ReplaceTrack_InvalidCodecChange(t *testing.T) {
 	rtpSender, err := sender.AddTrack(trackA)
 	assert.NoError(t, err)
 
-	err = rtpSender.tr.SetCodecPreferences([]RTPCodecParameters{{
+	err = rtpSender.rtpTransceiver.SetCodecPreferences([]RTPCodecParameters{{
 		RTPCodecCapability: RTPCodecCapability{MimeType: MimeTypeVP8},
 		PayloadType:        96,
 	}})


### PR DESCRIPTION
Add public methods to allow set stream and track id, this is useful
when using ORTC API
