### PR TITLE
Add ability to set RTP stream ID on TrackLocal

### DIFF
--- a/rtpsender.go
+++ b/rtpsender.go
@@ -1,3 +1,4 @@
+//go:build !js
 // +build !js
 
 package webrtc
@@ -107,6 +108,10 @@ func (r *RTPSender) Transport() *DTLSTransport {
 }
 
 func (r *RTPSender) getParameters() RTPSendParameters {
+	var rid string
+	if r.track != nil {
+		rid = r.track.RID()
+	}
 	sendParameters := RTPSendParameters{
 		RTPParameters: r.api.mediaEngine.getRTPParametersByKind(
 			r.kind,
@@ -115,6 +120,7 @@ func (r *RTPSender) getParameters() RTPSendParameters {
 		Encodings: []RTPEncodingParameters{
 			{
 				RTPCodingParameters: RTPCodingParameters{
+					RID:         rid,
 					SSRC:        r.ssrc,
 					PayloadType: r.payloadType,
 				},

--- a/track_local.go
+++ b/track_local.go
@@ -67,6 +67,9 @@ type TrackLocal interface {
 	// and StreamID would be 'desktop' or 'webcam'
 	ID() string
 
+	// RID is the RTP Stream ID for this track.
+	RID() string
+
 	// StreamID is the group this track belongs too. This must be unique
 	StreamID() string
 


### PR DESCRIPTION
This change makes it possible to set the RTP stream ID to
allow forwarding and production of simulcast streams.
