### PR TITLE
Use time.Ticker in play-from-disk

### DIFF
--- a/examples/play-from-disk-renegotation/main.go
+++ b/examples/play-from-disk-renegotation/main.go
@@ -167,15 +167,18 @@ func writeVideoToTrack(t *webrtc.TrackLocalStaticSample) {
 
 	// Send our video file frame at a time. Pace our sending so we send it at the same speed it should be played back as.
 	// This isn't required since the video is timestamped, but we will such much higher loss if we send all at once.
-	sleepTime := time.Millisecond * time.Duration((float32(header.TimebaseNumerator)/float32(header.TimebaseDenominator))*1000)
-	for {
+	//
+	// It is important to use a time.Ticker instead of time.Sleep because
+	// * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
+	// * works around latency issues with Sleep (see https://github.com/golang/go/issues/44343)
+	ticker := time.NewTicker(time.Millisecond * time.Duration((float32(header.TimebaseNumerator)/float32(header.TimebaseDenominator))*1000))
+	for ; true; <-ticker.C {
 		frame, _, err := ivf.ParseNextFrame()
 		if err != nil {
 			fmt.Printf("Finish writing video track: %s ", err)
 			return
 		}
 
-		time.Sleep(sleepTime)
 		if err = t.WriteSample(media.Sample{Data: frame, Duration: time.Second}); err != nil {
 			fmt.Printf("Finish writing video track: %s ", err)
 			return

--- a/examples/play-from-disk/README.md
+++ b/examples/play-from-disk/README.md
@@ -1,6 +1,8 @@
 # play-from-disk
 play-from-disk demonstrates how to send video and/or audio to your browser from files saved to disk.
 
+For an example of playing H264 from disk see [play-from-disk-h264](https://github.com/pion/example-webrtc-applications/tree/master/play-from-disk-h264)
+
 ## Instructions
 ### Create IVF named `output.ivf` that contains a VP8 track and/or `output.ogg` that contains a Opus track
 ```


### PR DESCRIPTION
time.Sleep is not precise, instead use a ticker.

Relates to golang/go#44343
