### PR TITLE
Make Transceiver Negotation more consistent

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -173,6 +173,7 @@ Slugalisk <slugalisk@gmail.com>
 Somers Matthews <somersbmatthews@gmail.com>
 soolaugust <soolaugust@gmail.com>
 spaceCh1mp <drimboat@gmail.com>
+Steffen Vogel <post@steffenvogel.de>
 stephanrotolante <stephanrotolante@gmail.com>
 Suhas Gaddam <suhas.g.2011@gmail.com>
 Suzuki Takeo <takeo@stko.info>
@@ -188,6 +189,7 @@ Vicken Simonian <vsimon@gmail.com>
 wattanakorn495 <wattanakorn.i@ku.th>
 Will Forcey <wsforc3y@gmail.com>
 Will Watson <william.a.watson@gmail.com>
+WofWca <wofwca@protonmail.com>
 Woodrow Douglass <wdouglass@carnegierobotics.com>
 xsbchen <xsbchen@qq.com>
 Yoon SeungYong <simon.y@hpcnt.com>

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -1247,7 +1247,7 @@ func TestPeerConnection_TransceiverDirection(t *testing.T) {
 			"offer sendonly answer sendrecv",
 			RTPTransceiverDirectionSendonly,
 			RTPTransceiverDirectionSendrecv,
-			[]RTPTransceiverDirection{RTPTransceiverDirectionSendrecv, RTPTransceiverDirectionRecvonly},
+			[]RTPTransceiverDirection{RTPTransceiverDirectionSendrecv},
 		},
 		{
 			"offer recvonly answer sendrecv",
@@ -1259,7 +1259,7 @@ func TestPeerConnection_TransceiverDirection(t *testing.T) {
 			"offer sendrecv answer sendonly",
 			RTPTransceiverDirectionSendrecv,
 			RTPTransceiverDirectionSendonly,
-			[]RTPTransceiverDirection{RTPTransceiverDirectionSendonly, RTPTransceiverDirectionRecvonly},
+			[]RTPTransceiverDirection{RTPTransceiverDirectionSendrecv},
 		},
 		{
 			"offer sendonly answer sendonly",

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -239,9 +239,9 @@ func satisfyTypeAndDirection(remoteKind RTPCodecType, remoteDirection RTPTransce
 	getPreferredDirections := func() []RTPTransceiverDirection {
 		switch remoteDirection {
 		case RTPTransceiverDirectionSendrecv:
-			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly, RTPTransceiverDirectionSendrecv}
+			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly, RTPTransceiverDirectionSendrecv, RTPTransceiverDirectionSendonly}
 		case RTPTransceiverDirectionSendonly:
-			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly}
+			return []RTPTransceiverDirection{RTPTransceiverDirectionRecvonly, RTPTransceiverDirectionSendrecv}
 		case RTPTransceiverDirectionRecvonly:
 			return []RTPTransceiverDirection{RTPTransceiverDirectionSendonly, RTPTransceiverDirectionSendrecv}
 		default:


### PR DESCRIPTION
Today a remote `recvonly` transceiver can be satisfied by a `sendonly` or `sendrecv` transceiver. However a remote `sendonly` transceiver can only be satisfied by a `recvonly` transceiver.

This PR updates the answer handling code to be more consistent.

