### PR TITLE
Add currentDirection to RTPTransceiver

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -984,6 +984,7 @@ func (pc *PeerConnection) SetLocalDescription(desc SessionDescription) error {
 	weAnswer := desc.Type == SDPTypeAnswer
 	remoteDesc := pc.RemoteDescription()
 	if weAnswer && remoteDesc != nil {
+		_ = setRTPTransceiverCurrentDirection(&desc, currentTransceivers, false)
 		if err := pc.startRTPSenders(currentTransceivers); err != nil {
 			return err
 		}
@@ -1143,6 +1144,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 
 	if isRenegotation {
 		if weOffer {
+			_ = setRTPTransceiverCurrentDirection(&desc, currentTransceivers, true)
 			if err = pc.startRTPSenders(currentTransceivers); err != nil {
 				return err
 			}
@@ -1172,6 +1174,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 	// Start the networking in a new routine since it will block until
 	// the connection is actually established.
 	if weOffer {
+		_ = setRTPTransceiverCurrentDirection(&desc, currentTransceivers, true)
 		if err := pc.startRTPSenders(currentTransceivers); err != nil {
 			return err
 		}
@@ -1228,6 +1231,51 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 			pc.onTrack(track, receiver)
 		}(t)
 	}
+}
+
+func setRTPTransceiverCurrentDirection(answer *SessionDescription, currentTransceivers []*RTPTransceiver, weOffer bool) error {
+	currentTransceivers = append([]*RTPTransceiver{}, currentTransceivers...)
+	for _, media := range answer.parsed.MediaDescriptions {
+		midValue := getMidValue(media)
+		if midValue == "" {
+			return errPeerConnRemoteDescriptionWithoutMidValue
+		}
+
+		if media.MediaName.Media == mediaSectionApplication {
+			continue
+		}
+
+		var t *RTPTransceiver
+		t, currentTransceivers = findByMid(midValue, currentTransceivers)
+
+		if t == nil {
+			return fmt.Errorf("%w: %q", errPeerConnTranscieverMidNil, midValue)
+		}
+
+		direction := getPeerDirection(media)
+		if direction == RTPTransceiverDirection(Unknown) {
+			continue
+		}
+
+		// reverse direction if it was a remote answer
+		if weOffer {
+			switch direction {
+			case RTPTransceiverDirectionSendonly:
+				direction = RTPTransceiverDirectionRecvonly
+			case RTPTransceiverDirectionRecvonly:
+				// Pion will answer recvonly with a offer recvonly transceiver, so we should
+				// not change the direction to sendonly if we are the offerer, otherwise this
+				// tranceiver can't be reuse for AddTrack
+				if t.Direction() != RTPTransceiverDirectionRecvonly {
+					direction = RTPTransceiverDirectionSendonly
+				}
+			default:
+			}
+		}
+
+		t.setCurrentDirection(direction)
+	}
+	return nil
 }
 
 func runIfNewReceiver(
@@ -1706,7 +1754,13 @@ func (pc *PeerConnection) AddTrack(track TrackLocal) (*RTPSender, error) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	for _, t := range pc.rtpTransceivers {
-		if !t.stopped && t.kind == track.Kind() && t.Sender() == nil {
+		currentDirection := t.getCurrentDirection()
+		// According to https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-addtrack, if the
+		// transceiver can be reused only if it's currentDirection never be sendrecv or sendonly.
+		// But that will cause sdp inflate. So we only check currentDirection's current value,
+		// that's worked for all browsers.
+		if !t.stopped && t.kind == track.Kind() && t.Sender() == nil &&
+			!(currentDirection == RTPTransceiverDirectionSendrecv || currentDirection == RTPTransceiverDirectionSendonly) {
 			sender, err := pc.api.NewRTPSender(track, pc.dtlsTransport)
 			if err == nil {
 				err = t.SetSender(sender, track)

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -13,10 +13,11 @@ import (
 
 // RTPTransceiver represents a combination of an RTPSender and an RTPReceiver that share a common mid.
 type RTPTransceiver struct {
-	mid       atomic.Value // string
-	sender    atomic.Value // *RTPSender
-	receiver  atomic.Value // *RTPReceiver
-	direction atomic.Value // RTPTransceiverDirection
+	mid              atomic.Value // string
+	sender           atomic.Value // *RTPSender
+	receiver         atomic.Value // *RTPReceiver
+	direction        atomic.Value // RTPTransceiverDirection
+	currentDirection atomic.Value // RTPTransceiverDirection
 
 	codecs []RTPCodecParameters // User provided codecs via SetCodecPreferences
 
@@ -38,6 +39,7 @@ func newRTPTransceiver(
 	t.setReceiver(receiver)
 	t.setSender(sender)
 	t.setDirection(direction)
+	t.setCurrentDirection(RTPTransceiverDirection(Unknown))
 	return t
 }
 
@@ -160,6 +162,7 @@ func (t *RTPTransceiver) Stop() error {
 	}
 
 	t.setDirection(RTPTransceiverDirectionInactive)
+	t.setCurrentDirection(RTPTransceiverDirectionInactive)
 	return nil
 }
 
@@ -177,6 +180,17 @@ func (t *RTPTransceiver) setReceiver(r *RTPReceiver) {
 
 func (t *RTPTransceiver) setDirection(d RTPTransceiverDirection) {
 	t.direction.Store(d)
+}
+
+func (t *RTPTransceiver) setCurrentDirection(d RTPTransceiverDirection) {
+	t.currentDirection.Store(d)
+}
+
+func (t *RTPTransceiver) getCurrentDirection() RTPTransceiverDirection {
+	if v, ok := t.currentDirection.Load().(RTPTransceiverDirection); ok {
+		return v
+	}
+	return RTPTransceiverDirection(Unknown)
 }
 
 func (t *RTPTransceiver) setSendingTrack(track TrackLocal) error {


### PR DESCRIPTION
add currentDirection to RTPTransceiver, don't reuse transceiver if its currentDirection is sendrecv or sendonly

#### Description
If remove track from transceiver then reuse it to add track without re-negotiation to transit its direction of sdp, then safari will not fire `removetrack` and `ontrack` events for that transceiver, so the mediatrack is lost.
Step:
1. sfu offer with 2 tracks, negotiation with safari, all things work, safari fire 2 `onTrack` event
2. sfu call RemoveTrack then AddTrack, will reuse rtptransceiver, after that, re-negotiation with safari. No new mid/transceiver in safari, the reused trasceiver changed its stream attributes to the new track.
3. safari can't fire `onTrack` for the new track.

According to https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-addtrack, if the transceiver can be reused only if it's currentDirection never be sendrecv or sendonly. But that will cause sdp inflate in sfu. So we only check currentDirection's current value, that's worked for all browsers.

> If any [RTCRtpSender](https://www.w3.org/TR/webrtc/#dom-rtcrtpsender) object in senders matches all the following criteria, let sender be that object, or null otherwise:
> 
> The sender's track is null.
> 
> The [transceiver kind](https://www.w3.org/TR/webrtc/#dfn-transceiver-kind) of the [RTCRtpTransceiver](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver), associated with the sender, matches kind.
> 
> The [[[Stopping]]](https://www.w3.org/TR/webrtc/#dfn-stopping) slot of the [RTCRtpTransceiver](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver) associated with the sender is false.
> 
> The sender has never been used to send. More precisely, the [[[CurrentDirection]]](https://www.w3.org/TR/webrtc/#dfn-currentdirection) slot of the [RTCRtpTransceiver](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver) associated with the sender has never had a value of "[sendrecv](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverdirection-sendrecv)" or "[sendonly](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverdirection-sendonly)".

#### Reference issue
I think #1843 is related to this fix, but chrome works well on my side, only safari have issue, with this PR, safari works well