### PR TITLE
Fix ignored calls during OnDataChannel

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -307,6 +307,9 @@ func (d *DataChannel) handleOpen(dc *datachannel.DataChannel, isRemote, isAlread
 	// * remote datachannels should fire OnOpened. This isn't spec compliant, but we can't break behavior yet
 	// * already negotiated datachannels should fire OnOpened
 	if d.api.settingEngine.detach.DataChannels || isRemote || isAlreadyNegotiated {
+		// bufferedAmountLowThreshold and onBufferedAmountLow might be set earlier
+		d.dataChannel.SetBufferedAmountLowThreshold(d.bufferedAmountLowThreshold)
+		d.dataChannel.OnBufferedAmountLow(d.onBufferedAmountLow)
 		d.onOpen()
 	} else {
 		dc.OnOpen(func() {


### PR DESCRIPTION
Set cached values passed by SetBufferedAmountLowThreshold and OnBufferedAmountLow correctly when the underlying datachannel become open.

#### Description
These method calls are ignored when they are called during OnDataChannel callback, before OnOpen callback.
* dc.SetBufferedAmountLowThreshold()
* dc.OnBufferedAmountLow()

The values are cached on webrtc.DataChannel object, but these were not passed when OnDataChannel is called.

#### Reference issue
Fixes #2441
