### PR TITLE
Support for send-side simulcast

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -142,6 +142,9 @@ var (
 	// ErrRTPSenderNewTrackHasIncorrectKind indicates that the new track is of a different kind than the previous/original
 	ErrRTPSenderNewTrackHasIncorrectKind = errors.New("new track must be of the same kind as previous")
 
+	// ErrRTPSenderNewTrackHasIncorrectEnvelope indicates that the new track has a different envelope than the previous/original
+	ErrRTPSenderNewTrackHasIncorrectEnvelope = errors.New("new track must have the same envelope as previous")
+
 	// ErrUnbindFailed indicates that a TrackLocal was not able to be unbind
 	ErrUnbindFailed = errors.New("failed to unbind TrackLocal from PeerConnection")
 
@@ -202,10 +205,16 @@ var (
 	errRTPReceiverWithSSRCTrackStreamNotFound = errors.New("unable to find stream for Track with SSRC")
 	errRTPReceiverForRIDTrackStreamNotFound   = errors.New("no trackStreams found for RID")
 
-	errRTPSenderTrackNil          = errors.New("Track must not be nil")
-	errRTPSenderDTLSTransportNil  = errors.New("DTLSTransport must not be nil")
-	errRTPSenderSendAlreadyCalled = errors.New("Send has already been called")
-	errRTPSenderTrackRemoved      = errors.New("Sender Track has been removed or replaced to nil")
+	errRTPSenderTrackNil             = errors.New("Track must not be nil")
+	errRTPSenderDTLSTransportNil     = errors.New("DTLSTransport must not be nil")
+	errRTPSenderSendAlreadyCalled    = errors.New("Send has already been called")
+	errRTPSenderStopped              = errors.New("Sender has already been stopped")
+	errRTPSenderTrackRemoved         = errors.New("Sender Track has been removed or replaced to nil")
+	errRTPSenderRidNil               = errors.New("Sender cannot add encoding as rid is empty")
+	errRTPSenderNoBaseEncoding       = errors.New("Sender cannot add encoding as there is no base track")
+	errRTPSenderBaseEncodingMismatch = errors.New("Sender cannot add encoding as provided track does not match base track")
+	errRTPSenderRIDCollision         = errors.New("Sender cannot encoding due to RID collision")
+	errRTPSenderNoTrackForRID        = errors.New("Sender does not have track for RID")
 
 	errRTPTransceiverCannotChangeMid        = errors.New("errRTPSenderTrackNil")
 	errRTPTransceiverSetSendingInvalidState = errors.New("invalid state change in RTPTransceiver.setSending")

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -371,7 +371,7 @@ func TestPeerConnection_Transceiver_Mid(t *testing.T) {
 	// Must have 3 media descriptions (2 video channels)
 	assert.Equal(t, len(offer.parsed.MediaDescriptions), 2)
 
-	assert.True(t, sdpMidHasSsrc(offer, "0", sender1.ssrc), "Expected mid %q with ssrc %d, offer.SDP: %s", "0", sender1.ssrc, offer.SDP)
+	assert.True(t, sdpMidHasSsrc(offer, "0", sender1.trackEncodings[0].ssrc), "Expected mid %q with ssrc %d, offer.SDP: %s", "0", sender1.trackEncodings[0].ssrc, offer.SDP)
 
 	// Remove first track, must keep same number of media
 	// descriptions and same track ssrc for mid 1 as previous
@@ -382,7 +382,7 @@ func TestPeerConnection_Transceiver_Mid(t *testing.T) {
 
 	assert.Equal(t, len(offer.parsed.MediaDescriptions), 2)
 
-	assert.True(t, sdpMidHasSsrc(offer, "1", sender2.ssrc), "Expected mid %q with ssrc %d, offer.SDP: %s", "1", sender2.ssrc, offer.SDP)
+	assert.True(t, sdpMidHasSsrc(offer, "1", sender2.trackEncodings[0].ssrc), "Expected mid %q with ssrc %d, offer.SDP: %s", "1", sender2.trackEncodings[0].ssrc, offer.SDP)
 
 	_, err = pcAnswer.CreateAnswer(nil)
 	assert.Equal(t, err, &rtcerr.InvalidStateError{Err: ErrIncorrectSignalingState})
@@ -402,8 +402,8 @@ func TestPeerConnection_Transceiver_Mid(t *testing.T) {
 	// We reuse the existing non-sending transceiver
 	assert.Equal(t, len(offer.parsed.MediaDescriptions), 2)
 
-	assert.True(t, sdpMidHasSsrc(offer, "0", sender3.ssrc), "Expected mid %q with ssrc %d, offer.sdp: %s", "0", sender3.ssrc, offer.SDP)
-	assert.True(t, sdpMidHasSsrc(offer, "1", sender2.ssrc), "Expected mid %q with ssrc %d, offer.sdp: %s", "1", sender2.ssrc, offer.SDP)
+	assert.True(t, sdpMidHasSsrc(offer, "0", sender3.trackEncodings[0].ssrc), "Expected mid %q with ssrc %d, offer.sdp: %s", "0", sender3.trackEncodings[0].ssrc, offer.SDP)
+	assert.True(t, sdpMidHasSsrc(offer, "1", sender2.trackEncodings[0].ssrc), "Expected mid %q with ssrc %d, offer.sdp: %s", "1", sender2.trackEncodings[0].ssrc, offer.SDP)
 
 	closePairNow(t, pcOffer, pcAnswer)
 }

--- a/rtpsender_test.go
+++ b/rtpsender_test.go
@@ -117,7 +117,7 @@ func Test_RTPSender_GetParameters(t *testing.T) {
 	parameters := rtpTransceiver.Sender().GetParameters()
 	assert.NotEqual(t, 0, len(parameters.Codecs))
 	assert.Equal(t, 1, len(parameters.Encodings))
-	assert.Equal(t, rtpTransceiver.Sender().ssrc, parameters.Encodings[0].SSRC)
+	assert.Equal(t, rtpTransceiver.Sender().trackEncodings[0].ssrc, parameters.Encodings[0].SSRC)
 	assert.Equal(t, "", parameters.Encodings[0].RID)
 
 	closePairNow(t, offerer, answerer)
@@ -337,6 +337,67 @@ func Test_RTPSender_Send_Track_Removed(t *testing.T) {
 	parameter := rtpSender.GetParameters()
 	assert.NoError(t, peerConnection.RemoveTrack(rtpSender))
 	assert.Equal(t, errRTPSenderTrackRemoved, rtpSender.Send(parameter))
+
+	assert.NoError(t, peerConnection.Close())
+}
+
+func Test_RTPSender_Add_Encoding(t *testing.T) {
+	track, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+	assert.NoError(t, err)
+
+	peerConnection, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	rtpSender, err := peerConnection.AddTrack(track)
+	assert.NoError(t, err)
+
+	assert.Equal(t, errRTPSenderTrackNil, rtpSender.AddEncoding(nil))
+
+	track1, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+	assert.NoError(t, err)
+	assert.Equal(t, errRTPSenderRidNil, rtpSender.AddEncoding(track1))
+
+	track1, err = NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion", WithRTPStreamID("h"))
+	assert.NoError(t, err)
+	assert.Equal(t, errRTPSenderNoBaseEncoding, rtpSender.AddEncoding(track1))
+
+	track, err = NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion", WithRTPStreamID("q"))
+	assert.NoError(t, err)
+
+	rtpSender, err = peerConnection.AddTrack(track)
+	assert.NoError(t, err)
+
+	track1, err = NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video1", "pion", WithRTPStreamID("h"))
+	assert.NoError(t, err)
+	assert.Equal(t, errRTPSenderBaseEncodingMismatch, rtpSender.AddEncoding(track1))
+
+	track1, err = NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion1", WithRTPStreamID("h"))
+	assert.NoError(t, err)
+	assert.Equal(t, errRTPSenderBaseEncodingMismatch, rtpSender.AddEncoding(track1))
+
+	track1, err = NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeOpus}, "video", "pion", WithRTPStreamID("h"))
+	assert.NoError(t, err)
+	assert.Equal(t, errRTPSenderBaseEncodingMismatch, rtpSender.AddEncoding(track1))
+
+	track1, err = NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion", WithRTPStreamID("q"))
+	assert.NoError(t, err)
+	assert.Equal(t, errRTPSenderRIDCollision, rtpSender.AddEncoding(track1))
+
+	track1, err = NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion", WithRTPStreamID("h"))
+	assert.NoError(t, err)
+	assert.NoError(t, rtpSender.AddEncoding(track1))
+
+	err = rtpSender.Send(rtpSender.GetParameters())
+	assert.NoError(t, err)
+
+	track1, err = NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion", WithRTPStreamID("f"))
+	assert.NoError(t, err)
+	assert.Equal(t, errRTPSenderSendAlreadyCalled, rtpSender.AddEncoding(track1))
+
+	err = rtpSender.Stop()
+	assert.NoError(t, err)
+
+	assert.Equal(t, errRTPSenderStopped, rtpSender.AddEncoding(track1))
 
 	assert.NoError(t, peerConnection.Close())
 }

--- a/srtp_writer_future.go
+++ b/srtp_writer_future.go
@@ -16,6 +16,7 @@ import (
 // srtpWriterFuture blocks Read/Write calls until
 // the SRTP Session is available
 type srtpWriterFuture struct {
+	ssrc           SSRC
 	rtpSender      *RTPSender
 	rtcpReadStream atomic.Value // *srtp.ReadStreamSRTCP
 	rtpWriteStream atomic.Value // *srtp.WriteStreamSRTP
@@ -52,7 +53,7 @@ func (s *srtpWriterFuture) init(returnWhenNoSRTP bool) error {
 		return err
 	}
 
-	rtcpReadStream, err := srtcpSession.OpenReadStream(uint32(s.rtpSender.ssrc))
+	rtcpReadStream, err := srtcpSession.OpenReadStream(uint32(s.ssrc))
 	if err != nil {
 		return err
 	}

--- a/track_local.go
+++ b/track_local.go
@@ -1,6 +1,9 @@
 package webrtc
 
-import "github.com/pion/rtp"
+import (
+	"github.com/pion/interceptor"
+	"github.com/pion/rtp"
+)
 
 // TrackLocalWriter is the Writer for outbound RTP Packets
 type TrackLocalWriter interface {
@@ -14,10 +17,11 @@ type TrackLocalWriter interface {
 // TrackLocalContext is the Context passed when a TrackLocal has been Binded/Unbinded from a PeerConnection, and used
 // in Interceptors.
 type TrackLocalContext struct {
-	id          string
-	params      RTPParameters
-	ssrc        SSRC
-	writeStream TrackLocalWriter
+	id              string
+	params          RTPParameters
+	ssrc            SSRC
+	writeStream     TrackLocalWriter
+	rtcpInterceptor interceptor.RTCPReader
 }
 
 // CodecParameters returns the negotiated RTPCodecParameters. These are the codecs supported by both
@@ -47,6 +51,11 @@ func (t *TrackLocalContext) WriteStream() TrackLocalWriter {
 // ID is a unique identifier that is used for both Bind/Unbind
 func (t *TrackLocalContext) ID() string {
 	return t.id
+}
+
+// RTCPReader returns the RTCP interceptor for this TrackLocal. Used to read RTCP of this TrackLocal.
+func (t *TrackLocalContext) RTCPReader() interceptor.RTCPReader {
+	return t.rtcpInterceptor
 }
 
 // TrackLocal is an interface that controls how the user can send media


### PR DESCRIPTION
@Sean-Der @davidzhao Not a real PR, but setting up one to get feedback on the direction. There are more bits to do here to make this simulcast capable, but wanted to make sure that the general approach is okay before I go further.

This makes sure that the API is not affected.

I was then planning to take encodings supplied in `RTPTransceiverInit` and apply it on the sender. Something like `setParamaters` on `RTPSender`. `setParameters` is much more strict. For v1 of this, I was thinking of not being that strict and apply the encodings. Then use that in `sdp.go` to generate the `simulcast:send` SDP. That will have both SSRC and RID, but I think that is fine.

And then I will have to figure out the `Read` and friends for the simulcast aware sender.