### PR TITLE
Simplify docker compose file of pion-to-pion

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -165,6 +165,7 @@ Simone Gotti <simone.gotti@gmail.com>
 Slugalisk <slugalisk@gmail.com>
 soolaugust <soolaugust@gmail.com>
 spaceCh1mp <drimboat@gmail.com>
+stephanrotolante <stephanrotolante@gmail.com>
 Suhas Gaddam <suhas.g.2011@gmail.com>
 Suzuki Takeo <takeo@stko.info>
 sylba2050 <masataka.hisasue@optim.co.jp>

--- a/examples/pion-to-pion/docker-compose.yml
+++ b/examples/pion-to-pion/docker-compose.yml
@@ -1,19 +1,11 @@
 version: '3'
 services:
   answer:
-    container_name: answer
     build: ./answer
     command: answer -offer-address offer:50000
-    hostname: answer
-    restart: always   
-    ports:
-      - 50000:50000    
-      
+
   offer:
-    depends_on:  
+    depends_on:
       - answer
-    container_name: offer
     build: ./offer
     command: offer -answer-address answer:60000
-    hostname: offer
-    restart: always


### PR DESCRIPTION
Removed unnecessary properties from docker-compose file. **hostname** by default is equal to service name. Custom **container_name** and port mapping are also not needed for the example.