### PR TITLE
Fix double loop in data channel ID generation

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -42,6 +42,7 @@ cnderrauber <zengjie9004@gmail.com>
 cyannuk <cyannuk@issart.com>
 David Hamilton <davidhamiltron@gmail.com>
 David Zhao <david@davidzhao.com>
+Dean Sheather <dean@coder.com>
 decanus <7621705+decanus@users.noreply.github.com>
 Denis <Hixon10@yandex.ru>
 digitalix <digitalix4@gmail.com>

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -963,7 +963,6 @@ func TestPeerConnection_Start_Right_Receiver(t *testing.T) {
 // Assert that failed Simulcast probing doesn't cause
 // the handleUndeclaredSSRC to be leaked
 func TestPeerConnection_Simulcast_Probe(t *testing.T) {
-	return
 	lim := test.TimeOut(time.Second * 30) //nolint
 	defer lim.Stop()
 

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -338,15 +338,6 @@ func (r *SCTPTransport) collectStats(collector *statsReportCollector) {
 }
 
 func (r *SCTPTransport) generateAndSetDataChannelID(dtlsRole DTLSRole, idOut **uint16) error {
-	isChannelWithID := func(id uint16) bool {
-		for _, d := range r.dataChannels {
-			if d.id != nil && *d.id == id {
-				return true
-			}
-		}
-		return false
-	}
-
 	var id uint16
 	if dtlsRole != DTLSRoleClient {
 		id++
@@ -356,8 +347,19 @@ func (r *SCTPTransport) generateAndSetDataChannelID(dtlsRole DTLSRole, idOut **u
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
+
+	// Create map of ids so we can compare without double-looping each time.
+	idsMap := make(map[uint16]struct{}, len(r.dataChannels))
+	for _, dc := range r.dataChannels {
+		if dc.id == nil {
+			continue
+		}
+
+		idsMap[*dc.id] = struct{}{}
+	}
+
 	for ; id < max-1; id += 2 {
-		if isChannelWithID(id) {
+		if _, ok := idsMap[id]; ok {
 			continue
 		}
 		*idOut = &id


### PR DESCRIPTION
#### Description

`(*SCTPTransport).generateAndSetDataChannelID` performed a double loop to find the next available data channel ID. This changes that behavior to generate a lookup map with the taken IDs first, so generating a data channel ID takes much less time.

Before, it would take more than 1000ms to generate the next data channel ID once you had roughly 50k of them. Now it only takes 4ms at that same point.

#### Reference issue
Fixes #1945

cc @coadler @kylecarbs