### PR TITLE
Open all DataChannels before accepting remote

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -50,6 +50,7 @@ digitalix <digitalix4@gmail.com>
 donotanswer <viktor.ferter@doclerholding.com>
 earle <aguilar@dm.ai>
 Egon Elbre <egonelbre@gmail.com>
+Eric Daniels <eric@erdaniels.com>
 feixiao <feixiao2020@sina.com>
 frank <frank@huzhedeMacBook-Pro.local>
 Gareth Hayes <gareth.hayes@gmail.com>

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1313,28 +1313,6 @@ func (pc *PeerConnection) startSCTP() {
 
 		return
 	}
-
-	// DataChannels that need to be opened now that SCTP is available
-	// make a copy we may have incoming DataChannels mutating this while we open
-	pc.sctpTransport.lock.RLock()
-	dataChannels := append([]*DataChannel{}, pc.sctpTransport.dataChannels...)
-	pc.sctpTransport.lock.RUnlock()
-
-	var openedDCCount uint32
-	for _, d := range dataChannels {
-		if d.ReadyState() == DataChannelStateConnecting {
-			err := d.open(pc.sctpTransport)
-			if err != nil {
-				pc.log.Warnf("failed to open data channel: %s", err)
-				continue
-			}
-			openedDCCount++
-		}
-	}
-
-	pc.sctpTransport.lock.Lock()
-	pc.sctpTransport.dataChannelsOpened += openedDCCount
-	pc.sctpTransport.lock.Unlock()
 }
 
 func (pc *PeerConnection) handleUndeclaredSSRC(ssrc SSRC, remoteDescription *SessionDescription) (handled bool, err error) {


### PR DESCRIPTION
A race existed with Negotiated DataChannels before this. Before the remote
could sends us a DataChannel message before the datachannel was
negotiated locally. We would then discard the message and print an
error.

This PR moves the processing of remote datachannel messages after we have
registered all local ones.
