### PR TITLE
Transceivers state  change from inactive to active

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1104,7 +1104,10 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error { 
 					}
 					_ = t.SetCodecPreferences(filteredCodecs)
 				}
-
+			case direction == RTPTransceiverDirectionSendonly:
+				if t.Direction() == RTPTransceiverDirectionInactive {
+					t.setDirection(RTPTransceiverDirectionRecvonly)
+				}
 			case direction == RTPTransceiverDirectionRecvonly:
 				if t.Direction() == RTPTransceiverDirectionSendrecv {
 					t.setDirection(RTPTransceiverDirectionSendonly)


### PR DESCRIPTION
#### Description
Reuse  transceivers in remote peer。

In the existing  RTC Transceivers, when the state of the remote transceiver changes from inactive to active, the state of the pion also needs to change from inactive to active。


#### Reference issue
Fixes #...
