### PR TITLE
Remove occurrences of Unknonwn ICECredentialType

### DIFF
--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -589,9 +589,7 @@ func iceServerToValue(server ICEServer) js.Value {
 			out["credential"] = oauthCredentialToValue(t)
 		}
 	}
-	if server.CredentialType != ICECredentialType(Unknown) {
-		out["credentialType"] = stringEnumToValueOrUndefined(server.CredentialType.String())
-	}
+	out["credentialType"] = stringEnumToValueOrUndefined(server.CredentialType.String())
 	return js.ValueOf(out)
 }
 
@@ -652,10 +650,6 @@ func valueToICEServer(iceServerValue js.Value) ICEServer {
 		CredentialType: tpe,
 	}
 
-	// default to password
-	if s.CredentialType == ICECredentialType(Unknown) {
-		s.CredentialType = ICECredentialTypePassword
-	}
 	return s
 }
 


### PR DESCRIPTION
In 3.1.37, we removed the possibility for ICECredentialType
to be Unknown.  Remove remaining tests for this case from
the WASM code.
