### PR TITLE
Missed second slash in schema protocol

### DIFF
--- a/examples/rtp-to-webrtc/README.md
+++ b/examples/rtp-to-webrtc/README.md
@@ -41,7 +41,7 @@ ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec libvpx -cpu-used 5 -
 If you wish to send audio replace both occurrences of `vp8` in `main.go` then run
 
 ```
-ffmpeg -f lavfi -i 'sine=frequency=1000' -c:a libopus -b:a 48000 -sample_fmt s16p -ssrc 1 -payload_type 111 -f rtp -max_delay 0 -application lowdelay 'rtp:/127.0.0.1:5004?pkt_size=1200'
+ffmpeg -f lavfi -i 'sine=frequency=1000' -c:a libopus -b:a 48000 -sample_fmt s16p -ssrc 1 -payload_type 111 -f rtp -max_delay 0 -application lowdelay 'rtp://127.0.0.1:5004?pkt_size=1200'
 ```
 
 ### Input rtp-to-webrtc's SessionDescription into your browser


### PR DESCRIPTION
Should be `rtp://`