### PR TITLE
Fix panic in save to disk example

### DIFF
--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -76,6 +76,9 @@ func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 	if i.ioWriter == nil {
 		return errFileNotOpened
 	}
+	if len(packet.Payload) == 0 {
+		return nil
+	}
 
 	vp8Packet := codecs.VP8Packet{}
 	if _, err := vp8Packet.Unmarshal(packet.Payload); err != nil {

--- a/pkg/media/ivfwriter/ivfwriter_test.go
+++ b/pkg/media/ivfwriter/ivfwriter_test.go
@@ -230,3 +230,12 @@ func TestIVFWriter_VP8(t *testing.T) {
 		}
 	}
 }
+
+func TestIVFWriter_EmptyPayload(t *testing.T) {
+	buffer := &bytes.Buffer{}
+
+	writer, err := NewWith(buffer)
+	assert.NoError(t, err)
+
+	assert.NoError(t, writer.WriteRTP(&rtp.Packet{Payload: []byte{}}))
+}

--- a/pkg/media/oggwriter/oggwriter.go
+++ b/pkg/media/oggwriter/oggwriter.go
@@ -172,6 +172,9 @@ func (i *OggWriter) WriteRTP(packet *rtp.Packet) error {
 	if packet == nil {
 		return errInvalidNilPacket
 	}
+	if len(packet.Payload) == 0 {
+		return nil
+	}
 
 	opusPacket := codecs.OpusPacket{}
 	if _, err := opusPacket.Unmarshal(packet.Payload); err != nil {

--- a/pkg/media/oggwriter/oggwriter_test.go
+++ b/pkg/media/oggwriter/oggwriter_test.go
@@ -56,9 +56,9 @@ func TestOggWriter_AddPacketAndClose(t *testing.T) {
 		},
 		{
 			buffer:       &bytes.Buffer{},
-			message:      "OggWriter shouldn't be able to write an empty packet",
+			message:      "OggWriter shouldn't be able to write a nil packet",
 			messageClose: "OggWriter should be able to close the file",
-			packet:       &rtp.Packet{},
+			packet:       nil,
 			err:          errInvalidNilPacket,
 			closeErr:     nil,
 		},
@@ -120,4 +120,13 @@ func TestOggWriter_AddPacketAndClose(t *testing.T) {
 			assert.Equal(t.closeErr, res, t.messageClose)
 		}
 	}
+}
+
+func TestOggWriter_EmptyPayload(t *testing.T) {
+	buffer := &bytes.Buffer{}
+
+	writer, err := NewWith(buffer, 48000, 2)
+	assert.NoError(t, err)
+
+	assert.NoError(t, writer.WriteRTP(&rtp.Packet{Payload: []byte{}}))
 }


### PR DESCRIPTION
github.com/pion/rtp to v1.7.4 fixed the parsing of padding bytes as
media payload. This fix skips over RTP packets with an empty payload,
such as unmarshalled padding-only packets.
