### PR TITLE
Add json serialization support to ICECredentialType

### DIFF
--- a/configuration_test.go
+++ b/configuration_test.go
@@ -41,7 +41,7 @@ func TestConfiguration_getICEServers(t *testing.T) {
 
 func TestConfigurationJSON(t *testing.T) {
 	j := `{
-    "iceServers": [{"URLs": ["turn:turn.example.org"],
+    "iceServers": [{"urls": ["turn:turn.example.org"],
                     "username": "jch",
                     "credential": "topsecret"
                   }],

--- a/errors.go
+++ b/errors.go
@@ -233,6 +233,9 @@ var (
 
 	errStatsICECandidateStateInvalid = errors.New("cannot convert to StatsICECandidatePairStateSucceeded invalid ice candidate state")
 
+	errInvalidICECredentialTypeString = errors.New("invalid ICECredentialType")
+	errInvalidICEServer               = errors.New("invalid ICEServer")
+
 	errICETransportNotInNew = errors.New("ICETransport can only be called in ICETransportStateNew")
 
 	errCertificatePEMFormatError = errors.New("bad Certificate PEM format")

--- a/icecredentialtype.go
+++ b/icecredentialtype.go
@@ -1,5 +1,10 @@
 package webrtc
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // ICECredentialType indicates the type of credentials used to connect to
 // an ICE server.
 type ICECredentialType int
@@ -7,7 +12,7 @@ type ICECredentialType int
 const (
 	// ICECredentialTypePassword describes username and password based
 	// credentials as described in https://tools.ietf.org/html/rfc5389.
-	ICECredentialTypePassword ICECredentialType = iota
+	ICECredentialTypePassword ICECredentialType = iota + 1
 
 	// ICECredentialTypeOauth describes token based credential as described
 	// in https://tools.ietf.org/html/rfc7635.
@@ -33,6 +38,8 @@ func newICECredentialType(raw string) ICECredentialType {
 
 func (t ICECredentialType) String() string {
 	switch t {
+	case Unknown:
+		return ""
 	case ICECredentialTypePassword:
 		return iceCredentialTypePasswordStr
 	case ICECredentialTypeOauth:
@@ -40,4 +47,27 @@ func (t ICECredentialType) String() string {
 	default:
 		return ErrUnknownType.Error()
 	}
+}
+
+// UnmarshalJSON parses the JSON-encoded data and stores the result
+func (t *ICECredentialType) UnmarshalJSON(b []byte) error {
+	var val string
+	var tmp ICECredentialType
+	if err := json.Unmarshal(b, &val); err != nil {
+		return err
+	}
+
+	tmp = newICECredentialType(val)
+
+	if (tmp == ICECredentialType(Unknown)) && (val != "") {
+		return fmt.Errorf("%w: (%s)", errInvalidICECredentialTypeString, val)
+	}
+
+	*t = tmp
+	return nil
+}
+
+// MarshalJSON returns the JSON encoding
+func (t ICECredentialType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }

--- a/icecredentialtype_test.go
+++ b/icecredentialtype_test.go
@@ -1,6 +1,7 @@
 package webrtc
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,5 +40,61 @@ func TestICECredentialType_String(t *testing.T) {
 			testCase.credentialType.String(),
 			"testCase: %d %v", i, testCase,
 		)
+	}
+}
+
+func TestICECredentialType_new(t *testing.T) {
+	testCases := []struct {
+		credentialType ICECredentialType
+		expectedString string
+	}{
+		{ICECredentialTypePassword, "password"},
+		{ICECredentialTypeOauth, "oauth"},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			newICECredentialType(testCase.expectedString),
+			testCase.credentialType,
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}
+
+func TestICECredentialType_Json(t *testing.T) {
+	testCases := []struct {
+		credentialType     ICECredentialType
+		jsonRepresentation []byte
+	}{
+		{ICECredentialTypePassword, []byte("\"password\"")},
+		{ICECredentialTypeOauth, []byte("\"oauth\"")},
+	}
+
+	for i, testCase := range testCases {
+		m, err := json.Marshal(testCase.credentialType)
+		assert.NoError(t, err)
+		assert.Equal(t,
+			testCase.jsonRepresentation,
+			m,
+			"Marshal testCase: %d %v", i, testCase,
+		)
+		var ct ICECredentialType
+		err = json.Unmarshal(testCase.jsonRepresentation, &ct)
+		assert.NoError(t, err)
+		assert.Equal(t,
+			testCase.credentialType,
+			ct,
+			"Unmarshal testCase: %d %v", i, testCase,
+		)
+	}
+
+	{
+		ct := ICECredentialType(1000)
+		err := json.Unmarshal([]byte("\"invalid\""), &ct)
+		assert.Error(t, err)
+		assert.Equal(t, ct, ICECredentialType(1000))
+		err = json.Unmarshal([]byte("\"invalid"), &ct)
+		assert.Error(t, err)
+		assert.Equal(t, ct, ICECredentialType(1000))
 	}
 }

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -566,13 +566,33 @@ func iceServersToValue(iceServers []ICEServer) js.Value {
 	return js.ValueOf(maps)
 }
 
+func oauthCredentialToValue(o OAuthCredential) js.Value {
+	out := map[string]interface{}{
+		"MACKey":      o.MACKey,
+		"AccessToken": o.AccessToken,
+	}
+	return js.ValueOf(out)
+}
+
 func iceServerToValue(server ICEServer) js.Value {
-	return js.ValueOf(map[string]interface{}{
-		"urls":           stringsToValue(server.URLs), // required
-		"username":       stringToValueOrUndefined(server.Username),
-		"credential":     interfaceToValueOrUndefined(server.Credential),
-		"credentialType": stringEnumToValueOrUndefined(server.CredentialType.String()),
-	})
+	out := map[string]interface{}{
+		"urls": stringsToValue(server.URLs), // required
+	}
+	if server.Username != "" {
+		out["username"] = stringToValueOrUndefined(server.Username)
+	}
+	if server.Credential != nil {
+		switch t := server.Credential.(type) {
+		case string:
+			out["credential"] = stringToValueOrUndefined(t)
+		case OAuthCredential:
+			out["credential"] = oauthCredentialToValue(t)
+		}
+	}
+	if server.CredentialType != ICECredentialType(Unknown) {
+		out["credentialType"] = stringEnumToValueOrUndefined(server.CredentialType.String())
+	}
+	return js.ValueOf(out)
 }
 
 func valueToConfiguration(configValue js.Value) Configuration {
@@ -603,14 +623,36 @@ func valueToICEServers(iceServersValue js.Value) []ICEServer {
 	return iceServers
 }
 
+func valueToICECredential(iceCredentialValue js.Value) interface{} {
+	if iceCredentialValue.IsNull() || iceCredentialValue.IsUndefined() {
+		return nil
+	}
+	if iceCredentialValue.Type() == js.TypeString {
+		return iceCredentialValue.String()
+	}
+	if iceCredentialValue.Type() == js.TypeObject {
+		return OAuthCredential{
+			MACKey:      iceCredentialValue.Get("MACKey").String(),
+			AccessToken: iceCredentialValue.Get("AccessToken").String(),
+		}
+	}
+	return nil
+}
+
 func valueToICEServer(iceServerValue js.Value) ICEServer {
-	return ICEServer{
+	s := ICEServer{
 		URLs:     valueToStrings(iceServerValue.Get("urls")), // required
 		Username: valueToStringOrZero(iceServerValue.Get("username")),
 		// Note: Credential and CredentialType are not currently supported.
-		// Credential: iceServerValue.Get("credential"),
-		// CredentialType: newICECredentialType(valueToStringOrZero(iceServerValue.Get("credentialType"))),
+		Credential:     valueToICECredential(iceServerValue.Get("credential")),
+		CredentialType: newICECredentialType(valueToStringOrZero(iceServerValue.Get("credentialType"))),
 	}
+
+	// default to password
+	if s.CredentialType == ICECredentialType(Unknown) {
+		s.CredentialType = ICECredentialTypePassword
+	}
+	return s
 }
 
 func valueToICECandidate(val js.Value) *ICECandidate {

--- a/peerconnection_js_test.go
+++ b/peerconnection_js_test.go
@@ -69,3 +69,35 @@ func TestValueToICECandidate(t *testing.T) {
 		assert.Equal(t, testCase.expect, val)
 	}
 }
+
+func TestValueToICEServer(t *testing.T) {
+	testCases := []ICEServer{
+		{
+			URLs:           []string{"turn:192.158.29.39?transport=udp"},
+			Username:       "unittest",
+			Credential:     "placeholder",
+			CredentialType: ICECredentialTypePassword,
+		},
+		{
+			URLs:           []string{"turn:[2001:db8:1234:5678::1]?transport=udp"},
+			Username:       "unittest",
+			Credential:     "placeholder",
+			CredentialType: ICECredentialTypePassword,
+		},
+		{
+			URLs:     []string{"turn:192.158.29.39?transport=udp"},
+			Username: "unittest",
+			Credential: OAuthCredential{
+				MACKey:      "WmtzanB3ZW9peFhtdm42NzUzNG0=",
+				AccessToken: "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA==",
+			},
+			CredentialType: ICECredentialTypeOauth,
+		},
+	}
+
+	for _, testCase := range testCases {
+		v := iceServerToValue(testCase)
+		s := valueToICEServer(v)
+		assert.Equal(t, testCase, s)
+	}
+}


### PR DESCRIPTION
#### Description
When serializing to/from json, the ICECredentialType should serialize as as a string instead of an enumeration.
