### PR TITLE
refs #2092; port copySessionDescription to all relevant examples; tin…

### DIFF
--- a/examples/broadcast/README.md
+++ b/examples/broadcast/README.md
@@ -11,7 +11,7 @@ go get github.com/pion/webrtc/v3/examples/broadcast
 ```
 
 ### Open broadcast example page
-[jsfiddle.net](https://jsfiddle.net/1jc4go7v/) You should see two buttons 'Publish a Broadcast' and 'Join a Broadcast'
+[jsfiddle.net](https://jsfiddle.net/ypcsbnu3/) You should see two buttons `Publish a Broadcast` and `Join a Broadcast`
 
 ### Run Broadcast
 #### Linux/macOS
@@ -20,7 +20,7 @@ Run `broadcast` OR run `main.go` in `github.com/pion/webrtc/examples/broadcast`
 ### Start a publisher
 
 * Click `Publish a Broadcast`
-* Copy the string in the first input labelled `Browser base64 Session Description`
+* Press `Copy browser SDP to clipboard` or copy the `Browser base64 Session Description` string manually
 * Run `curl localhost:8080/sdp -d "$BROWSER_OFFER"`. `$BROWSER_OFFER` is the value you copied in the last step.
 * The `broadcast` terminal application will respond with an answer, paste this into the second input field in your browser.
 * Press `Start Session`

--- a/examples/broadcast/jsfiddle/demo.html
+++ b/examples/broadcast/jsfiddle/demo.html
@@ -1,7 +1,12 @@
 <div id="signalingContainer" style="display: none">
   Browser base64 Session Description<br />
   <textarea id="localSessionDescription" readonly="true"></textarea> <br />
-  
+  <button onclick="window.copySDP()">
+    Copy browser SDP to clipboard
+  </button>
+  <br />
+  <br />
+
   Golang base64 Session Description<br />
   <textarea id="remoteSessionDescription"></textarea> <br/>
   <button onclick="window.startSession()"> Start Session </button><br />

--- a/examples/broadcast/jsfiddle/demo.js
+++ b/examples/broadcast/jsfiddle/demo.js
@@ -54,6 +54,21 @@ window.createSession = isPublisher => {
     }
   }
 
+  window.copySDP = () => {
+  const browserSDP = document.getElementById('localSessionDescription')
+
+  browserSDP.focus()
+  browserSDP.select()
+
+  try {
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
+    log('Copying SDP was ' + msg)
+  } catch (err) {
+    log('Unable to copy SDP ' + err)
+  }
+}
+
   let btns = document.getElementsByClassName('createSessionButton')
   for (let i = 0; i < btns.length; i++) {
     btns[i].style = 'display: none'

--- a/examples/data-channels/README.md
+++ b/examples/data-channels/README.md
@@ -9,10 +9,10 @@ go get github.com/pion/webrtc/v3/examples/data-channels
 ```
 
 ### Open data-channels example page
