### PR TITLE
Revert "Generate unique extmap id for extensions"

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,6 +7,7 @@ a-wing <1@233.email>
 Aaron Boushley <boushley@pretzelaux.com>
 Aaron France <aaron.l.france@gmail.com>
 Adam Kiss <masterada@gmail.com>
+Adrian Cable <6544927+adriancable@users.noreply.github.com>
 Adrian Cable <adrian.cable@gmail.com>
 adwpc <adwpc@hotmail.com>
 aggresss <aggresss@163.com>

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -569,33 +569,31 @@ func (m *MediaEngine) getRTPParametersByKind(typ RTPCodecType, directions []RTPT
 			}
 		}
 	} else {
-		mediaHeaderExtensions := make(map[int]mediaEngineHeaderExtension)
 		for _, e := range m.headerExtensions {
-			usingNegotiatedID := false
-			for id := range m.negotiatedHeaderExtensions {
-				if m.negotiatedHeaderExtensions[id].uri == e.uri {
-					usingNegotiatedID = true
-					mediaHeaderExtensions[id] = e
-					break
-				}
-			}
-			if !usingNegotiatedID {
-				for id := 1; id < 15; id++ {
-					idAvailable := true
-					if _, ok := mediaHeaderExtensions[id]; ok {
-						idAvailable = false
-					}
-					if _, taken := m.negotiatedHeaderExtensions[id]; idAvailable && !taken {
-						mediaHeaderExtensions[id] = e
+			if haveRTPTransceiverDirectionIntersection(e.allowedDirections, directions) && (e.isAudio && typ == RTPCodecTypeAudio || e.isVideo && typ == RTPCodecTypeVideo) {
+				usingNegotiatedID := false
+				for id := range m.negotiatedHeaderExtensions {
+					if m.negotiatedHeaderExtensions[id].uri == e.uri {
+						usingNegotiatedID = true
+						headerExtensions = append(headerExtensions, RTPHeaderExtensionParameter{ID: id, URI: e.uri})
 						break
 					}
 				}
-			}
-		}
-
-		for id, e := range mediaHeaderExtensions {
-			if haveRTPTransceiverDirectionIntersection(e.allowedDirections, directions) && (e.isAudio && typ == RTPCodecTypeAudio || e.isVideo && typ == RTPCodecTypeVideo) {
-				headerExtensions = append(headerExtensions, RTPHeaderExtensionParameter{ID: id, URI: e.uri})
+				if !usingNegotiatedID {
+					for id := 1; id < 15; id++ {
+						idAvailable := true
+						for checkID := range headerExtensions {
+							if headerExtensions[checkID].ID == id {
+								idAvailable = false
+								break
+							}
+						}
+						if _, taken := m.negotiatedHeaderExtensions[id]; idAvailable && !taken {
+							headerExtensions = append(headerExtensions, RTPHeaderExtensionParameter{ID: id, URI: e.uri})
+							break
+						}
+					}
+				}
 			}
 		}
 	}

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -415,20 +415,6 @@ func TestMediaEngineHeaderExtensionDirection(t *testing.T) {
 		assert.ErrorIs(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirectionInactive), ErrRegisterHeaderExtensionInvalidDirection)
 		assert.ErrorIs(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio, RTPTransceiverDirection(0)), ErrRegisterHeaderExtensionInvalidDirection)
 	})
-
-	t.Run("Unique extmapid with different codec", func(t *testing.T) {
-		m := &MediaEngine{}
-		registerCodec(m)
-		assert.NoError(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test"}, RTPCodecTypeAudio))
-		assert.NoError(t, m.RegisterHeaderExtension(RTPHeaderExtensionCapability{"pion-header-test2"}, RTPCodecTypeVideo))
-
-		audio := m.getRTPParametersByKind(RTPCodecTypeAudio, []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly})
-		video := m.getRTPParametersByKind(RTPCodecTypeVideo, []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly})
-
-		assert.Equal(t, 1, len(audio.HeaderExtensions))
-		assert.Equal(t, 1, len(video.HeaderExtensions))
-		assert.NotEqual(t, audio.HeaderExtensions[0].ID, video.HeaderExtensions[0].ID)
-	})
 }
 
 // If a user attempts to register a codec twice we should just discard duplicate calls


### PR DESCRIPTION
Reverts pion/webrtc#2236

For some reason, the TestExtensionIdCollision test, which hasn't been changed, *occasionally* now fails. It looks like some kind of data race. Will need to dig into this further.

To repro, try: go test -run=ExtensionIdCollision -count=50