### PR TITLE
Fixed panic when ICEGatherer closed after calling Gather

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -49,6 +49,7 @@ cyannuk <cyannuk@issart.com>
 Daniele Sluijters <daenney@users.noreply.github.com>
 David Hamilton <davidhamiltron@gmail.com>
 David Zhao <david@davidzhao.com>
+David Zhao <dz@livekit.io>
 david.s <david.s@hpcnt.com>
 Dean Sheather <dean@coder.com>
 decanus <7621705+decanus@users.noreply.github.com>

--- a/icegatherer.go
+++ b/icegatherer.go
@@ -4,6 +4,7 @@
 package webrtc
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -143,6 +144,11 @@ func (g *ICEGatherer) Gather() error {
 	g.lock.Lock()
 	agent := g.agent
 	g.lock.Unlock()
+
+	// it is possible agent had just been closed
+	if agent == nil {
+		return fmt.Errorf("%w: unable to gather", errICEAgentNotExist)
+	}
 
 	g.setState(ICEGathererStateGathering)
 	if err := agent.OnCandidate(func(candidate ice.Candidate) {


### PR DESCRIPTION
#### Description

It's possible for ICEGatherer to be closed after Gather had just started. We've seen this panic during load testing.
