### PR TITLE
Fix RTPSender.Send crash

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -205,6 +205,7 @@ var (
 	errRTPSenderTrackNil          = errors.New("Track must not be nil")
 	errRTPSenderDTLSTransportNil  = errors.New("DTLSTransport must not be nil")
 	errRTPSenderSendAlreadyCalled = errors.New("Send has already been called")
+	errRTPSenderTrackRemoved      = errors.New("Sender Track has been removed or replaced to nil")
 
 	errRTPTransceiverCannotChangeMid        = errors.New("errRTPSenderTrackNil")
 	errRTPTransceiverSetSendingInvalidState = errors.New("invalid state change in RTPTransceiver.setSending")

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -195,8 +195,11 @@ func (r *RTPSender) Send(parameters RTPSendParameters) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.hasSent() {
+	switch {
+	case r.hasSent():
 		return errRTPSenderSendAlreadyCalled
+	case r.track == nil:
+		return errRTPSenderTrackRemoved
 	}
 
 	writeStream := &interceptorToTrackLocalWriter{}

--- a/rtpsender_test.go
+++ b/rtpsender_test.go
@@ -271,3 +271,59 @@ func Test_RTPSender_GetParameters_NilTrack(t *testing.T) {
 
 	assert.NoError(t, peerConnection.Close())
 }
+
+func Test_RTPSender_Send(t *testing.T) {
+	track, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+	assert.NoError(t, err)
+
+	peerConnection, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	rtpSender, err := peerConnection.AddTrack(track)
+	assert.NoError(t, err)
+
+	parameter := rtpSender.GetParameters()
+	err = rtpSender.Send(parameter)
+	<-rtpSender.sendCalled
+	assert.NoError(t, err)
+
+	assert.NoError(t, peerConnection.Close())
+}
+
+func Test_RTPSender_Send_Called_Once(t *testing.T) {
+	track, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+	assert.NoError(t, err)
+
+	peerConnection, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	rtpSender, err := peerConnection.AddTrack(track)
+	assert.NoError(t, err)
+
+	parameter := rtpSender.GetParameters()
+	err = rtpSender.Send(parameter)
+	<-rtpSender.sendCalled
+	assert.NoError(t, err)
+
+	err = rtpSender.Send(parameter)
+	assert.Equal(t, errRTPSenderSendAlreadyCalled, err)
+
+	assert.NoError(t, peerConnection.Close())
+}
+
+func Test_RTPSender_Send_Track_Removed(t *testing.T) {
+	track, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+	assert.NoError(t, err)
+
+	peerConnection, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	rtpSender, err := peerConnection.AddTrack(track)
+	assert.NoError(t, err)
+
+	parameter := rtpSender.GetParameters()
+	assert.NoError(t, peerConnection.RemoveTrack(rtpSender))
+	assert.Equal(t, errRTPSenderTrackRemoved, rtpSender.Send(parameter))
+
+	assert.NoError(t, peerConnection.Close())
+}


### PR DESCRIPTION
#### Description
If PeerConnection removes track while RTPSender is created and being negotiated,
RTPSender.Send would access nil pointer.
Check If track is nil.

I think it's related with issue #2065 

#### Reference issue
Fixes #...
