### PR TITLE
Fix lint errors in tests

### DIFF
--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -1,7 +1,6 @@
 package webrtc
 
 import (
-	"context"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -751,39 +750,4 @@ func TestTransportChain(t *testing.T) {
 	assert.NotNil(t, offer.SCTP().Transport().ICETransport())
 
 	closePairNow(t, offer, answer)
-}
-
-func TestNegotiationNeededWithRecvonlyTrack(t *testing.T) {
-	lim := test.TimeOut(time.Second * 30)
-	defer lim.Stop()
-
-	report := test.CheckRoutines(t)
-	defer report()
-
-	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	pcAnswer.OnNegotiationNeeded(wg.Done)
-
-	_, err = pcOffer.AddTransceiverFromKind(RTPCodecTypeVideo, RTPTransceiverInit{Direction: RTPTransceiverDirectionRecvonly})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := signalPair(pcOffer, pcAnswer); err != nil {
-		t.Fatal(err)
-	}
-
-	onDataChannel, onDataChannelCancel := context.WithCancel(context.Background())
-	pcAnswer.OnDataChannel(func(d *DataChannel) {
-		onDataChannelCancel()
-	})
-	<-onDataChannel.Done()
-	wg.Wait()
-
-	closePairNow(t, pcOffer, pcAnswer)
 }


### PR DESCRIPTION
Switch from reflect.DeepEqual to errors.Is