### PR TITLE
Max receive buffer size via SettingEngine

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -103,8 +103,9 @@ func (r *SCTPTransport) Start(remoteCaps SCTPCapabilities) error {
 	}
 
 	sctpAssociation, err := sctp.Client(sctp.Config{
-		NetConn:       dtlsTransport.conn,
-		LoggerFactory: r.api.settingEngine.LoggerFactory,
+		NetConn:              dtlsTransport.conn,
+		MaxReceiveBufferSize: r.api.settingEngine.sctp.maxReceiveBufferSize,
+		LoggerFactory:        r.api.settingEngine.LoggerFactory,
 	})
 	if err != nil {
 		return err

--- a/settingengine.go
+++ b/settingengine.go
@@ -54,6 +54,9 @@ type SettingEngine struct {
 	dtls struct {
 		retransmissionInterval time.Duration
 	}
+	sctp struct {
+		maxReceiveBufferSize uint32
+	}
 	sdpMediaLevelFingerprints                 bool
 	answeringDTLSRole                         DTLSRole
 	disableCertificateFingerprintVerification bool
@@ -303,4 +306,10 @@ func (e *SettingEngine) SetReceiveMTU(receiveMTU uint) {
 // SetDTLSRetransmissionInterval sets the retranmission interval for DTLS.
 func (e *SettingEngine) SetDTLSRetransmissionInterval(interval time.Duration) {
 	e.dtls.retransmissionInterval = interval
+}
+
+// SetSCTPMaxReceiveBufferSize sets the maximum receive buffer size.
+// Leave this 0 for the default maxReceiveBufferSize.
+func (e *SettingEngine) SetSCTPMaxReceiveBufferSize(maxReceiveBufferSize uint32) {
+	e.sctp.maxReceiveBufferSize = maxReceiveBufferSize
 }

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -233,3 +233,12 @@ func TestSetDTLSRetransmissionInterval(t *testing.T) {
 		t.Errorf("Failed to set DTLS retransmission interval")
 	}
 }
+
+func TestSetSCTPMaxReceiverBufferSize(t *testing.T) {
+	s := SettingEngine{}
+	assert.Equal(t, uint32(0), s.sctp.maxReceiveBufferSize)
+
+	expSize := uint32(4 * 1024 * 1024)
+	s.SetSCTPMaxReceiveBufferSize(expSize)
+	assert.Equal(t, expSize, s.sctp.maxReceiveBufferSize)
+}


### PR DESCRIPTION
Relates to pion/sctp#218

#### Description
Current pion/sctp's receive buffer size is hardcoded as 1 MiB. This change makes the value configurable from the SettingEngine.

#### Reference issue
See pion/sctp#218 for more details about the context of this pull-request.