### PR TITLE
Populate RTPTransceiver stopped flag

### DIFF
--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -24,8 +24,7 @@ type RTPTransceiver struct {
 
 	codecs []RTPCodecParameters // User provided codecs via SetCodecPreferences
 
-	stopped bool
-	kind    RTPCodecType
+	kind RTPCodecType
 
 	api *API
 	mu  sync.RWMutex


### PR DESCRIPTION
There is use of `t.stopped` in `peerconnection.go`, but that flag is not set/used in `RTPTransceiver` at all. This PR sets that when a transceiver is stopped and provides an API to check if a transceiver is stopped.

@Sean-Der @davidzhao @cnderrauber The fact that code does not seem to get tripped makes me think I am missing something, but I noticed the ☝️ (i. e. `stopped` flag in `RTPTransceiver` was not set/used) and made this PR to address this. Have tested this change with LiveKit and it seems fine.