### PR TITLE
option to configure the receive MTU in SettingEngine option

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -26,6 +26,7 @@ baiyufei <baiyufei@outlook.com>
 Bao Nguyen <bao@n4n.dev>
 Ben Weitzman <benweitzman@gmail.com>
 Benny Daon <benny@tuzig.com>
+bkim <bruce.kim.it@gmail.com>
 Bo Shi <boshi@mural.co>
 Brendan Rius <brendan.rius@gmail.com>
 Cameron Elliott <cameron-elliott@users.noreply.github.com>

--- a/icetransport.go
+++ b/icetransport.go
@@ -155,7 +155,7 @@ func (t *ICETransport) Start(gatherer *ICEGatherer, params ICEParameters, role *
 
 	config := mux.Config{
 		Conn:          t.conn,
-		BufferSize:    receiveMTU,
+		BufferSize:    int(t.gatherer.api.settingEngine.getReceiveMTU()),
 		LoggerFactory: t.loggerFactory,
 	}
 	t.mux = mux.NewMux(config)

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1179,7 +1179,7 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 	}
 
 	go func() {
-		b := make([]byte, receiveMTU)
+		b := make([]byte, pc.api.settingEngine.getReceiveMTU())
 		n, _, err := receiver.Track().peek(b)
 		if err != nil {
 			pc.log.Warnf("Could not determine PayloadType for SSRC %d (%s)", receiver.Track().SSRC(), err)
@@ -1362,7 +1362,7 @@ func (pc *PeerConnection) handleUndeclaredSSRC(rtpStream io.Reader, ssrc SSRC) e
 		return errPeerConnSimulcastStreamIDRTPExtensionRequired
 	}
 
-	b := make([]byte, receiveMTU)
+	b := make([]byte, pc.api.settingEngine.getReceiveMTU())
 	var mid, rid string
 	for readCount := 0; readCount <= simulcastProbeCount; readCount++ {
 		i, err := rtpStream.Read(b)

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -194,7 +194,7 @@ func (r *RTPReceiver) ReadSimulcast(b []byte, rid string) (n int, a interceptor.
 // ReadRTCP is a convenience method that wraps Read and unmarshal for you.
 // It also runs any configured interceptors.
 func (r *RTPReceiver) ReadRTCP() ([]rtcp.Packet, interceptor.Attributes, error) {
-	b := make([]byte, receiveMTU)
+	b := make([]byte, r.api.settingEngine.getReceiveMTU())
 	i, attributes, err := r.Read(b)
 	if err != nil {
 		return nil, nil, err
@@ -210,7 +210,7 @@ func (r *RTPReceiver) ReadRTCP() ([]rtcp.Packet, interceptor.Attributes, error) 
 
 // ReadSimulcastRTCP is a convenience method that wraps ReadSimulcast and unmarshal for you
 func (r *RTPReceiver) ReadSimulcastRTCP(rid string) ([]rtcp.Packet, interceptor.Attributes, error) {
-	b := make([]byte, receiveMTU)
+	b := make([]byte, r.api.settingEngine.getReceiveMTU())
 	i, attributes, err := r.ReadSimulcast(b, rid)
 	if err != nil {
 		return nil, nil, err

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -258,7 +258,7 @@ func (r *RTPSender) Read(b []byte) (n int, a interceptor.Attributes, err error) 
 
 // ReadRTCP is a convenience method that wraps Read and unmarshals for you.
 func (r *RTPSender) ReadRTCP() ([]rtcp.Packet, interceptor.Attributes, error) {
-	b := make([]byte, receiveMTU)
+	b := make([]byte, r.api.settingEngine.getReceiveMTU())
 	i, attributes, err := r.Read(b)
 	if err != nil {
 		return nil, nil, err

--- a/settingengine.go
+++ b/settingengine.go
@@ -63,6 +63,16 @@ type SettingEngine struct {
 	iceProxyDialer                            proxy.Dialer
 	disableMediaEngineCopy                    bool
 	srtpProtectionProfiles                    []dtls.SRTPProtectionProfile
+	receiveMTU                                uint
+}
+
+// getReceiveMTU returns the configured MTU. If SettingEngine's MTU is configured to 0 it returns the default
+func (e *SettingEngine) getReceiveMTU() uint {
+	if e.receiveMTU != 0 {
+		return e.receiveMTU
+	}
+
+	return receiveMTU
 }
 
 // DetachDataChannels enables detaching data channels. When enabled
@@ -278,4 +288,10 @@ func (e *SettingEngine) SetICEProxyDialer(d proxy.Dialer) {
 // modify codecs after signaling. Make sure not to share MediaEngines between PeerConnections.
 func (e *SettingEngine) DisableMediaEngineCopy(isDisabled bool) {
 	e.disableMediaEngineCopy = isDisabled
+}
+
+// SetReceiveMTU sets the size of read buffer that copies incoming packets. This is optional.
+// Leave this 0 for the default receiveMTU
+func (e *SettingEngine) SetReceiveMTU(receiveMTU uint) {
+	e.receiveMTU = receiveMTU
 }

--- a/track_remote.go
+++ b/track_remote.go
@@ -157,7 +157,7 @@ func (t *TrackRemote) checkAndUpdateTrack(b []byte) error {
 
 // ReadRTP is a convenience method that wraps Read and unmarshals for you.
 func (t *TrackRemote) ReadRTP() (*rtp.Packet, interceptor.Attributes, error) {
-	b := make([]byte, receiveMTU)
+	b := make([]byte, t.receiver.api.settingEngine.getReceiveMTU())
 	i, attributes, err := t.Read(b)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
#### Description

This gives an option to raise the receive MTU as SettingEngine option.
If SettingEngine has not been set the MTU, then default value is used instead, `1460`

#### Reference issue
https://github.com/pion/webrtc/issues/1925

Fixes #...
