### PR TITLE
Specify bitrate in ffmpeg commands for more usable video stream

### DIFF
--- a/examples/play-from-disk-renegotation/README.md
+++ b/examples/play-from-disk-renegotation/README.md
@@ -16,11 +16,15 @@ cd webrtc/examples/play-from-disk-renegotiation
 ```
 
 ### Create IVF named `output.ivf` that contains a VP8 track
+
 ```
-ffmpeg -i $INPUT_FILE -g 30 output.ivf
+ffmpeg -i $INPUT_FILE -g 30 -b:v 2M output.ivf
 ```
 
+**Note**: In the `ffmpeg` command, the argument `-b:v 2M` specifies the video bitrate to be 2 megabits per second. We provide this default value to produce decent video quality, but if you experience problems with this configuration (such as dropped frames etc.), you can decrease this. See the [ffmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for more information on the format of the value.
+
 ### Run play-from-disk-renegotiation
+
 The `output.ivf` you created should be in the same directory as `play-from-disk-renegotiation`. Execute `go run *.go`
 
 ### Open the Web UI

--- a/examples/play-from-disk/README.md
+++ b/examples/play-from-disk/README.md
@@ -6,11 +6,14 @@ For an example of playing H264 from disk see [play-from-disk-h264](https://githu
 ## Instructions
 ### Create IVF named `output.ivf` that contains a VP8 track and/or `output.ogg` that contains a Opus track
 ```
-ffmpeg -i $INPUT_FILE -g 30 output.ivf
+ffmpeg -i $INPUT_FILE -g 30 -b:v 2M output.ivf
 ffmpeg -i $INPUT_FILE -c:a libopus -page_duration 20000 -vn output.ogg
 ```
 
+**Note**: In the `ffmpeg` command which produces the .ivf file, the argument `-b:v 2M` specifies the video bitrate to be 2 megabits per second. We provide this default value to produce decent video quality, but if you experience problems with this configuration (such as dropped frames etc.), you can decrease this. See the [ffmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for more information on the format of the value.
+
 ### Download play-from-disk
+
 ```
 export GO111MODULE=on
 go get github.com/pion/webrtc/v3/examples/play-from-disk


### PR DESCRIPTION
#### Description
I've found that with the default ffmpeg configuration in the ivf-based `play-from-disk` examples, the bitrate is not specified. This results in a very poor default value of only 256 kbit/s which is low enough for the encoder to drop to black and white video on every third frames. When running the provided command, ffmpeg even warns us about this:
```
[libvpx @ 0000023541414040] Neither bitrate nor constrained quality specified, using default CRF of 32 and bitrate of 256kbit/sec
```

I believe this could lead some people to believe that this is an issue with their software or with Pion, when it's actually just a flag in ffmpeg. I don't understand why the ffmpeg authors set the defaults so low, but I've updated the README files so that the bitrate now matches that of the H264 stream from the `play-from-disk-h264` example (2Mbit/s), which results in a much much better video stream.

#### Comparison
I've made a small video comparing the old vs. the new ffmpeg configuration:
https://youtu.be/_PTwhVo7SNI