### PR TITLE
Fixes issue 1822

### DIFF
--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -141,13 +141,13 @@ func (t *RTPTransceiver) Direction() RTPTransceiverDirection {
 
 // Stop irreversibly stops the RTPTransceiver
 func (t *RTPTransceiver) Stop() error {
-	if t.Sender() != nil {
-		if err := t.Sender().Stop(); err != nil {
+	if sender := t.Sender(); sender != nil {
+		if err := sender.Stop(); err != nil {
 			return err
 		}
 	}
-	if t.Receiver() != nil {
-		if err := t.Receiver().Stop(); err != nil {
+	if receiver := t.Receiver(); receiver != nil {
+		if err := receiver.Stop(); err != nil {
 			return err
 		}
 	}

--- a/sdp.go
+++ b/sdp.go
@@ -344,9 +344,9 @@ func addTransceiverSDP(d *sdp.SessionDescription, isPlanB, shouldAddCandidates b
 	}
 
 	for _, mt := range transceivers {
-		if mt.Sender() != nil && mt.Sender().Track() != nil {
-			track := mt.Sender().Track()
-			media = media.WithMediaSource(uint32(mt.Sender().ssrc), track.StreamID() /* cname */, track.StreamID() /* streamLabel */, track.ID())
+		if sender := mt.Sender(); sender != nil && sender.Track() != nil {
+			track := sender.Track()
+			media = media.WithMediaSource(uint32(sender.ssrc), track.StreamID() /* cname */, track.StreamID() /* streamLabel */, track.ID())
 			if !isPlanB {
 				media = media.WithPropertyAttribute("msid:" + track.StreamID() + " " + track.ID())
 				break


### PR DESCRIPTION
#### Description
Previously we've had a few if statements like `transceiver.Sender() != nil && transceiver.Sender().isNegotiated()` where during first condition `transceiver.Sender() != nil` would pass, but then in 2nd condition could become nil so `transceiver.Sender().isNegotiated()` would panic.

The original issue is only about `.Sender()` but II noticed the same problem with `.Receiver()` so I changed them too.

#### Reference issue
Fixes #1822
