### PR TITLE
Make TrackLocalContext an interface

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -60,6 +60,7 @@ Dean Sheather <dean@coder.com>
 decanus <7621705+decanus@users.noreply.github.com>
 Denis <Hixon10@yandex.ru>
 digitalix <digitalix4@gmail.com>
+do-hyung-kim <do_hyung.kim@navercorp.com>
 donotanswer <viktor.ferter@doclerholding.com>
 earle <aguilar@dm.ai>
 Egon Elbre <egonelbre@gmail.com>
@@ -137,6 +138,7 @@ mr-shitij <21.shitijagrawal@gmail.com>
 mxmCherry <mxmCherry@gmail.com>
 Nam V. Do <vannam12a7@gmail.com>
 Nick Mykins <nmykins@digitalocean.com>
+Nicolas Menard <nicolas.p.menard@gmail.com>
 nindolabs <6729798+nindolabs@users.noreply.github.com>
 Norman Rasmussen <norman@rasmussen.co.za>
 notedit <notedit@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -102,6 +102,7 @@ juberti <juberti@alphaexplorationco.com>
 Juliusz Chroboczek <jch@irif.fr>
 Justin Okamoto <jdokamoto@gmail.com>
 Justin Okamoto <justmoto@amazon.com>
+Kevin <kevmo314@gmail.com>
 Kevin Staunton-Lambert <kevin.staunton-lambert@metacdn.com>
 Kevin Wang <kevmo314@gmail.com>
 Konstantin Chugalinskiy <kchugalinskiy@yandex.ru>

--- a/track_local.go
+++ b/track_local.go
@@ -19,7 +19,31 @@ type TrackLocalWriter interface {
 
 // TrackLocalContext is the Context passed when a TrackLocal has been Binded/Unbinded from a PeerConnection, and used
 // in Interceptors.
-type TrackLocalContext struct {
+type TrackLocalContext interface {
+	// CodecParameters returns the negotiated RTPCodecParameters. These are the codecs supported by both
+	// PeerConnections and the SSRC/PayloadTypes
+	CodecParameters() []RTPCodecParameters
+
+	// HeaderExtensions returns the negotiated RTPHeaderExtensionParameters. These are the header extensions supported by
+	// both PeerConnections and the SSRC/PayloadTypes
+	HeaderExtensions() []RTPHeaderExtensionParameter
+
+	// SSRC requires the negotiated SSRC of this track
+	// This track may have multiple if RTX is enabled
+	SSRC() SSRC
+
+	// WriteStream returns the WriteStream for this TrackLocal. The implementer writes the outbound
+	// media packets to it
+	WriteStream() TrackLocalWriter
+
+	// ID is a unique identifier that is used for both Bind/Unbind
+	ID() string
+
+	// RTCPReader returns the RTCP interceptor for this TrackLocal. Used to read RTCP of this TrackLocal.
+	RTCPReader() interceptor.RTCPReader
+}
+
+type baseTrackLocalContext struct {
 	id              string
 	params          RTPParameters
 	ssrc            SSRC
@@ -29,35 +53,35 @@ type TrackLocalContext struct {
 
 // CodecParameters returns the negotiated RTPCodecParameters. These are the codecs supported by both
 // PeerConnections and the SSRC/PayloadTypes
-func (t *TrackLocalContext) CodecParameters() []RTPCodecParameters {
+func (t *baseTrackLocalContext) CodecParameters() []RTPCodecParameters {
 	return t.params.Codecs
 }
 
 // HeaderExtensions returns the negotiated RTPHeaderExtensionParameters. These are the header extensions supported by
 // both PeerConnections and the SSRC/PayloadTypes
-func (t *TrackLocalContext) HeaderExtensions() []RTPHeaderExtensionParameter {
+func (t *baseTrackLocalContext) HeaderExtensions() []RTPHeaderExtensionParameter {
 	return t.params.HeaderExtensions
 }
 
 // SSRC requires the negotiated SSRC of this track
 // This track may have multiple if RTX is enabled
-func (t *TrackLocalContext) SSRC() SSRC {
+func (t *baseTrackLocalContext) SSRC() SSRC {
 	return t.ssrc
 }
 
 // WriteStream returns the WriteStream for this TrackLocal. The implementer writes the outbound
 // media packets to it
-func (t *TrackLocalContext) WriteStream() TrackLocalWriter {
+func (t *baseTrackLocalContext) WriteStream() TrackLocalWriter {
 	return t.writeStream
 }
 
 // ID is a unique identifier that is used for both Bind/Unbind
-func (t *TrackLocalContext) ID() string {
+func (t *baseTrackLocalContext) ID() string {
 	return t.id
 }
 
 // RTCPReader returns the RTCP interceptor for this TrackLocal. Used to read RTCP of this TrackLocal.
-func (t *TrackLocalContext) RTCPReader() interceptor.RTCPReader {
+func (t *baseTrackLocalContext) RTCPReader() interceptor.RTCPReader {
 	return t.rtcpInterceptor
 }
 


### PR DESCRIPTION
This allows external users to provide their own TrackLocalContext to be
bound to a track.