### PR TITLE
Don't consider simulcast for undeclared SSRC

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -147,6 +147,7 @@ tarrencev <tarrence13@gmail.com>
 Thomas Miller <tmiv74@gmail.com>
 Tobias Fridén <tobias.friden@gmail.com>
 Tomek <tomek@pop-os.localdomain>
+Twometer <twometer@outlook.de>
 Vicken Simonian <vsimon@gmail.com>
 wattanakorn495 <wattanakorn.i@ku.th>
 Will Watson <william.a.watson@gmail.com>

--- a/constants.go
+++ b/constants.go
@@ -22,9 +22,13 @@ const (
 
 	mediaSectionApplication = "application"
 
+	sdpAttributeRid = "rid"
+
 	rtpOutboundMTU = 1200
 
 	rtpPayloadTypeBitmask = 0x7F
+
+	incomingUnhandledRTPSsrc = "Incoming unhandled RTP ssrc(%d), OnTrack will not be fired. %v"
 )
 
 func defaultSrtpProtectionProfiles() []dtls.SRTPProtectionProfile {

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -15,7 +15,7 @@ import (
 )
 
 // trackStreams maintains a mapping of RTP/RTCP streams to a specific track
-// a RTPReceiver may contain multiple streams if we are dealing with Multicast
+// a RTPReceiver may contain multiple streams if we are dealing with Simulcast
 type trackStreams struct {
 	track *TrackRemote
 

--- a/sdp.go
+++ b/sdp.go
@@ -166,7 +166,7 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) [
 func getRids(media *sdp.MediaDescription) map[string]string {
 	rids := map[string]string{}
 	for _, attr := range media.Attributes {
-		if attr.Key == "rid" {
+		if attr.Key == sdpAttributeRid {
 			split := strings.Split(attr.Value, " ")
 			rids[split[0]] = attr.Value
 		}
@@ -341,7 +341,7 @@ func addTransceiverSDP(d *sdp.SessionDescription, isPlanB, shouldAddCandidates b
 		recvRids := make([]string, 0, len(mediaSection.ridMap))
 
 		for rid := range mediaSection.ridMap {
-			media.WithValueAttribute("rid", rid+" recv")
+			media.WithValueAttribute(sdpAttributeRid, rid+" recv")
 			recvRids = append(recvRids, rid)
 		}
 		// Simulcast
@@ -653,7 +653,6 @@ func rtpExtensionsFromMediaDescription(m *sdp.MediaDescription) (map[string]int,
 // for subsequent calling, it updates Origin for SessionDescription from saved one
 // and increments session version by one.
 // https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-25#section-5.2.2
-// https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-25#section-5.3.2
 func updateSDPOrigin(origin *sdp.Origin, d *sdp.SessionDescription) {
 	if atomic.CompareAndSwapUint64(&origin.SessionVersion, 0, d.Origin.SessionVersion) { // store
 		atomic.StoreUint64(&origin.SessionID, d.Origin.SessionID)

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -204,7 +204,7 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 					},
 					Attributes: []sdp.Attribute{
 						{Key: "sendonly"},
-						{Key: "rid", Value: "f send pt=97;max-width=1280;max-height=720"},
+						{Key: sdpAttributeRid, Value: "f send pt=97;max-width=1280;max-height=720"},
 					},
 				},
 			},
@@ -368,7 +368,7 @@ func TestMediaDescriptionFingerprints(t *testing.T) {
 }
 
 func TestPopulateSDP(t *testing.T) {
-	t.Run("Rid", func(t *testing.T) {
+	t.Run("rid", func(t *testing.T) {
 		se := SettingEngine{}
 
 		me := &MediaEngine{}
@@ -394,7 +394,7 @@ func TestPopulateSDP(t *testing.T) {
 				continue
 			}
 			for _, a := range desc.Attributes {
-				if a.Key == "rid" {
+				if a.Key == sdpAttributeRid {
 					if strings.Contains(a.Value, "ridkey") {
 						found = true
 						break
@@ -458,7 +458,7 @@ func TestGetRIDs(t *testing.T) {
 			},
 			Attributes: []sdp.Attribute{
 				{Key: "sendonly"},
-				{Key: "rid", Value: "f send pt=97;max-width=1280;max-height=720"},
+				{Key: sdpAttributeRid, Value: "f send pt=97;max-width=1280;max-height=720"},
 			},
 		},
 	}


### PR DESCRIPTION
If we have a media section with no SSRC we would fire an OnTrack. This
code now properly ignores a MediaSection that has a rid attribute.

Resolves #1808