### PR TITLE
Match header extensions to all media sections in offer

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -455,6 +455,30 @@ func (m *MediaEngine) matchRemoteCodec(remoteCodec RTPCodecParameters, typ RTPCo
 	return matchType, nil
 }
 
+// Update header extensions from a remote media section
+func (m *MediaEngine) updateHeaderExtensionFromMediaSection(media *sdp.MediaDescription) error {
+	var typ RTPCodecType
+	switch {
+	case strings.EqualFold(media.MediaName.Media, "audio"):
+		typ = RTPCodecTypeAudio
+	case strings.EqualFold(media.MediaName.Media, "video"):
+		typ = RTPCodecTypeVideo
+	default:
+		return nil
+	}
+	extensions, err := rtpExtensionsFromMediaDescription(media)
+	if err != nil {
+		return err
+	}
+
+	for extension, id := range extensions {
+		if err = m.updateHeaderExtension(id, extension, typ); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Look up a header extension and enable if it exists
 func (m *MediaEngine) updateHeaderExtension(id int, extension string, typ RTPCodecType) error {
 	if m.negotiatedHeaderExtensions == nil {
@@ -498,14 +522,27 @@ func (m *MediaEngine) updateFromRemoteDescription(desc sdp.SessionDescription) e
 
 	for _, media := range desc.MediaDescriptions {
 		var typ RTPCodecType
+
 		switch {
-		case !m.negotiatedAudio && strings.EqualFold(media.MediaName.Media, "audio"):
-			m.negotiatedAudio = true
+		case strings.EqualFold(media.MediaName.Media, "audio"):
 			typ = RTPCodecTypeAudio
-		case !m.negotiatedVideo && strings.EqualFold(media.MediaName.Media, "video"):
-			m.negotiatedVideo = true
+		case strings.EqualFold(media.MediaName.Media, "video"):
 			typ = RTPCodecTypeVideo
+		}
+
+		switch {
+		case !m.negotiatedAudio && typ == RTPCodecTypeAudio:
+			m.negotiatedAudio = true
+		case !m.negotiatedVideo && typ == RTPCodecTypeVideo:
+			m.negotiatedVideo = true
 		default:
+			// update header extesions from remote sdp if codec is negotiated, Firefox
+			// would send updated header extension in renegotiation.
+			// e.g. publish first track without simucalst ->negotiated-> publish second track with simucalst
+			// then the two media secontions have different rtp header extensions in offer
+			if err := m.updateHeaderExtensionFromMediaSection(media); err != nil {
+				return err
+			}
 			continue
 		}
 
@@ -541,15 +578,8 @@ func (m *MediaEngine) updateFromRemoteDescription(desc sdp.SessionDescription) e
 			continue
 		}
 
-		extensions, err := rtpExtensionsFromMediaDescription(media)
-		if err != nil {
+		if err := m.updateHeaderExtensionFromMediaSection(media); err != nil {
 			return err
-		}
-
-		for extension, id := range extensions {
-			if err = m.updateHeaderExtension(id, extension, typ); err != nil {
-				return err
-			}
 		}
 	}
 	return nil

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2465,7 +2465,9 @@ func (pc *PeerConnection) generateMatchedSDP(transceivers []*RTPTransceiver, use
 				sender.setNegotiated()
 			}
 			mediaTransceivers := []*RTPTransceiver{t}
-			mediaSections = append(mediaSections, mediaSection{id: midValue, transceivers: mediaTransceivers, ridMap: getRids(media)})
+
+			extensions, _ := rtpExtensionsFromMediaDescription(media)
+			mediaSections = append(mediaSections, mediaSection{id: midValue, transceivers: mediaTransceivers, matchExtensions: extensions, ridMap: getRids(media)})
 		}
 	}
 

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -1080,6 +1080,9 @@ func TestPeerConnection_Simulcast_Probe(t *testing.T) {
 			return
 		}))
 
+		peerConnectionConnected := untilConnectionState(PeerConnectionStateConnected, pcOffer, pcAnswer)
+		peerConnectionConnected.Wait()
+
 		sequenceNumber := uint16(0)
 		sendRTPPacket := func() {
 			sequenceNumber++
@@ -1097,12 +1100,12 @@ func TestPeerConnection_Simulcast_Probe(t *testing.T) {
 			sendRTPPacket()
 		}
 
-		assert.NoError(t, signalPair(pcOffer, pcAnswer))
-
 		trackRemoteChan := make(chan *TrackRemote, 1)
 		pcAnswer.OnTrack(func(trackRemote *TrackRemote, _ *RTPReceiver) {
 			trackRemoteChan <- trackRemote
 		})
+
+		assert.NoError(t, signalPair(pcOffer, pcAnswer))
 
 		trackRemote := func() *TrackRemote {
 			for {

--- a/sdp.go
+++ b/sdp.go
@@ -487,6 +487,11 @@ func addTransceiverSDP(
 
 	parameters := mediaEngine.getRTPParametersByKind(t.kind, directions)
 	for _, rtpExtension := range parameters.HeaderExtensions {
+		if mediaSection.matchExtensions != nil {
+			if _, enabled := mediaSection.matchExtensions[rtpExtension.URI]; !enabled {
+				continue
+			}
+		}
 		extURL, err := url.Parse(rtpExtension.URI)
 		if err != nil {
 			return false, err
@@ -533,10 +538,11 @@ type simulcastRid struct {
 }
 
 type mediaSection struct {
-	id           string
-	transceivers []*RTPTransceiver
-	data         bool
-	ridMap       map[string]*simulcastRid
+	id              string
+	transceivers    []*RTPTransceiver
+	data            bool
+	matchExtensions map[string]int
+	ridMap          map[string]*simulcastRid
 }
 
 func bundleMatchFromRemote(matchBundleGroup *string) func(mid string) bool {


### PR DESCRIPTION
#### Description

We noticed that once pion has negotiated headers and codecs for a given Kind, when a subsequent offer SDP adds a media section for that same Kind with different header extensions, the generated answer uses the original headers for all media sections. 

This doesn't happen in Chrome, which never seems to send mixed headers like this. Firefox does, though.

We ran into this when sending an offer in which the first video media section had simulcast disabled, and thus didn't set this attribute
```
a=extmap:8/sendonly urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
```
but the second video media section had simulcast enabled, so included that header.

The resulting answer didn't include that header in either media section, but the second media section did correctly have these attributes 
```
a=rid:f recv
a=rid:h recv
a=rid:q recv
a=simulcast:recv f;h;q
```
Resulting in this error 
```
Incoming unhandled RTP ssrc(3870936274), OnTrack will not be fired. stream id RTP Extensions required for Simulcast
```

This patch fixes our manual test case, but I suspect there are more places in the code where this assumption is being made. I'm also not sure whether Plan B vs Unified expects different behavior in this case.

#### Reference issue
Fixes #...
