### PR TITLE
Fix Simulcast + non-simulcast remote tracks

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -28,6 +28,7 @@ Ben Weitzman <benweitzman@gmail.com>
 Benny Daon <benny@tuzig.com>
 bkim <bruce.kim.it@gmail.com>
 Bo Shi <boshi@mural.co>
+boks1971 <raja.gobi@tutanota.com>
 Brendan Rius <brendan.rius@gmail.com>
 Cameron Elliott <cameron-elliott@users.noreply.github.com>
 Cecylia Bocovich <cohosh@torproject.org>
@@ -152,6 +153,7 @@ Tomek <tomek@pop-os.localdomain>
 Twometer <twometer@outlook.de>
 Vicken Simonian <vsimon@gmail.com>
 wattanakorn495 <wattanakorn.i@ku.th>
+Will Forcey <wsforc3y@gmail.com>
 Will Watson <william.a.watson@gmail.com>
 Woodrow Douglass <wdouglass@carnegierobotics.com>
 xsbchen <xsbchen@qq.com>

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -3,6 +3,7 @@
 package webrtc
 
 import (
+	"bufio"
 	"context"
 	"io"
 	"strconv"
@@ -1134,6 +1135,16 @@ func TestPeerConnection_Renegotiation_Simulcast(t *testing.T) {
 
 		newRids := []string{"d", "e", "f"}
 		assert.NoError(t, signalPairWithModification(pcOffer, pcAnswer, func(sessionDescription string) string {
+			scanner := bufio.NewScanner(strings.NewReader(sessionDescription))
+			sessionDescription = ""
+			for scanner.Scan() {
+				l := scanner.Text()
+				if strings.HasPrefix(l, "a=rid") || strings.HasPrefix(l, "a=simulcast") {
+					continue
+				}
+
+				sessionDescription += l + "\n"
+			}
 			return signalWithRids(sessionDescription, newRids)
 		}))
 


### PR DESCRIPTION
Problem:
--------
In the following negotiation sequence, the Simulcast track is lost.
1. Remote Offer with Simulcast tracks with rids
2. A new track added to Remote Offer with tracks using SSRCs

When the updated `offer` is received, the Simulcast transceiver's
receiver gets overwritten because the tracks from SDP is compared
against current transceivers. The current transceiver for the
Simulcast track already had SSRCs set as media has been received.
But, tracks read from the SDP only has `rid`. So, no current
transceiver matches and hence a new receiver is created which
clobeers the good Simulcast receiver.

Fix:
----
- Prioritize search by `rid`.
- Also found a case of a loop where the index was missing entries
in the loop. Fix it.

Testing:
--------
- The above case works
