### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/browser-e2e.yaml
+++ b/.github/workflows/browser-e2e.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
     name: Test

--- a/.github/workflows/generate-authors.yml
+++ b/.github/workflows/generate-authors.yml
@@ -14,8 +14,13 @@ name: generate-authors
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   checksecret:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     outputs:
       is_PIONBOT_PRIVATE_KEY_set: ${{ steps.checksecret_job.outputs.is_PIONBOT_PRIVATE_KEY_set }}
@@ -28,6 +33,8 @@ jobs:
           echo "::set-output name=is_PIONBOT_PRIVATE_KEY_set::${{ env.PIONBOT_PRIVATE_KEY != '' }}"
 
   generate-authors:
+    permissions:
+      contents: write  # for Git to git push
     needs: [checksecret]
     if: needs.checksecret.outputs.is_PIONBOT_PRIVATE_KEY_set == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,6 +16,9 @@ on:
       - opened
       - edited
       - synchronize
+permissions:
+  contents: read
+
 jobs:
   lint-commit-message:
     name: Metadata
@@ -37,6 +40,9 @@ jobs:
           run: .github/lint-disallowed-functions-in-library.sh
 
   lint-go:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: Go
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/standardjs.yaml
+++ b/.github/workflows/standardjs.yaml
@@ -5,6 +5,9 @@ on:
       - opened
       - edited
       - synchronize
+permissions:
+  contents: read
+
 jobs:
   StandardJS:
     runs-on: ubuntu-latest

--- a/.github/workflows/tidy-check.yaml
+++ b/.github/workflows/tidy-check.yaml
@@ -18,6 +18,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   Check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
