### PR TITLE
Avoid including SSRC in single media offers

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1486,6 +1486,8 @@ func (pc *PeerConnection) handleUndeclaredSSRC(ssrc SSRC, remoteDescription *Ses
 	onlyMediaSection := remoteDescription.parsed.MediaDescriptions[0]
 	streamID := ""
 	id := ""
+	hasRidAttribute := false
+	hasSSRCAttribute := false
 
 	for _, a := range onlyMediaSection.Attributes {
 		switch a.Key {
@@ -1495,10 +1497,16 @@ func (pc *PeerConnection) handleUndeclaredSSRC(ssrc SSRC, remoteDescription *Ses
 				id = split[1]
 			}
 		case sdp.AttrKeySSRC:
-			return false, errPeerConnSingleMediaSectionHasExplicitSSRC
+			hasSSRCAttribute = true
 		case sdpAttributeRid:
-			return false, nil
+			hasRidAttribute = true
 		}
+	}
+
+	if hasRidAttribute {
+		return false, nil
+	} else if hasSSRCAttribute {
+		return false, errPeerConnSingleMediaSectionHasExplicitSSRC
 	}
 
 	incoming := trackDetails{


### PR DESCRIPTION
#### Description

Sending simulcast tracks from a pion sender to a pion receiver is failing unless there are other medias added:

```
Incoming unhandled RTP ssrc(xxxx), OnTrack will not be fired. single media section has an explicit SSRC
```

I admit I am not well versed in SDP semantics so please let me know if there's more to this that we should consider. The proposed changes are incredibly dumb as we are simply checking if there are multiple media sections and if not we avoid adding the ssrc attribute.

#### Reference issue

This is strictly related to https://github.com/pion/webrtc/pull/2299 which I guess is also a working solution although I am thinking that if we are being strict on the receiving side we should probably do the same on the sending side.
