### PR TITLE
Open all DataChannels before accepting remote

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -50,6 +50,7 @@ digitalix <digitalix4@gmail.com>
 donotanswer <viktor.ferter@doclerholding.com>
 earle <aguilar@dm.ai>
 Egon Elbre <egonelbre@gmail.com>
+Eric Daniels <eric@erdaniels.com>
 feixiao <feixiao2020@sina.com>
 frank <frank@huzhedeMacBook-Pro.local>
 Gareth Hayes <gareth.hayes@gmail.com>

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/onsi/ginkgo v1.16.1 // indirect
 	github.com/onsi/gomega v1.11.0 // indirect
-	github.com/pion/datachannel v1.5.0
+	github.com/pion/datachannel v1.5.1
 	github.com/pion/dtls/v2 v2.0.10
 	github.com/pion/ice/v2 v2.1.13
 	github.com/pion/interceptor v0.1.0
@@ -13,7 +13,7 @@ require (
 	github.com/pion/randutil v0.1.0
 	github.com/pion/rtcp v1.2.8
 	github.com/pion/rtp v1.7.4
-	github.com/pion/sctp v1.7.12
+	github.com/pion/sctp v1.8.0
 	github.com/pion/sdp/v3 v3.0.4
 	github.com/pion/srtp/v2 v2.0.5
 	github.com/pion/transport v0.12.3

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.11.0 h1:+CqWgvj0OZycCaqclBD1pxKHAU+tOkHmQIWvDHq2aug=
 github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
-github.com/pion/datachannel v1.5.0 h1:Jy6xWr9hysxet69qP23ibiJ6M0P30ZRnndHU+N6cpkY=
-github.com/pion/datachannel v1.5.0/go.mod h1:TVbgWP+PVM9TlwL1IkG3JqXXfjGxLvsu9QUeFdpTegI=
+github.com/pion/datachannel v1.5.1 h1:qoYSs6+wJRCdfU6jnOAdcHKjVYcSMNBGT7ZVlxgTPmo=
+github.com/pion/datachannel v1.5.1/go.mod h1:FTGQWaHrdCwIJ1rw6xBIfZVkslikjShim5yr05XFuCQ=
 github.com/pion/dtls/v2 v2.0.9/go.mod h1:O0Wr7si/Zj5/EBFlDzDd6UtVxx25CE1r7XM7BQKYQho=
 github.com/pion/dtls/v2 v2.0.10 h1:wgys7gPR1NMbWjmjJ3CW7lkUGaun8djgH8nahpNLnxI=
 github.com/pion/dtls/v2 v2.0.10/go.mod h1:00OxfeCRWHShcqT9jx8pKKmBWuTt0NCZoVPCaC4VKvU=
@@ -59,8 +59,8 @@ github.com/pion/rtp v1.7.0/go.mod h1:bDb5n+BFZxXx0Ea7E5qe+klMuqiBrP+w8XSjiWtCUko
 github.com/pion/rtp v1.7.2/go.mod h1:bDb5n+BFZxXx0Ea7E5qe+klMuqiBrP+w8XSjiWtCUko=
 github.com/pion/rtp v1.7.4 h1:4dMbjb1SuynU5OpA3kz1zHK+u+eOCQjW3MAeVHf1ODA=
 github.com/pion/rtp v1.7.4/go.mod h1:bDb5n+BFZxXx0Ea7E5qe+klMuqiBrP+w8XSjiWtCUko=
-github.com/pion/sctp v1.7.12 h1:GsatLufywVruXbZZT1CKg+Jr8ZTkwiPnmUC/oO9+uuY=
-github.com/pion/sctp v1.7.12/go.mod h1:xFe9cLMZ5Vj6eOzpyiKjT9SwGM4KpK/8Jbw5//jc+0s=
+github.com/pion/sctp v1.8.0 h1:6erMF2qmQwXr+0iB1lm0AUSmDr9LdmpaBzgSVAEgehw=
+github.com/pion/sctp v1.8.0/go.mod h1:xFe9cLMZ5Vj6eOzpyiKjT9SwGM4KpK/8Jbw5//jc+0s=
 github.com/pion/sdp/v3 v3.0.4 h1:2Kf+dgrzJflNCSw3TV5v2VLeI0s/qkzy2r5jlR0wzf8=
 github.com/pion/sdp/v3 v3.0.4/go.mod h1:bNiSknmJE0HYBprTHXKPQ3+JjacTv5uap92ueJZKsRk=
 github.com/pion/srtp/v2 v2.0.5 h1:ks3wcTvIUE/GHndO3FAvROQ9opy0uLELpwHJaQ1yqhQ=

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1313,28 +1313,6 @@ func (pc *PeerConnection) startSCTP() {
 
 		return
 	}
-
-	// DataChannels that need to be opened now that SCTP is available
-	// make a copy we may have incoming DataChannels mutating this while we open
-	pc.sctpTransport.lock.RLock()
-	dataChannels := append([]*DataChannel{}, pc.sctpTransport.dataChannels...)
-	pc.sctpTransport.lock.RUnlock()
-
-	var openedDCCount uint32
-	for _, d := range dataChannels {
-		if d.ReadyState() == DataChannelStateConnecting {
-			err := d.open(pc.sctpTransport)
-			if err != nil {
-				pc.log.Warnf("failed to open data channel: %s", err)
-				continue
-			}
-			openedDCCount++
-		}
-	}
-
-	pc.sctpTransport.lock.Lock()
-	pc.sctpTransport.dataChannelsOpened += openedDCCount
-	pc.sctpTransport.lock.Unlock()
 }
 
 func (pc *PeerConnection) handleUndeclaredSSRC(ssrc SSRC, remoteDescription *SessionDescription) (handled bool, err error) {

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -110,10 +110,26 @@ func (r *SCTPTransport) Start(remoteCaps SCTPCapabilities) error {
 	}
 
 	r.lock.Lock()
-	defer r.lock.Unlock()
-
 	r.sctpAssociation = sctpAssociation
 	r.state = SCTPTransportStateConnected
+	dataChannels := append([]*DataChannel{}, r.dataChannels...)
+	r.lock.Unlock()
+
+	var openedDCCount uint32
+	for _, d := range dataChannels {
+		if d.ReadyState() == DataChannelStateConnecting {
+			err := d.open(r)
+			if err != nil {
+				r.log.Warnf("failed to open data channel: %s", err)
+				continue
+			}
+			openedDCCount++
+		}
+	}
+
+	r.lock.Lock()
+	r.dataChannelsOpened += openedDCCount
+	r.lock.Unlock()
 
 	go r.acceptDataChannels(sctpAssociation)
 
@@ -139,16 +155,34 @@ func (r *SCTPTransport) Stop() error {
 }
 
 func (r *SCTPTransport) acceptDataChannels(a *sctp.Association) {
+	r.lock.RLock()
+	dataChannels := make([]*datachannel.DataChannel, 0, len(r.dataChannels))
+	for _, dc := range r.dataChannels {
+		dc.mu.Lock()
+		isNil := dc.dataChannel == nil
+		dc.mu.Unlock()
+		if isNil {
+			continue
+		}
+		dataChannels = append(dataChannels, dc.dataChannel)
+	}
+	r.lock.RUnlock()
+ACCEPT:
 	for {
 		dc, err := datachannel.Accept(a, &datachannel.Config{
 			LoggerFactory: r.api.settingEngine.LoggerFactory,
-		})
+		}, dataChannels...)
 		if err != nil {
 			if err != io.EOF {
 				r.log.Errorf("Failed to accept data channel: %v", err)
 				r.onError(err)
 			}
 			return
+		}
+		for _, ch := range dataChannels {
+			if ch.StreamIdentifier() == dc.StreamIdentifier() {
+				continue ACCEPT
+			}
 		}
 
 		var (


### PR DESCRIPTION
A race existed with Negotiated DataChannels before this. Before
the remote could sends us a DataChannel message before the
datachannel was negotiated locally. We would then discard the
message and print an error.

This PR moves the processing of remote datachannel messages after
we have registered all local ones. It also informs
datachannel.Accept of existing datachannels in order to prevent
any initialization logic from proceeding incorrectly.
