### PR TITLE
Make setMid of Transceiver public

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -660,7 +660,7 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 					continue
 				}
 				pc.greaterMid++
-				err = t.setMid(strconv.Itoa(pc.greaterMid))
+				err = t.SetMid(strconv.Itoa(pc.greaterMid))
 				if err != nil {
 					return SessionDescription{}, err
 				}
@@ -1092,7 +1092,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 			}
 
 			if t.Mid() == "" {
-				if err := t.setMid(midValue); err != nil {
+				if err := t.SetMid(midValue); err != nil {
 					return err
 				}
 			}

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -115,8 +115,8 @@ func (t *RTPTransceiver) Receiver() *RTPReceiver {
 	return nil
 }
 
-// setMid sets the RTPTransceiver's mid. If it was already set, will return an error.
-func (t *RTPTransceiver) setMid(mid string) error {
+// SetMid sets the RTPTransceiver's mid. If it was already set, will return an error.
+func (t *RTPTransceiver) SetMid(mid string) error {
 	if currentMid := t.Mid(); currentMid != "" {
 		return fmt.Errorf("%w: %s to %s", errRTPTransceiverCannotChangeMid, currentMid, mid)
 	}


### PR DESCRIPTION
in some case like session migration from one sfu node
to another, we need manual set mid of transceiver instead of
auto generate, to make mid consistent between to sfu node.

#### Description

#### Reference issue
Fixes #...
