### PR TITLE
Fix generated Mid conflict with user set Mid

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -659,7 +659,13 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 				}
 			}
 			for _, t := range currentTransceivers {
-				if t.Mid() != "" {
+				if mid := t.Mid(); mid != "" {
+					numericMid, errMid := strconv.Atoi(mid)
+					if errMid == nil {
+						if numericMid > pc.greaterMid {
+							pc.greaterMid = numericMid
+						}
+					}
 					continue
 				}
 				pc.greaterMid++


### PR DESCRIPTION
Inside one cycle renegotiation, if user both has manually set Mid and auto generated Mid for transceivers, CreateOffer will failed for Mid conflict.