### PR TITLE
Ignore explicit SSRCes in RID Simulcast processing

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1450,6 +1450,18 @@ func (pc *PeerConnection) handleIncomingSSRC(rtpStream io.Reader, ssrc SSRC) err
 		return errPeerConnRemoteDescriptionNil
 	}
 
+	// If a SSRC already exists in the RemoteDescription don't perform heuristics upon it
+	for _, track := range trackDetailsFromSDP(pc.log, remoteDescription.parsed) {
+		if track.repairSsrc != nil && ssrc == *track.repairSsrc {
+			return nil
+		}
+		for _, trackSsrc := range track.ssrcs {
+			if ssrc == trackSsrc {
+				return nil
+			}
+		}
+	}
+
 	// If the remote SDP was only one media section the ssrc doesn't have to be explicitly declared
 	if handled, err := pc.handleUndeclaredSSRC(ssrc, remoteDescription); handled || err != nil {
 		return err

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1538,12 +1538,6 @@ func (pc *PeerConnection) handleIncomingSSRC(rtpStream io.Reader, ssrc SSRC) err
 		}
 	}
 
-	if readStream != nil {
-		_ = readStream.Close()
-	}
-	if rtcpReadStream != nil {
-		_ = rtcpReadStream.Close()
-	}
 	pc.api.interceptor.UnbindRemoteStream(streamInfo)
 	return errPeerConnSimulcastIncomingSSRCFailed
 }

--- a/sdp.go
+++ b/sdp.go
@@ -25,7 +25,7 @@ type trackDetails struct {
 	streamID   string
 	id         string
 	ssrcs      []SSRC
-	repairSsrc SSRC
+	repairSsrc *SSRC
 	rids       []string
 }
 
@@ -168,9 +168,10 @@ func trackDetailsFromSDP(log logging.LeveledLogger, s *sdp.SessionDescription) (
 				trackDetails.id = trackID
 				trackDetails.ssrcs = []SSRC{SSRC(ssrc)}
 
-				for repairSsrc, baseSsrc := range rtxRepairFlows {
+				for r, baseSsrc := range rtxRepairFlows {
 					if baseSsrc == ssrc {
-						trackDetails.repairSsrc = SSRC(repairSsrc)
+						repairSsrc := SSRC(r)
+						trackDetails.repairSsrc = &repairSsrc
 					}
 				}
 
@@ -216,7 +217,9 @@ func trackDetailsToRTPReceiveParameters(t *trackDetails) RTPReceiveParameters {
 			encodings[i].SSRC = t.ssrcs[i]
 		}
 
-		encodings[i].RTX.SSRC = t.repairSsrc
+		if t.repairSsrc != nil {
+			encodings[i].RTX.SSRC = *t.repairSsrc
+		}
 	}
 
 	return RTPReceiveParameters{Encodings: encodings}


### PR DESCRIPTION
If the SRTP Stream hasn't been opened yet we would attempt to process
(and fail) RTP traffic. This change causes us to not even attempt to
read.

No behavior change from this, but will cause less useless logging.
