### PR TITLE
Use transceiver's codec when getting codecs

### DIFF
--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -69,7 +69,10 @@ func (t *RTPTransceiver) getCodecs() []RTPCodecParameters {
 	filteredCodecs := []RTPCodecParameters{}
 	for _, codec := range t.codecs {
 		if c, matchType := codecParametersFuzzySearch(codec, mediaEngineCodecs); matchType != codecMatchNone {
-			filteredCodecs = append(filteredCodecs, c)
+			if codec.PayloadType == 0 {
+				codec.PayloadType = c.PayloadType
+			}
+			filteredCodecs = append(filteredCodecs, codec)
 		}
 	}
 

--- a/rtptransceiver_test.go
+++ b/rtptransceiver_test.go
@@ -124,7 +124,7 @@ func Test_RTPTransceiver_SetCodecPreferences_PayloadType(t *testing.T) {
 	assert.NoError(t, err)
 
 	// VP8 with proper PayloadType
-	assert.NotEqual(t, -1, strings.Index(answer.SDP, "a=rtpmap:96 VP8/90000"))
+	assert.NotEqual(t, -1, strings.Index(answer.SDP, "a=rtpmap:51 VP8/90000"))
 
 	// testCodec is ignored since offerer doesn't support
 	assert.Equal(t, -1, strings.Index(answer.SDP, "testCodec"))


### PR DESCRIPTION
Issue:
------
A transceiver's codecs can be modified using `SetCodecPreferences`.
When retrieving codecs from the transceiver after changing codec
preferences of the transceiver (for example changing the SDPFmtpLine),
the filter function was using codec from the media engine. Thus,
the change from `SetCodecPreferences` is lost.

Fix:
----
When a match is found (either exact or partial), use the codec from
the transceiver instead of media engine.

Testing:
--------
- Modify SDPFmtpLine of a codec of a transceiver using `SetCodecPreferences` method of `RTPTransceiver`.
- Invoke `GetParamters` of `RTPReceiver` and ensure that `Codecs` has the SDPFmtpLine modification. Before this change the change was not reflected in the returned `Codecs`.

#### Description

#### Reference issue
Fixes #...
