### PR TITLE
Throw error earlier for RTPSender with no codecs

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -135,6 +135,10 @@ var (
 	// ErrUnsupportedCodec indicates the remote peer doesn't support the requested codec
 	ErrUnsupportedCodec = errors.New("unable to start track, codec is not supported by remote")
 
+	// ErrSenderWithNoCodecs indicates that a RTPSender was created without any codecs. To send media the MediaEngine needs at
+	// least one configured codec.
+	ErrSenderWithNoCodecs = errors.New("unable to populate media section, RTPSender created with no codecs")
+
 	// ErrRTPSenderNewTrackHasIncorrectKind indicates that the new track is of a different kind than the previous/original
 	ErrRTPSenderNewTrackHasIncorrectKind = errors.New("new track must be of the same kind as previous")
 
@@ -225,4 +229,6 @@ var (
 	errCertificatePEMFormatError = errors.New("bad Certificate PEM format")
 
 	errRTPTooShort = errors.New("not long enough to be a RTP Packet")
+
+	errExcessiveRetries = errors.New("excessive retries in CreateOffer")
 )

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -394,9 +394,9 @@ func TestMediaEngineHeaderExtensionDirection(t *testing.T) {
 		m := &MediaEngine{}
 		registerCodec(m)
 
-		assert.Error(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirectionSendrecv), ErrRegisterHeaderExtensionInvalidDirection)
-		assert.Error(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirectionInactive), ErrRegisterHeaderExtensionInvalidDirection)
-		assert.Error(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirection(0)), ErrRegisterHeaderExtensionInvalidDirection)
+		assert.ErrorIs(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirectionSendrecv), ErrRegisterHeaderExtensionInvalidDirection)
+		assert.ErrorIs(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirectionInactive), ErrRegisterHeaderExtensionInvalidDirection)
+		assert.ErrorIs(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirection(0)), ErrRegisterHeaderExtensionInvalidDirection)
 	})
 }
 

--- a/ortc_datachannel_test.go
+++ b/ortc_datachannel_test.go
@@ -58,7 +58,7 @@ func TestDataChannel_ORTCE2E(t *testing.T) {
 	assert.NoError(t, stackB.close())
 
 	// attempt to send when channel is closed
-	assert.Error(t, channelA.Send([]byte("ABC")), io.ErrClosedPipe)
-	assert.Error(t, channelA.SendText("test"), io.ErrClosedPipe)
-	assert.Error(t, channelA.ensureOpen(), io.ErrClosedPipe)
+	assert.ErrorIs(t, channelA.Send([]byte("ABC")), io.ErrClosedPipe)
+	assert.ErrorIs(t, channelA.SendText("test"), io.ErrClosedPipe)
+	assert.ErrorIs(t, channelA.ensureOpen(), io.ErrClosedPipe)
 }

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -6,7 +6,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -585,8 +584,6 @@ func (pc *PeerConnection) hasLocalDescriptionChanged(desc *SessionDescription) b
 	}
 	return false
 }
-
-var errExcessiveRetries = errors.New("excessive retries in CreateOffer")
 
 // CreateOffer starts the PeerConnection and generates the localDescription
 // https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -442,7 +442,7 @@ func TestPeerConnection_AnswerWithClosedConnection(t *testing.T) {
 	assert.NoError(t, answerPeerConn.Close())
 
 	_, err = answerPeerConn.CreateAnswer(nil)
-	assert.Error(t, err, &rtcerr.InvalidStateError{Err: ErrConnectionClosed})
+	assert.Equal(t, err, &rtcerr.InvalidStateError{Err: ErrConnectionClosed})
 }
 
 func TestPeerConnection_satisfyTypeAndDirection(t *testing.T) {

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -382,7 +382,7 @@ func TestPeerConnection_Transceiver_Mid(t *testing.T) {
 	assert.True(t, sdpMidHasSsrc(offer, "1", sender2.ssrc), "Expected mid %q with ssrc %d, offer.SDP: %s", "1", sender2.ssrc, offer.SDP)
 
 	_, err = pcAnswer.CreateAnswer(nil)
-	assert.Error(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
+	assert.Equal(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
 
 	pcOffer.ops.Done()
 	pcAnswer.ops.Done()

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -321,7 +321,7 @@ func TestCreateOfferAnswer(t *testing.T) {
 	// so CreateAnswer should return an InvalidStateError
 	assert.Equal(t, answerPeerConn.SignalingState(), SignalingStateStable)
 	_, err = answerPeerConn.CreateAnswer(nil)
-	assert.Error(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
+	assert.Error(t, err)
 
 	closePairNow(t, offerPeerConn, answerPeerConn)
 }

--- a/rtpreceiver_test.go
+++ b/rtpreceiver_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/transport/packetio"
 	"github.com/pion/transport/test"
 	"github.com/pion/webrtc/v3/pkg/media"
 	"github.com/stretchr/testify/assert"
@@ -41,10 +40,10 @@ func Test_RTPReceiver_SetReadDeadline(t *testing.T) {
 		assert.NoError(t, readErr)
 
 		_, _, readErr = trackRemote.ReadRTP()
-		assert.Error(t, readErr, packetio.ErrTimeout)
+		assert.Error(t, readErr)
 
 		_, _, readErr = r.ReadRTCP()
-		assert.Error(t, readErr, packetio.ErrTimeout)
+		assert.Error(t, readErr)
 
 		seenPacketCancel()
 	})

--- a/rtpsender_test.go
+++ b/rtpsender_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/transport/packetio"
 	"github.com/pion/transport/test"
 	"github.com/pion/webrtc/v3/pkg/media"
 	"github.com/stretchr/testify/assert"
@@ -161,7 +160,7 @@ func Test_RTPSender_SetReadDeadline(t *testing.T) {
 
 	assert.NoError(t, rtpSender.SetReadDeadline(time.Now().Add(1*time.Second)))
 	_, _, err = rtpSender.ReadRTCP()
-	assert.Error(t, err, packetio.ErrTimeout)
+	assert.Error(t, err)
 
 	assert.NoError(t, wan.Stop())
 	closePairNow(t, sender, receiver)

--- a/rtptransceiver_test.go
+++ b/rtptransceiver_test.go
@@ -40,7 +40,7 @@ func Test_RTPTransceiver_SetCodecPreferences(t *testing.T) {
 	}
 
 	for _, testCase := range failTestCases {
-		assert.Error(t, tr.SetCodecPreferences(testCase), errRTPTransceiverCodecUnsupported)
+		assert.ErrorIs(t, tr.SetCodecPreferences(testCase), errRTPTransceiverCodecUnsupported)
 	}
 
 	successTestCases := [][]RTPCodecParameters{

--- a/sdp.go
+++ b/sdp.go
@@ -303,6 +303,11 @@ func addTransceiverSDP(d *sdp.SessionDescription, isPlanB, shouldAddCandidates b
 		}
 	}
 	if len(codecs) == 0 {
+		// If we are sender and we have no codecs throw an error early
+		if t.Sender() != nil {
+			return false, ErrSenderWithNoCodecs
+		}
+
 		// Explicitly reject track if we don't have the codec
 		d.WithMedia(&sdp.MediaDescription{
 			MediaName: sdp.MediaName{


### PR DESCRIPTION
It isn't possible to send media if a MediaEngine has no codecs. This
catches a common misconfiguration issues that users find themselves in.

Resolves #1702
