### PR TITLE
Skip HelloVerify Verification for WebRTC connections

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -313,7 +313,7 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 			ClientAuth:              dtls.RequireAnyClientCert,
 			LoggerFactory:           t.api.settingEngine.LoggerFactory,
 			InsecureSkipVerify:      true,
-			InsecureSkipVerifyHello: true,
+			InsecureSkipVerifyHello: t.api.settingEngine.disableDTLSHelloVerifyDoSProtection,
 		}, nil
 	}
 

--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -313,7 +313,7 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 			ClientAuth:              dtls.RequireAnyClientCert,
 			LoggerFactory:           t.api.settingEngine.LoggerFactory,
 			InsecureSkipVerify:      true,
-			InsecureSkipVerifyHello: t.api.settingEngine.disableDTLSHelloVerifyDoSProtection,
+			InsecureSkipVerifyHello: t.api.settingEngine.dtls.disableDTLSHelloVerifyDoSProtection,
 		}, nil
 	}
 

--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -310,9 +310,10 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 
 				return defaultSrtpProtectionProfiles()
 			}(),
-			ClientAuth:         dtls.RequireAnyClientCert,
-			LoggerFactory:      t.api.settingEngine.LoggerFactory,
-			InsecureSkipVerify: true,
+			ClientAuth:              dtls.RequireAnyClientCert,
+			LoggerFactory:           t.api.settingEngine.LoggerFactory,
+			InsecureSkipVerify:      true,
+			InsecureSkipVerifyHello: true,
 		}, nil
 	}
 

--- a/settingengine.go
+++ b/settingengine.go
@@ -67,6 +67,7 @@ type SettingEngine struct {
 	disableSRTPReplayProtection               bool
 	disableSRTCPReplayProtection              bool
 	net                                       transport.Net
+	disableDTLSHelloVerifyDoSProtection       bool
 	BufferFactory                             func(packetType packetio.BufferPacketType, ssrc uint32) io.ReadWriteCloser
 	LoggerFactory                             logging.LoggerFactory
 	iceTCPMux                                 ice.TCPMux
@@ -353,4 +354,13 @@ func (e *SettingEngine) SetDTLSRetransmissionInterval(interval time.Duration) {
 // Leave this 0 for the default maxReceiveBufferSize.
 func (e *SettingEngine) SetSCTPMaxReceiveBufferSize(maxReceiveBufferSize uint32) {
 	e.sctp.maxReceiveBufferSize = maxReceiveBufferSize
+}
+
+// DisableDTLSHelloVerifyDoSProtection set whether WebRTC connection's underlying DTLS connection
+// would not require client to send HelloVerify packet when acting as DTLS servers.
+// When set to true, the WebRTC connection would enjoy slightly less DoS Protection,
+// as ICE already provides some DoS protection. This is the browser's common behaviour.
+// Leave this false for the default to require client to send DTLS HelloVerify packet
+func (e *SettingEngine) DisableDTLSHelloVerifyDoSProtection(isDisabled bool) {
+	e.disableDTLSHelloVerifyDoSProtection = isDisabled
 }

--- a/settingengine.go
+++ b/settingengine.go
@@ -358,8 +358,8 @@ func (e *SettingEngine) SetSCTPMaxReceiveBufferSize(maxReceiveBufferSize uint32)
 
 // DisableDTLSHelloVerifyDoSProtection set whether WebRTC connection's underlying DTLS connection
 // would not require client to send HelloVerify packet when acting as DTLS servers.
-// When set to true, the WebRTC connection would enjoy slightly less DoS Protection,
-// as ICE already provides some DoS protection. This is the browser's common behaviour.
+// When set to true, the WebRTC connection would enjoy slightly less DoS protection,
+// as ICE already provides some DoS protection. This is the browser's common behavior.
 // Leave this false for the default to require client to send DTLS HelloVerify packet
 func (e *SettingEngine) DisableDTLSHelloVerifyDoSProtection(isDisabled bool) {
 	e.disableDTLSHelloVerifyDoSProtection = isDisabled

--- a/settingengine.go
+++ b/settingengine.go
@@ -56,7 +56,8 @@ type SettingEngine struct {
 		SRTCP *uint
 	}
 	dtls struct {
-		retransmissionInterval time.Duration
+		retransmissionInterval              time.Duration
+		disableDTLSHelloVerifyDoSProtection bool
 	}
 	sctp struct {
 		maxReceiveBufferSize uint32
@@ -67,7 +68,6 @@ type SettingEngine struct {
 	disableSRTPReplayProtection               bool
 	disableSRTCPReplayProtection              bool
 	net                                       transport.Net
-	disableDTLSHelloVerifyDoSProtection       bool
 	BufferFactory                             func(packetType packetio.BufferPacketType, ssrc uint32) io.ReadWriteCloser
 	LoggerFactory                             logging.LoggerFactory
 	iceTCPMux                                 ice.TCPMux
@@ -362,5 +362,5 @@ func (e *SettingEngine) SetSCTPMaxReceiveBufferSize(maxReceiveBufferSize uint32)
 // as ICE already provides some DoS protection. This is the browser's common behavior.
 // Leave this false for the default to require client to send DTLS HelloVerify packet
 func (e *SettingEngine) DisableDTLSHelloVerifyDoSProtection(isDisabled bool) {
-	e.disableDTLSHelloVerifyDoSProtection = isDisabled
+	e.dtls.disableDTLSHelloVerifyDoSProtection = isDisabled
 }

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -245,8 +245,8 @@ func TestSetSCTPMaxReceiverBufferSize(t *testing.T) {
 
 func TestDisableDTLSHelloVerifyDoSProtection(t *testing.T) {
 	s := SettingEngine{}
-	assert.False(t, s.disableDTLSHelloVerifyDoSProtection)
+	assert.False(t, s.dtls.disableDTLSHelloVerifyDoSProtection)
 
 	s.DisableDTLSHelloVerifyDoSProtection(true)
-	assert.True(t, s.disableDTLSHelloVerifyDoSProtection)
+	assert.True(t, s.dtls.disableDTLSHelloVerifyDoSProtection)
 }

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -242,3 +242,11 @@ func TestSetSCTPMaxReceiverBufferSize(t *testing.T) {
 	s.SetSCTPMaxReceiveBufferSize(expSize)
 	assert.Equal(t, expSize, s.sctp.maxReceiveBufferSize)
 }
+
+func TestDisableDTLSHelloVerifyDoSProtection(t *testing.T) {
+	s := SettingEngine{}
+	assert.False(t, s.disableDTLSHelloVerifyDoSProtection)
+
+	s.DisableDTLSHelloVerifyDoSProtection(true)
+	assert.True(t, s.disableDTLSHelloVerifyDoSProtection)
+}


### PR DESCRIPTION
#### Description
This is a pull request that set `InsecureSkipVerifyHello` option on webrtc's underlying DTLS connection. This allow the current implementation of webrtc to match browser behavior better and reduce the time to establish a connection.

It have been observed that snowflake, a crowdsourced censorship resistant proxy has been blocked in some part of Russia by identifying the transmission of HelloVerify packet. This pull request is a series of pull request to remove this distinguisher.

#### Reference issue