-[jsfiddle.net](https://jsfiddle.net/9tsx15mg/90/)
+[jsfiddle.net](https://jsfiddle.net/t3johb5g/2/)
 
 ### Run data-channels, with your browsers SessionDescription as stdin
-In the jsfiddle the top textarea is your browser's session description, copy that and:
+In the jsfiddle the top textarea is your browser's session description, press `Copy browser SDP to clipboard` or copy the base64 string manually and:
 #### Linux/macOS
 Run `echo $BROWSER_SDP | data-channels`
 #### Windows

--- a/examples/data-channels/jsfiddle/demo.html
+++ b/examples/data-channels/jsfiddle/demo.html
@@ -1,5 +1,10 @@
 Browser base64 Session Description<br />
 <textarea id="localSessionDescription" readonly="true"></textarea> <br />
+<button onclick="window.copySDP()">
+	Copy browser SDP to clipboard
+</button>
+<br />
+<br />
 
 Golang base64 Session Description<br />
 <textarea id="remoteSessionDescription"></textarea><br/>

--- a/examples/data-channels/jsfiddle/demo.js
+++ b/examples/data-channels/jsfiddle/demo.js
@@ -47,3 +47,18 @@ window.startSession = () => {
     alert(e)
   }
 }
+
+window.copySDP = () => {
+  const browserSDP = document.getElementById('localSessionDescription')
+
+  browserSDP.focus()
+  browserSDP.select()
+
+  try {
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
+    log('Copying SDP was ' + msg)
+  } catch (err) {
+    log('Unable to copy SDP ' + err)
+  }
+}

--- a/examples/reflect/README.md
+++ b/examples/reflect/README.md
@@ -9,10 +9,12 @@ go get github.com/pion/webrtc/v3/examples/reflect
 ```
 
 ### Open reflect example page
-[jsfiddle.net](https://jsfiddle.net/9jgukzt1/) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/ogs7muqh/1/) you should see two text-areas and a 'Start Session' button.
 
 ### Run reflect, with your browsers SessionDescription as stdin
-In the jsfiddle the top textarea is your browser, copy that and:
+In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.
+We will use this value in the next step.
+
 #### Linux/macOS
 Run `echo $BROWSER_SDP | reflect`
 #### Windows

--- a/examples/reflect/jsfiddle/demo.html
+++ b/examples/reflect/jsfiddle/demo.html
@@ -1,5 +1,10 @@
 Browser base64 Session Description<br />
 <textarea id="localSessionDescription" readonly="true"></textarea> <br />
+<button onclick="window.copySDP()">
+	Copy browser SDP to clipboard
+</button>
+<br />
+<br />
 
 Golang base64 Session Description<br />
 <textarea id="remoteSessionDescription"></textarea> <br/>

--- a/examples/reflect/jsfiddle/demo.js
+++ b/examples/reflect/jsfiddle/demo.js
@@ -44,3 +44,19 @@ window.startSession = () => {
     alert(e)
   }
 }
+
+window.copySDP = () => {
+  const browserSDP = document.getElementById('localSessionDescription')
+
+  browserSDP.focus()
+  browserSDP.select()
+
+  try {
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
+    log('Copying SDP was ' + msg)
+  } catch (err) {
+    log('Unable to copy SDP ' + err)
+  }
+}
+

--- a/examples/rtp-forwarder/README.md
+++ b/examples/rtp-forwarder/README.md
@@ -9,10 +9,12 @@ go get github.com/pion/webrtc/v3/examples/rtp-forwarder
 ```
 
 ### Open rtp-forwarder example page
-[jsfiddle.net](https://jsfiddle.net/1qva2zd8/) you should see your Webcam, two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/xjcve6d3/) you should see your Webcam, two text-areas and `Copy browser SDP to clipboard`, `Start Session` buttons
 
 ### Run rtp-forwarder, with your browsers SessionDescription as stdin
-In the jsfiddle the top textarea is your browser, copy that and:
+In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.
+We will use this value in the next step.
+
 #### Linux/macOS
 Run `echo $BROWSER_SDP | rtp-forwarder`
 #### Windows

--- a/examples/rtp-forwarder/jsfiddle/demo.html
+++ b/examples/rtp-forwarder/jsfiddle/demo.html
@@ -1,5 +1,10 @@
 Browser base64 Session Description<br />
 <textarea id="localSessionDescription" readonly="true"></textarea> <br />
+<button onclick="window.copySDP()">
+	Copy browser SDP to clipboard
+</button>
+<br />
+<br />
 
 Golang base64 Session Description<br />
 <textarea id="remoteSessionDescription"></textarea> <br/>

--- a/examples/rtp-forwarder/jsfiddle/demo.js
+++ b/examples/rtp-forwarder/jsfiddle/demo.js
@@ -37,3 +37,18 @@ window.startSession = () => {
     alert(e)
   }
 }
+
+window.copySDP = () => {
+  const browserSDP = document.getElementById('localSessionDescription')
+
+  browserSDP.focus()
+  browserSDP.select()
+
+  try {
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
+    log('Copying SDP was ' + msg)
+  } catch (err) {
+    log('Unable to copy SDP ' + err)
+  }
+}

--- a/examples/save-to-disk/README.md
+++ b/examples/save-to-disk/README.md
@@ -11,10 +11,12 @@ go get github.com/pion/webrtc/v3/examples/save-to-disk
 ```
 
 ### Open save-to-disk example page
-[jsfiddle.net](https://jsfiddle.net/vfmcg8rk/1/) you should see your Webcam, two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/xjcve6d3/) you should see your Webcam, two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
 
 ### Run save-to-disk, with your browsers SessionDescription as stdin
-In the jsfiddle the top textarea is your browser, copy that and:
+In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.
+We will use this value in the next step.
+
 #### Linux/macOS
 Run `echo $BROWSER_SDP | save-to-disk`
 #### Windows

--- a/examples/save-to-disk/jsfiddle/demo.html
+++ b/examples/save-to-disk/jsfiddle/demo.html
@@ -1,5 +1,10 @@
 Browser base64 Session Description<br />
 <textarea id="localSessionDescription" readonly="true"></textarea> <br />
+<button onclick="window.copySDP()">
+	Copy browser SDP to clipboard
+</button>
+<br />
+<br />
 
 Golang base64 Session Description<br />
 <textarea id="remoteSessionDescription"></textarea> <br/>

--- a/examples/save-to-disk/jsfiddle/demo.js
+++ b/examples/save-to-disk/jsfiddle/demo.js
@@ -38,3 +38,18 @@ window.startSession = () => {
     alert(e)
   }
 }
+
+window.copySDP = () => {
+  const browserSDP = document.getElementById('localSessionDescription')
+
+  browserSDP.focus()
+  browserSDP.select()
+
+  try {
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
+    log('Copying SDP was ' + msg)
+  } catch (err) {
+    log('Unable to copy SDP ' + err)
+  }
+}

--- a/examples/simulcast/README.md
+++ b/examples/simulcast/README.md
@@ -13,10 +13,12 @@ go get github.com/pion/webrtc/v3/examples/simulcast
 ```
 
 ### Open simulcast example page
-[jsfiddle.net](https://jsfiddle.net/rxk4bftc) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/zLebmv41/1/) you should see two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
 
 ### Run simulcast, with your browsers SessionDescription as stdin
-In the jsfiddle the top textarea is your browser, copy that and:
+In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.
+We will use this value in the next step.
+
 #### Linux/macOS
 Run `echo $BROWSER_SDP | simulcast`
 #### Windows

--- a/examples/simulcast/jsfiddle/demo.html
+++ b/examples/simulcast/jsfiddle/demo.html
@@ -1,6 +1,11 @@
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
 Browser base64 Session Description<br />
 <textarea id="localSessionDescription" readonly="true"></textarea> <br />
+<button onclick="window.copySDP()">
+  Copy browser SDP to clipboard
+</button>
+<br />
+<br />
 
 Golang base64 Session Description<br />
 <textarea id="remoteSessionDescription"></textarea> <br />

--- a/examples/simulcast/jsfiddle/demo.js
+++ b/examples/simulcast/jsfiddle/demo.js
@@ -90,3 +90,18 @@ window.startSession = () => {
     alert(e);
   }
 };
+
+window.copySDP = () => {
+  const browserSDP = document.getElementById('localSessionDescription')
+
+  browserSDP.focus()
+  browserSDP.select()
+
+  try {
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
+    console.log('Copying SDP was ' + msg)
+  } catch (err) {
+    console.log('Unable to copy SDP ' + err)
+  }
+}

--- a/examples/swap-tracks/README.md
+++ b/examples/swap-tracks/README.md
@@ -9,10 +9,12 @@ go get github.com/pion/webrtc/v3/examples/swap-tracks
 ```
 
 ### Open swap-tracks example page
-[jsfiddle.net](https://jsfiddle.net/dzc17fga/) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/39w24tr6/1/) you should see two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
 
 ### Run swap-tracks, with your browsers SessionDescription as stdin
-In the jsfiddle the top textarea is your browser, copy that and:
+In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.
+We will use this value in the next step.
+
 #### Linux/macOS
 Run `echo $BROWSER_SDP | swap-tracks`
 #### Windows

--- a/examples/swap-tracks/jsfiddle/demo.html
+++ b/examples/swap-tracks/jsfiddle/demo.html
@@ -1,5 +1,10 @@
 Browser base64 Session Description<br />
 <textarea id="localSessionDescription" readonly="true"></textarea> <br />
+<button onclick="window.copySDP()">
+  Copy browser SDP to clipboard
+</button>
+<br />
+<br />
 
 Golang base64 Session Description<br />
 <textarea id="remoteSessionDescription"></textarea> <br/>

--- a/examples/swap-tracks/jsfiddle/demo.js
+++ b/examples/swap-tracks/jsfiddle/demo.js
@@ -66,3 +66,18 @@ window.startSession = () => {
     alert(e)
   }
 }
+
+window.copySDP = () => {
+  const browserSDP = document.getElementById('localSessionDescription')
+
+  browserSDP.focus()
+  browserSDP.select()
+
+  try {
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
+    console.log('Copying SDP was ' + msg)
+  } catch (err) {
+    console.log('Unable to copy SDP ' + err)
+  }
+}

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -502,7 +502,6 @@ func (pc *PeerConnection) AddTransceiverFromKind(kind RTPCodecType, init ...RTPT
 		return &RTPTransceiver{
 			underlying: pc.underlying.Call("addTransceiver", kind.String(), rtpTransceiverInitInitToValue(init[0])),
 		}, err
-
 	}
 
 	return &RTPTransceiver{


### PR DESCRIPTION
…y fixes codestyle in api.go file;

#### Description
I've updated all relevant jsfiddles in the example directory.

Tiny fixes codestyle in api.go. Move default initialize before executing option callbacks.

refs #2092 ticket;
