### PR TITLE
Adds WithPacketHeadHandler to SampleBuilder

### DIFF
--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -17,6 +17,7 @@ type Sample struct {
 	Duration           time.Duration
 	PacketTimestamp    uint32
 	PrevDroppedPackets uint16
+	Metadata           interface{}
 }
 
 // Writer defines an interface to handle


### PR DESCRIPTION
#### Description
This option allows inspecting head packet for each media.Sample and then lets the user return their custom metadata. This might be useful in case when you need to check whether the given sample is a keyframe.
