### PR TITLE
Fix incorrectly generated (i.e. conflicting or misassigned) extmap IDs when re-offering

### DIFF
--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -460,3 +460,61 @@ func TestUpdateHeaderExtenstionToClonedMediaEngine(t *testing.T) {
 	validate(&src)
 	validate(src.copy())
 }
+
+func TestExtensionIdCollision(t *testing.T) {
+	mustParse := func(raw string) sdp.SessionDescription {
+		s := sdp.SessionDescription{}
+		assert.NoError(t, s.Unmarshal([]byte(raw)))
+		return s
+	}
+	sdpSnippet := `v=0
+o=- 4596489990601351948 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
+a=rtpmap:111 opus/48000/2
+`
+
+	m := MediaEngine{}
+	assert.NoError(t, m.RegisterDefaultCodecs())
+
+	assert.NoError(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{sdp.SDESMidURI}, RTPCodecTypeVideo))
+	assert.NoError(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"urn:3gpp:video-orientation"}, RTPCodecTypeVideo))
+
+	assert.NoError(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{sdp.SDESMidURI}, RTPCodecTypeAudio))
+	assert.NoError(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{sdp.AudioLevelURI}, RTPCodecTypeAudio))
+
+	assert.NoError(t, m.updateFromRemoteDescription(mustParse(sdpSnippet)))
+
+	assert.True(t, m.negotiatedAudio)
+	assert.False(t, m.negotiatedVideo)
+
+	id, audioNegotiated, videoNegotiated := m.getHeaderExtensionID(RTPHeaderExtensionCapability{sdp.ABSSendTimeURI})
+	assert.Equal(t, id, 0)
+	assert.False(t, audioNegotiated)
+	assert.False(t, videoNegotiated)
+
+	id, audioNegotiated, videoNegotiated = m.getHeaderExtensionID(RTPHeaderExtensionCapability{sdp.SDESMidURI})
+	assert.Equal(t, id, 2)
+	assert.True(t, audioNegotiated)
+	assert.False(t, videoNegotiated)
+
+	id, audioNegotiated, videoNegotiated = m.getHeaderExtensionID(RTPHeaderExtensionCapability{sdp.AudioLevelURI})
+	assert.Equal(t, id, 1)
+	assert.True(t, audioNegotiated)
+	assert.False(t, videoNegotiated)
+
+	params := m.getRTPParametersByKind(RTPCodecTypeVideo, []RTPTransceiverDirection{RTPTransceiverDirectionSendonly})
+	extensions := params.HeaderExtensions
+
+	assert.Equal(t, 2, len(extensions))
+	assert.Equal(t, sdp.SDESMidURI, extensions[0].URI)
+	assert.Equal(t, 2, extensions[0].ID)
+	assert.Equal(t, "urn:3gpp:video-orientation", extensions[1].URI)
+	assert.NotEqual(t, 1, extensions[1].ID)
+	assert.NotEqual(t, 2, extensions[1].ID)
+	assert.NotEqual(t, 5, extensions[1].ID)
+}


### PR DESCRIPTION
#### Thanks

First big thanks to @k0nserv who originally reported this and put together an initial test showing the failure.

#### Background

This PR addresses an issue whereby under a specific (but not unusual) circumstance, pion fails in two different ways to generate the correct SDP extmap IDs for a track. Some browsers are more picky about this than others, but Firefox is known to be picky and this issue may be responsible for some reported incompatibilities.

Sequence to trigger the issue:

1. Pion side registers audio & video codecs and audio & video header extensions.
2. Pion side gets an audio-only offer from the remote, and responds with an answer.
3. At some later point in time, Pion side wants to add a video track and prepares a new offer.
4. Extmap IDs in the new offer SDP are usually incorrect (conflicting or misassigned).

#### Minimal example code

