### PR TITLE
Turn error into a warning when SSRCs are included when they don't need to be

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1425,7 +1425,7 @@ func (pc *PeerConnection) handleUndeclaredSSRC(ssrc SSRC, remoteDescription *Ses
 				id = split[1]
 			}
 		case sdp.AttrKeySSRC:
-			return false, errPeerConnSingleMediaSectionHasExplicitSSRC
+			pc.log.Warnf("deprecated ssrc behavior %q", errPeerConnSingleMediaSectionHasExplicitSSRC)
 		case sdpAttributeRid:
 			return false, nil
 		}


### PR DESCRIPTION
#### Description

I ran into an issue when testing that exposed what I believe is a bug where pion can't consume simulcast streams that it creates.
When pion [populates the SDP](https://github.com/pion/webrtc/blob/master/sdp.go#L359-L365) with sender information it includes an SSRC attribute for each encoding. This conflicts with [`handleUndeclaredSSRC`](https://github.com/pion/webrtc/blob/master/peerconnection.go#L1427-L1428) behavior which returns an error if it encounters an `a=ssrc...` attribute in the media section.

The [comment](https://github.com/pion/webrtc/blob/4e853582ca30d90f2370750571a273a3413b187e/peerconnection.go#L1474) around this functionality implies that this is not prohibited, just discouraged it seems reasonable to log an error when encountering this rather than returning an error
>If the remote SDP was only one media section the ssrc doesn't have to be explicitly declared


#### Reference issue
Fixes #...
