### PR TITLE
Resolve issue with rejecting tracks from Firefox

### DIFF
--- a/sdp.go
+++ b/sdp.go
@@ -424,12 +424,23 @@ func addTransceiverSDP(
 		}
 
 		// Explicitly reject track if we don't have the codec
+		// We need to include connection information even if we're rejecting a track, otherwise Firefox will fail to
+		// parse the SDP with an error like:
+		// SIPCC Failed to parse SDP: SDP Parse Error on line 50:  c= connection line not specified for every media level, validation failed.
+		// In addition this makes our SDP compliant with RFC 4566 Section 5.7: https://datatracker.ietf.org/doc/html/rfc4566#section-5.7
 		d.WithMedia(&sdp.MediaDescription{
 			MediaName: sdp.MediaName{
 				Media:   t.kind.String(),
 				Port:    sdp.RangedPort{Value: 0},
 				Protos:  []string{"UDP", "TLS", "RTP", "SAVPF"},
 				Formats: []string{"0"},
+			},
+			ConnectionInformation: &sdp.ConnectionInformation{
+				NetworkType: "IN",
+				AddressType: "IP4",
+				Address: &sdp.Address{
+					Address: "0.0.0.0",
+				},
 			},
 		})
 		return false, nil


### PR DESCRIPTION
When running the reflect example against Firefox 99.0.1 I was receiving
errors around parsing the SDP from Pion.

The error was:

  SIPCC Failed to parse SDP: SDP Parse Error on line 50:  c= connection
  line not specified for every media level, validation failed.

According to the RFC [4566 5.7](https://datatracker.ietf.org/doc/html/rfc4566#section-5.7)

  A session description MUST contain either at least one "c=" field in
  each media description or a single "c=" field at the session level.
  It MAY contain a single session-level "c=" field and additional "c="
  field(s) per media description, in which case the per-media values
  override the session-level settings for the respective media.

I don't see any errors in the Pion repos for this. Interestingly the
webrtc-rs project that is porting Pion to rust has [an issue](https://github.com/webrtc-rs/webrtc/issues/144) where they're encountering this same error.