```
func main() {
  // Create a MediaEngine object to configure the supported codecs
  m := &webrtc.MediaEngine{}

  // Setup video codec
  m.RegisterCodec(webrtc.RTPCodecParameters{
    RTPCodecCapability: webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264, ClockRate: 90000, Channels: 0, SDPFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f", RTCPFeedback: nil},
    PayloadType:        96,
  }, webrtc.RTPCodecTypeVideo)

  // Setup audio codec
  m.RegisterCodec(webrtc.RTPCodecParameters{
    RTPCodecCapability: webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeOpus, ClockRate: 48000, Channels: 2, SDPFmtpLine: "minptime=10;useinbandfec=1", RTCPFeedback: nil},
    PayloadType:        111,
  }, webrtc.RTPCodecTypeAudio)

  m.RegisterHeaderExtension(webrtc.RTPHeaderExtensionCapability{URI: "urn:ietf:params:rtp-hdrext:sdes:mid"}, webrtc.RTPCodecTypeVideo)
  m.RegisterHeaderExtension(webrtc.RTPHeaderExtensionCapability{URI: "urn:3gpp:video-orientation"}, webrtc.RTPCodecTypeVideo)

  m.RegisterHeaderExtension(webrtc.RTPHeaderExtensionCapability{URI: "urn:ietf:params:rtp-hdrext:sdes:mid"}, webrtc.RTPCodecTypeAudio)
  m.RegisterHeaderExtension(webrtc.RTPHeaderExtensionCapability{URI: "urn:ietf:params:rtp-hdrext:ssrc-audio-level"}, webrtc.RTPCodecTypeAudio)

  // Create the API object with the MediaEngine
  api := webrtc.NewAPI(webrtc.WithMediaEngine(m))

  // Create a new RTCPeerConnection
  peerConnection, _ := api.NewPeerConnection(webrtc.Configuration{})
  peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeAudio, webrtc.RTPTransceiverInit{ Direction: webrtc.RTPTransceiverDirectionSendrecv })

  sdp_snippet := `v=0
o=- 4596489990601351948 2 IN IP4 127.0.0.1
s=-
t=0 0
m=audio 9 UDP/TLS/RTP/SAVPF 111
a=mid:0
a=ice-ufrag:LgQ1
a=ice-pwd:2jUslCr2ub4FRFMtR3jRAPG+
a=ice-options:trickle renomination
a=fingerprint:sha-256 12:C7:4A:71:4E:87:8E:54:FF:ED:FB:D8:E2:E3:BA:A4:D3:24:E0:BD:D3:AB:B4:6B:FE:83:0D:C3:CB:56:76:2B
a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=rtpmap:111 opus/48000/2
a=sendrecv
`

  // Remote side offers sdp_snippet
  peerConnection.SetRemoteDescription(webrtc.SessionDescription{ Type: webrtc.NewSDPType("offer"), SDP: sdp_snippet })

  // Pion side answers
  answer, _ := peerConnection.CreateAnswer(nil)
  peerConnection.SetLocalDescription(answer)

  // Pion side now wants to add a video track, so it makes an updated offer (which would get sent out-of-band in a real example)
  peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeVideo, webrtc.RTPTransceiverInit{ Direction: webrtc.RTPTransceiverDirectionSendrecv })
  offer, _ := peerConnection.CreateOffer(nil)

  peerConnection.SetLocalDescription(offer)

  // Oops! The video section in the new offer contains two incorrectly assigned extmap IDs.
  fmt.Println(peerConnection.LocalDescription().SDP)
}
```

Output (SDP offer created by pion):

```
...
m=audio 9 UDP/TLS/RTP/SAVPF 111
a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
...
m=video 9 UDP/TLS/RTP/SAVPF 96
a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:2 urn:3gpp:video-orientation
...
```

Unfortunately both of the video extmap assignments are illegal.

The `urn:ietf:params:rtp-hdrext:sdes:mid` is assigned ID 1, but must actually be ID 2 (see: https://www.rfc-editor.org/rfc/rfc8843.html#section-12). This is the *misassignment* failure mode.

The `urn:3gpp:video-orientation` is assigned ID 2, but this conflicts with `urn:ietf:params:rtp-hdrext:ssrc-audio-level` in the `m=audio` section, see: https://www.rfc-editor.org/rfc/rfc8285.html#page-14). This is the *conflict* failure mode.

#### What this PR does

This PR fixes the logic in `getRTPParametersByKind` to avoid these two failure modes. Also, a new test is added.