### PR TITLE
Add test for pion-to-pion example

### DIFF
--- a/.github/workflows/examples-tests.yaml
+++ b/.github/workflows/examples-tests.yaml
@@ -1,0 +1,19 @@
+name: Examples Tests
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  pion-to-pion-test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: test
+        run: cd examples/pion-to-pion && ./test.sh
+

--- a/examples/pion-to-pion/docker-compose.yml
+++ b/examples/pion-to-pion/docker-compose.yml
@@ -1,10 +1,12 @@
 version: '3'
 services:
   answer:
+    container_name: answer
     build: ./answer
     command: answer -offer-address offer:50000
 
   offer:
+    container_name: offer
     depends_on:
       - answer
     build: ./offer

--- a/examples/pion-to-pion/test.sh
+++ b/examples/pion-to-pion/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+docker compose up -d
+
+function on_exit {
+  docker compose logs
+  docker compose rm -fsv
+}
+
+trap on_exit EXIT
+
+TIMEOUT=10
+timeout $TIMEOUT docker compose logs -f | grep -q "answer  | Message from DataChannel"
+timeout $TIMEOUT docker compose logs -f | grep -q "offer   | Message from DataChannel"


### PR DESCRIPTION
Also add new GitHub Actions workflow to run tests for example apps

This is an implementation of the following idea: https://github.com/pion/webrtc/wiki/Big-Ideas#run-tests-against-examples

At the moment latest released example is tested. Next step is to build examples from source and test them.