### PR TITLE
Fix per-track codec selection

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -457,10 +457,10 @@ func (m *MediaEngine) updateFromRemoteDescription(desc sdp.SessionDescription) e
 	for _, media := range desc.MediaDescriptions {
 		var typ RTPCodecType
 		switch {
-		case !m.negotiatedAudio && strings.EqualFold(media.MediaName.Media, "audio"):
+		case strings.EqualFold(media.MediaName.Media, "audio"):
 			m.negotiatedAudio = true
 			typ = RTPCodecTypeAudio
-		case !m.negotiatedVideo && strings.EqualFold(media.MediaName.Media, "video"):
+		case strings.EqualFold(media.MediaName.Media, "video"):
 			m.negotiatedVideo = true
 			typ = RTPCodecTypeVideo
 		default:

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -206,8 +206,16 @@ func (m *MediaEngine) RegisterCodec(codec RTPCodecParameters, typ RTPCodecType) 
 	codec.statsID = fmt.Sprintf("RTPCodec-%d", time.Now().UnixNano())
 	switch typ {
 	case RTPCodecTypeAudio:
+		if m.negotiatedAudio {
+			m.negotiatedAudioCodecs = m.addCodec(m.negotiatedAudioCodecs, codec)
+			return nil
+		}
 		m.audioCodecs = m.addCodec(m.audioCodecs, codec)
 	case RTPCodecTypeVideo:
+		if m.negotiatedVideo {
+			m.negotiatedVideoCodecs = m.addCodec(m.negotiatedVideoCodecs, codec)
+			return nil
+		}
 		m.videoCodecs = m.addCodec(m.videoCodecs, codec)
 	default:
 		return ErrUnknownType

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2286,7 +2286,10 @@ func (pc *PeerConnection) generateMatchedSDP(transceivers []*RTPTransceiver, use
 			if err != nil {
 				return nil, err
 			}
-			t.codecs = codecs
+
+			if len(t.codecs) == 0 {
+				t.codecs = codecs
+			}
 
 			mediaTransceivers := []*RTPTransceiver{t}
 			mediaSections = append(mediaSections, mediaSection{id: midValue, transceivers: mediaTransceivers, ridMap: getRids(media)})

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2281,6 +2281,13 @@ func (pc *PeerConnection) generateMatchedSDP(transceivers []*RTPTransceiver, use
 			if sender := t.Sender(); sender != nil {
 				sender.setNegotiated()
 			}
+
+			codecs, err := codecsFromMediaDescription(media)
+			if err != nil {
+				return nil, err
+			}
+			t.codecs = codecs
+
 			mediaTransceivers := []*RTPTransceiver{t}
 			mediaSections = append(mediaSections, mediaSection{id: midValue, transceivers: mediaTransceivers, ridMap: getRids(media)})
 		}


### PR DESCRIPTION
This fixes per-track codec selection (ie H264 camera + VP8 screenshare)

This may not be the right way to do it though @Sean-Der @OrlandoCo @davidzhao 
#### Description

#### Reference issue
Fixes #...
