### PR TITLE
Use ICE role to set DTLS role in answer

### DIFF
--- a/sdp.go
+++ b/sdp.go
@@ -732,3 +732,13 @@ func updateSDPOrigin(origin *sdp.Origin, d *sdp.SessionDescription) {
 		d.Origin.SessionVersion = atomic.AddUint64(&origin.SessionVersion, 1)
 	}
 }
+
+func isIceLiteSet(desc *sdp.SessionDescription) bool {
+	for _, a := range desc.Attributes {
+		if strings.TrimSpace(a.Key) == sdp.AttrKeyICELite {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
When creating answer, check ICE role while determining DTLS role.
ORTC thread on how roles are set
https://github.com/w3c/ortc/issues/167#issuecomment-69409953

When remote is ice-lite and there is no answering role set,
the answer uses the default which is DTLS client. So 'setup'
is set as 'active' and answer sent.

But, when DTLS transport is started, it checks the ICE role
and sets itself as DTLS server (because remote is lite
and hence local agent becomes controlling ICE agent).

So, both sides end up being DTLS server adnd nobody sends
client hello.
