### PR TITLE
Fix panics in ICEGatherer when it is already closed

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -142,10 +142,7 @@ func (g *ICEGatherer) Gather() error {
 		return err
 	}
 
-	g.lock.Lock()
-	agent := g.agent
-	g.lock.Unlock()
-
+	agent := g.getAgent()
 	// it is possible agent had just been closed
 	if agent == nil {
 		return fmt.Errorf("%w: unable to gather", errICEAgentNotExist)
@@ -205,7 +202,13 @@ func (g *ICEGatherer) GetLocalParameters() (ICEParameters, error) {
 		return ICEParameters{}, err
 	}
 
-	frag, pwd, err := g.agent.GetLocalUserCredentials()
+	agent := g.getAgent()
+	// it is possible agent had just been closed
+	if agent == nil {
+		return ICEParameters{}, fmt.Errorf("%w: unable to get local parameters", errICEAgentNotExist)
+	}
+
+	frag, pwd, err := agent.GetLocalUserCredentials()
 	if err != nil {
 		return ICEParameters{}, err
 	}
@@ -222,7 +225,14 @@ func (g *ICEGatherer) GetLocalCandidates() ([]ICECandidate, error) {
 	if err := g.createAgent(); err != nil {
 		return nil, err
 	}
-	iceCandidates, err := g.agent.GetLocalCandidates()
+
+	agent := g.getAgent()
+	// it is possible agent had just been closed
+	if agent == nil {
+		return nil, fmt.Errorf("%w: unable to get local candidates", errICEAgentNotExist)
+	}
+
+	iceCandidates, err := agent.GetLocalCandidates()
 	if err != nil {
 		return nil, err
 	}

--- a/icegatherer_test.go
+++ b/icegatherer_test.go
@@ -98,3 +98,58 @@ func TestICEGather_mDNSCandidateGathering(t *testing.T) {
 	<-gotMulticastDNSCandidate.Done()
 	assert.NoError(t, gatherer.Close())
 }
+
+func TestICEGatherer_AlreadyClosed(t *testing.T) {
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	opts := ICEGatherOptions{
+		ICEServers: []ICEServer{{URLs: []string{"stun:stun.l.google.com:19302"}}},
+	}
+
+	t.Run("Gather", func(t *testing.T) {
+		gatherer, err := NewAPI().NewICEGatherer(opts)
+		assert.NoError(t, err)
+
+		err = gatherer.createAgent()
+		assert.NoError(t, err)
+
+		err = gatherer.Close()
+		assert.NoError(t, err)
+
+		err = gatherer.Gather()
+		assert.ErrorIs(t, err, errICEAgentNotExist)
+	})
+
+	t.Run("GetLocalParameters", func(t *testing.T) {
+		gatherer, err := NewAPI().NewICEGatherer(opts)
+		assert.NoError(t, err)
+
+		err = gatherer.createAgent()
+		assert.NoError(t, err)
+
+		err = gatherer.Close()
+		assert.NoError(t, err)
+
+		_, err = gatherer.GetLocalParameters()
+		assert.ErrorIs(t, err, errICEAgentNotExist)
+	})
+
+	t.Run("GetLocalCandidates", func(t *testing.T) {
+		gatherer, err := NewAPI().NewICEGatherer(opts)
+		assert.NoError(t, err)
+
+		err = gatherer.createAgent()
+		assert.NoError(t, err)
+
+		err = gatherer.Close()
+		assert.NoError(t, err)
+
+		_, err = gatherer.GetLocalCandidates()
+		assert.ErrorIs(t, err, errICEAgentNotExist)
+	})
+}


### PR DESCRIPTION
#### Description

ICEGatherer throws panics in GetLocalCandidates(), GetLocalParameters() when it is already closed.
We have seen these panics during our load tests even though the PR #2230 has been merged.

This PR fixes these panics and added some test codes.

#### Reference issue

Fixes #2261 
Related to #2230 
