### PR TITLE
10 PeerConnections are made, not 5. Fix grammar.

### DIFF
--- a/examples/ice-single-port/README.md
+++ b/examples/ice-single-port/README.md
@@ -2,8 +2,8 @@
 ice-single-port demonstrates Pion WebRTC's ability to serve many PeerConnections on a single port.
 
 Pion WebRTC has no global state, so by default ports can't be shared between two PeerConnections.
-Using the SettingEngine a developer can manually share state between many PeerConnections and allow
-multiple to use the same port
+Using the SettingEngine, a developer can manually share state between many PeerConnections to allow
+multiple PeerConnections to use the same port.
 
 ## Instructions
 
@@ -21,8 +21,8 @@ cd webrtc/examples/ice-single-port
 Execute `go run *.go`
 
 ### Open the Web UI
-Open [http://localhost:8080](http://localhost:8080). This will automatically open 5 PeerConnections. This page will print
+Open [http://localhost:8080](http://localhost:8080). This will automatically open 10 PeerConnections. This page will print
 a Local/Remote line for each PeerConnection. Note that all 10 PeerConnections have different ports for their Local port.
 However for the remote they all will be using port 8443.
 
-Congrats, you have used Pion WebRTC! Now start building something cool
+Congrats, you have used Pion WebRTC! Now start building something cool.


### PR DESCRIPTION
According to https://github.com/pion/webrtc/blob/045df4c4bfd47ae0d657af98053f18e9a707ac34/examples/ice-single-port/index.html#L48 and from running the example, it is clear there are actually 10 PeerConnections, not 5.  Also fixed some grammar.

#### Description

#### Reference issue
Fixes #...
