### PR TITLE
fix: Allow ICETransportStateNew in ensureICEConn

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -32,6 +32,7 @@ Bo Shi <boshi@mural.co>
 boks1971 <raja.gobi@tutanota.com>
 Brendan Rius <brendan.rius@gmail.com>
 brian <brian@cyalive.com>
+Bryan Phelps <bryan@coder.com>
 Cameron Elliott <cameron-elliott@users.noreply.github.com>
 Cecylia Bocovich <cohosh@torproject.org>
 Cedric Fung <cedric@vec.io>

--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -446,7 +446,7 @@ func (t *DTLSTransport) validateFingerPrint(remoteCert *x509.Certificate) error 
 }
 
 func (t *DTLSTransport) ensureICEConn() error {
-	if t.iceTransport == nil || t.iceTransport.State() == ICETransportStateNew {
+	if t.iceTransport == nil {
 		return errICEConnectionNotStarted
 	}
 


### PR DESCRIPTION
#### Description

In #2113 , we were seeing intermittent DTLS connectivity issues. Based on discussion with @Sean-Der and @kylecarbs in the thread, we suspected this condition in `dtlstransport` 
https://github.com/pion/webrtc/blob/8796a5c5a7359e12f0164823631d6e25579a4260/dtlstransport.go#L284-L286

It makes sense that we should be able to start a new DTLSTransport over an existing ICETransport, so this PR revises th e condition in `ensureICEConn` to allow `ICETransportStateNew`.

#### Reference issue
We're still testing - but potentially fixes #2113