### PR TITLE
Match remote codec ordering in transceivers created by remote SDP

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1064,6 +1064,20 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 				pc.mu.Lock()
 				pc.addRTPTransceiver(t)
 				pc.mu.Unlock()
+
+				// if transceiver is create by remote sdp, set prefer codec same as remote peer
+				if codecs, err := codecsFromMediaDescription(media); err == nil {
+					filteredCodecs := []RTPCodecParameters{}
+					for _, codec := range codecs {
+						if c, matchType := codecParametersFuzzySearch(codec, pc.api.mediaEngine.getCodecsByKind(kind)); matchType == codecMatchExact {
+							// if codec match exact, use payloadtype register to mediaengine
+							codec.PayloadType = c.PayloadType
+							filteredCodecs = append(filteredCodecs, codec)
+						}
+					}
+					_ = t.SetCodecPreferences(filteredCodecs)
+				}
+
 			case direction == RTPTransceiverDirectionRecvonly:
 				if t.Direction() == RTPTransceiverDirectionSendrecv {
 					t.setDirection(RTPTransceiverDirectionSendonly)

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -129,6 +129,9 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 100)
+			if pcOffer.ICEConnectionState() != ICEConnectionStateConnected {
+				continue
+			}
 			if routineErr := vp8Track.WriteSample(media.Sample{Data: []byte{0x00}, Duration: time.Second}); routineErr != nil {
 				fmt.Println(routineErr)
 			}


### PR DESCRIPTION
if a transceiver is created by remote sdp, then set
prefer codec same as offer peer.

#### Description
If a client set preference codec, then create offer and send to pion sfu,
then sfu create a recvonly transceiver from the sdp, but the codec seq
is the same as mediaengine's register, I think it should be same as the 
offer peer's prefer codec, so the client can use codec  prefer.

#### Reference issue
Fixes #...
