### PR TITLE
Remove `new RTCSessionDescription` pattern

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -150,6 +150,7 @@ ronan <ronan.jezequel@gmail.com>
 Ryan Shumate <Ryan.Shumate@garmin.com>
 salmān aljammāz <s@aljmz.com>
 Sam Lancia <sam@vaion.com>
+Sean DuBois <duboisea@justin.tv>
 Sean DuBois <duboisea@twitch.tv>
 Sean DuBois <seaduboi@amazon.com>
 Sean DuBois <sean@siobud.com>

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -91,7 +91,7 @@ func TestE2E_Audio(t *testing.T) {
 			}
 			var result string
 			if err := page.RunScript(
-				"pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(answer)))",
+				"pc.setRemoteDescription(JSON.parse(answer))",
 				map[string]interface{}{"answer": string(answerBytes)},
 				&result,
 			); err != nil {
@@ -231,7 +231,7 @@ func TestE2E_DataChannel(t *testing.T) {
 			}
 			var result string
 			if err := page.RunScript(
-				"pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(answer)))",
+				"pc.setRemoteDescription(JSON.parse(answer))",
 				map[string]interface{}{"answer": string(answerBytes)},
 				&result,
 			); err != nil {

--- a/examples/broadcast/README.md
+++ b/examples/broadcast/README.md
@@ -11,7 +11,7 @@ go get github.com/pion/webrtc/v3/examples/broadcast
 ```
 
 ### Open broadcast example page
-[jsfiddle.net](https://jsfiddle.net/ypcsbnu3/) You should see two buttons `Publish a Broadcast` and `Join a Broadcast`
+[jsfiddle.net](https://jsfiddle.net/us4h58jx/) You should see two buttons `Publish a Broadcast` and `Join a Broadcast`
 
 ### Run Broadcast
 #### Linux/macOS

--- a/examples/broadcast/jsfiddle/demo.js
+++ b/examples/broadcast/jsfiddle/demo.js
@@ -48,7 +48,7 @@ window.createSession = isPublisher => {
     }
 
     try {
-      pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+      pc.setRemoteDescription(JSON.parse(atob(sd)))
     } catch (e) {
       alert(e)
     }

--- a/examples/data-channels/README.md
+++ b/examples/data-channels/README.md
@@ -9,7 +9,7 @@ go get github.com/pion/webrtc/v3/examples/data-channels
 ```
 
 ### Open data-channels example page
-[jsfiddle.net](https://jsfiddle.net/t3johb5g/2/)
+[jsfiddle.net](https://jsfiddle.net/e41tgovp/)
 
 ### Run data-channels, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser's session description, press `Copy browser SDP to clipboard` or copy the base64 string manually and:

--- a/examples/data-channels/jsfiddle/demo.js
+++ b/examples/data-channels/jsfiddle/demo.js
@@ -42,7 +42,7 @@ window.startSession = () => {
   }
 
   try {
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }

--- a/examples/insertable-streams/README.md
+++ b/examples/insertable-streams/README.md
@@ -19,7 +19,7 @@ go get github.com/pion/webrtc/v3/examples/insertable-streams
 ```
 
 ### Open insertable-streams example page
-[jsfiddle.net](https://jsfiddle.net/uqr80Lak/) you should see two text-areas and a 'Start Session' button. You will also have a 'Decrypt' checkbox.
+[jsfiddle.net](https://jsfiddle.net/t5xoaryc/) you should see two text-areas and a 'Start Session' button. You will also have a 'Decrypt' checkbox.
 When unchecked the browser will not decrypt the incoming video stream, so it will stop playing or display certificates.
 
 ### Run insertable-streams with your browsers SessionDescription as stdin

--- a/examples/insertable-streams/jsfiddle/demo.js
+++ b/examples/insertable-streams/jsfiddle/demo.js
@@ -60,7 +60,7 @@ window.startSession = () => {
   }
 
   try {
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }

--- a/examples/play-from-disk/README.md
+++ b/examples/play-from-disk/README.md
@@ -20,7 +20,7 @@ go get github.com/pion/webrtc/v3/examples/play-from-disk
 ```
 
 ### Open play-from-disk example page
-[jsfiddle.net](https://jsfiddle.net/a1cz42op/) you should see two text-areas, 'Start Session' button and 'Copy browser SessionDescription to clipboard'
+[jsfiddle.net](https://jsfiddle.net/8kup9mvn/) you should see two text-areas, 'Start Session' button and 'Copy browser SessionDescription to clipboard'
 
 ### Run play-from-disk with your browsers Session Description as stdin
 The `output.ivf` you created should be in the same directory as `play-from-disk`. In the jsfiddle press 'Copy browser Session Description to clipboard' or copy the base64 string manually.

--- a/examples/play-from-disk/jsfiddle/demo.js
+++ b/examples/play-from-disk/jsfiddle/demo.js
@@ -42,7 +42,7 @@ window.startSession = () => {
   }
 
   try {
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }

--- a/examples/reflect/README.md
+++ b/examples/reflect/README.md
@@ -9,7 +9,7 @@ go get github.com/pion/webrtc/v3/examples/reflect
 ```
 
 ### Open reflect example page
-[jsfiddle.net](https://jsfiddle.net/ogs7muqh/1/) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/g643ft1k/) you should see two text-areas and a 'Start Session' button.
 
 ### Run reflect, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.

--- a/examples/reflect/jsfiddle/demo.js
+++ b/examples/reflect/jsfiddle/demo.js
@@ -39,7 +39,7 @@ window.startSession = () => {
   }
 
   try {
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }

--- a/examples/rtcp-processing/README.md
+++ b/examples/rtcp-processing/README.md
@@ -16,7 +16,7 @@ go get github.com/pion/webrtc/v3/examples/rtcp-processing
 ```
 
 ### Open rtcp-processing example page
-[jsfiddle.net](https://jsfiddle.net/Le3zg7sd/) you should see two text-areas, 'Start Session' button and 'Copy browser SessionDescription to clipboard'
+[jsfiddle.net](https://jsfiddle.net/zurq6j7x/) you should see two text-areas, 'Start Session' button and 'Copy browser SessionDescription to clipboard'
 
 ### Run rtcp-processing with your browsers Session Description as stdin
 In the jsfiddle press 'Copy browser Session Description to clipboard' or copy the base64 string manually.

--- a/examples/rtcp-processing/jsfiddle/demo.js
+++ b/examples/rtcp-processing/jsfiddle/demo.js
@@ -40,7 +40,7 @@ window.startSession = () => {
   }
 
   try {
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }

--- a/examples/rtp-forwarder/README.md
+++ b/examples/rtp-forwarder/README.md
@@ -9,7 +9,7 @@ go get github.com/pion/webrtc/v3/examples/rtp-forwarder
 ```
 
 ### Open rtp-forwarder example page
-[jsfiddle.net](https://jsfiddle.net/xjcve6d3/) you should see your Webcam, two text-areas and `Copy browser SDP to clipboard`, `Start Session` buttons
+[jsfiddle.net](https://jsfiddle.net/fm7btvr3/) you should see your Webcam, two text-areas and `Copy browser SDP to clipboard`, `Start Session` buttons
 
 ### Run rtp-forwarder, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.

--- a/examples/rtp-forwarder/jsfiddle/demo.js
+++ b/examples/rtp-forwarder/jsfiddle/demo.js
@@ -32,7 +32,7 @@ window.startSession = () => {
   }
 
   try {
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }

--- a/examples/save-to-disk/README.md
+++ b/examples/save-to-disk/README.md
@@ -11,7 +11,7 @@ go get github.com/pion/webrtc/v3/examples/save-to-disk
 ```
 
 ### Open save-to-disk example page
-[jsfiddle.net](https://jsfiddle.net/xjcve6d3/) you should see your Webcam, two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
+[jsfiddle.net](https://jsfiddle.net/s179hacu/) you should see your Webcam, two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
 
 ### Run save-to-disk, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.

--- a/examples/save-to-disk/jsfiddle/demo.js
+++ b/examples/save-to-disk/jsfiddle/demo.js
@@ -33,7 +33,7 @@ window.startSession = () => {
   }
 
   try {
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }

--- a/examples/simulcast/README.md
+++ b/examples/simulcast/README.md
@@ -13,7 +13,7 @@ go get github.com/pion/webrtc/v3/examples/simulcast
 ```
 
 ### Open simulcast example page
-[jsfiddle.net](https://jsfiddle.net/zLebmv41/1/) you should see two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
+[jsfiddle.net](https://jsfiddle.net/tz4d5bhj/) you should see two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
 
 ### Run simulcast, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.

--- a/examples/simulcast/jsfiddle/demo.js
+++ b/examples/simulcast/jsfiddle/demo.js
@@ -85,7 +85,7 @@ window.startSession = () => {
 
   try {
     console.log('answer', JSON.parse(atob(sd)))
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }

--- a/examples/swap-tracks/README.md
+++ b/examples/swap-tracks/README.md
@@ -9,7 +9,7 @@ go get github.com/pion/webrtc/v3/examples/swap-tracks
 ```
 
 ### Open swap-tracks example page
-[jsfiddle.net](https://jsfiddle.net/39w24tr6/1/) you should see two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
+[jsfiddle.net](https://jsfiddle.net/1rx5on86/) you should see two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
 
 ### Run swap-tracks, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.

--- a/examples/swap-tracks/jsfiddle/demo.js
+++ b/examples/swap-tracks/jsfiddle/demo.js
@@ -68,7 +68,7 @@ window.startSession = () => {
   }
 
   try {
-    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(atob(sd))))
+    pc.setRemoteDescription(JSON.parse(atob(sd)))
   } catch (e) {
     alert(e)
   }


### PR DESCRIPTION
SetRemoteDescription accepts a RTCSessionDescriptionInit so this is no longer needed

Resolves #2324
