### PR TITLE
fix get set isClosed not in atomic

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -30,6 +30,7 @@ bkim <bruce.kim.it@gmail.com>
 Bo Shi <boshi@mural.co>
 boks1971 <raja.gobi@tutanota.com>
 Brendan Rius <brendan.rius@gmail.com>
+brian <brian@cyalive.com>
 Cameron Elliott <cameron-elliott@users.noreply.github.com>
 Cecylia Bocovich <cohosh@torproject.org>
 Cedric Fung <cedric@vec.io>

--- a/atomicbool.go
+++ b/atomicbool.go
@@ -18,3 +18,11 @@ func (b *atomicBool) set(value bool) { // nolint: unparam
 func (b *atomicBool) get() bool {
 	return atomic.LoadInt32(&(b.val)) != 0
 }
+
+func (b *atomicBool) swap(value bool) bool {
+	var i int32 = 0
+	if value {
+		i = 1
+	}
+	return atomic.SwapInt32(&(b.val), i) != 0
+}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1851,12 +1851,10 @@ func (pc *PeerConnection) writeRTCP(pkts []rtcp.Packet, _ interceptor.Attributes
 // Close ends the PeerConnection
 func (pc *PeerConnection) Close() error {
 	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #1)
-	if pc.isClosed.get() {
+	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #2)
+	if pc.isClosed.swap(true) {
 		return nil
 	}
-
-	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #2)
-	pc.isClosed.set(true)
 
 	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #3)
 	pc.signalingState.Set(SignalingStateClosed)


### PR DESCRIPTION
Thanks for this awesome project. 
When I was learning the code, I realized the isClosed on Close function is not in atomic.
if this function is called at the same time on different go routines, the peerConnect may close multiple times.
Here is the fix to make the get and set in atomic.
Hope this help.

