### PR TITLE
fix: return correct bytes written on WriteRTCP on dtlsTransport

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -142,10 +142,7 @@ func (t *DTLSTransport) WriteRTCP(pkts []rtcp.Packet) (int, error) {
 		return 0, fmt.Errorf("%w: %v", errPeerConnWriteRTCPOpenWriteStream, err)
 	}
 
-	if n, err := writeStream.Write(raw); err != nil {
-		return n, err
-	}
-	return 0, nil
+	return writeStream.Write(raw)
 }
 
 // GetLocalParameters returns the DTLS parameters of the local DTLSTransport upon construction.


### PR DESCRIPTION
#### Description

Currently WriteRTCP function in `dtlstransport.go` doesn't return bytes written info. This PR fixes this and handles error and success response correctly. 
#### Reference issue
Fixes #...
