### PR TITLE
Handle Simulcast RepairStream

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -31,6 +31,8 @@ const (
 	incomingUnhandledRTPSsrc = "Incoming unhandled RTP ssrc(%d), OnTrack will not be fired. %v"
 
 	generatedCertificateOrigin = "WebRTC"
+
+	sdesRepairRTPStreamIDURI = "urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id"
 )
 
 func defaultSrtpProtectionProfiles() []dtls.SRTPProtectionProfile {

--- a/errors.go
+++ b/errors.go
@@ -200,7 +200,6 @@ var (
 	errRTPReceiverDTLSTransportNil            = errors.New("DTLSTransport must not be nil")
 	errRTPReceiverReceiveAlreadyCalled        = errors.New("Receive has already been called")
 	errRTPReceiverWithSSRCTrackStreamNotFound = errors.New("unable to find stream for Track with SSRC")
-	errRTPReceiverForSSRCTrackStreamNotFound  = errors.New("no trackStreams found for SSRC")
 	errRTPReceiverForRIDTrackStreamNotFound   = errors.New("no trackStreams found for RID")
 
 	errRTPSenderTrackNil          = errors.New("Track must not be nil")

--- a/interceptor.go
+++ b/interceptor.go
@@ -117,7 +117,7 @@ func (i *interceptorToTrackLocalWriter) Write(b []byte) (int, error) {
 	return i.WriteRTP(&packet.Header, packet.Payload)
 }
 
-func createStreamInfo(id string, ssrc SSRC, payloadType PayloadType, codec RTPCodecCapability, webrtcHeaderExtensions []RTPHeaderExtensionParameter) interceptor.StreamInfo {
+func createStreamInfo(id string, ssrc SSRC, payloadType PayloadType, codec RTPCodecCapability, webrtcHeaderExtensions []RTPHeaderExtensionParameter) *interceptor.StreamInfo {
 	headerExtensions := make([]interceptor.RTPHeaderExtension, 0, len(webrtcHeaderExtensions))
 	for _, h := range webrtcHeaderExtensions {
 		headerExtensions = append(headerExtensions, interceptor.RTPHeaderExtension{ID: h.ID, URI: h.URI})
@@ -128,7 +128,7 @@ func createStreamInfo(id string, ssrc SSRC, payloadType PayloadType, codec RTPCo
 		feedbacks = append(feedbacks, interceptor.RTCPFeedback{Type: f.Type, Parameter: f.Parameter})
 	}
 
-	return interceptor.StreamInfo{
+	return &interceptor.StreamInfo{
 		ID:                  id,
 		Attributes:          interceptor.Attributes{},
 		SSRC:                uint32(ssrc),

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -1175,7 +1175,14 @@ func TestPeerConnection_Simulcast(t *testing.T) {
 					PayloadType:    96,
 				}
 				assert.NoError(t, header.SetExtension(1, []byte("0")))
-				assert.NoError(t, header.SetExtension(2, []byte(rid)))
+
+				// Send RSID for first 10 packets
+				if sequenceNumber >= 10 {
+					assert.NoError(t, header.SetExtension(2, []byte(rid)))
+				} else {
+					assert.NoError(t, header.SetExtension(3, []byte(rid)))
+					header.SSRC += 10
+				}
 
 				_, err := vp8Writer.bindings[0].writeStream.WriteRTP(header, []byte{0x00})
 				assert.NoError(t, err)

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -211,7 +211,7 @@ func (r *RTPSender) Send(parameters RTPSendParameters) error {
 	}
 	r.context.params.Codecs = []RTPCodecParameters{codec}
 
-	r.streamInfo = createStreamInfo(r.id, parameters.Encodings[0].SSRC, codec.PayloadType, codec.RTPCodecCapability, parameters.HeaderExtensions)
+	r.streamInfo = *createStreamInfo(r.id, parameters.Encodings[0].SSRC, codec.PayloadType, codec.RTPCodecCapability, parameters.HeaderExtensions)
 	rtpInterceptor := r.api.interceptor.BindLocalStream(&r.streamInfo, interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
 		return r.srtpStream.WriteRTP(header, payload)
 	}))

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -247,7 +247,7 @@ func satisfyTypeAndDirection(remoteKind RTPCodecType, remoteDirection RTPTransce
 
 // handleUnknownRTPPacket consumes a single RTP Packet and returns information that is helpful
 // for demuxing and handling an unknown SSRC (usually for Simulcast)
-func handleUnknownRTPPacket(buf []byte, midExtensionID, streamIDExtensionID uint8) (mid, rid string, payloadType PayloadType, err error) {
+func handleUnknownRTPPacket(buf []byte, midExtensionID, streamIDExtensionID, repairStreamIDExtensionID uint8, mid, rid, rsid *string) (payloadType PayloadType, err error) {
 	rp := &rtp.Packet{}
 	if err = rp.Unmarshal(buf); err != nil {
 		return
@@ -259,11 +259,15 @@ func handleUnknownRTPPacket(buf []byte, midExtensionID, streamIDExtensionID uint
 
 	payloadType = PayloadType(rp.PayloadType)
 	if payload := rp.GetExtension(midExtensionID); payload != nil {
-		mid = string(payload)
+		*mid = string(payload)
 	}
 
 	if payload := rp.GetExtension(streamIDExtensionID); payload != nil {
-		rid = string(payload)
+		*rid = string(payload)
+	}
+
+	if payload := rp.GetExtension(repairStreamIDExtensionID); payload != nil {
+		*rsid = string(payload)
 	}
 
 	return


### PR DESCRIPTION
Read + Discard packets from the Simulcast repair stream. When a
Simulcast stream is enabled the remote will send packets via the repair
stream for probing. We can't ignore these packets anymore because it
will cause gaps in the feedback reports

Resolves #1957
