### PR TITLE
Fix simulcast track set to incorrect stream id

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1340,6 +1340,7 @@ func (pc *PeerConnection) configureRTPReceivers(isRenegotiation bool, remoteDesc
 				continue
 			}
 
+			mid := t.Mid()
 			receiverNeedsStopped := false
 			func() {
 				for _, t := range tracks {
@@ -1347,7 +1348,7 @@ func (pc *PeerConnection) configureRTPReceivers(isRenegotiation bool, remoteDesc
 					defer t.mu.Unlock()
 
 					if t.rid != "" {
-						if details := trackDetailsForRID(incomingTracks, t.rid); details != nil {
+						if details := trackDetailsForRID(incomingTracks, mid, t.rid); details != nil {
 							t.id = details.id
 							t.streamID = details.streamID
 							continue

--- a/sdp.go
+++ b/sdp.go
@@ -40,8 +40,12 @@ func trackDetailsForSSRC(trackDetails []trackDetails, ssrc SSRC) *trackDetails {
 	return nil
 }
 
-func trackDetailsForRID(trackDetails []trackDetails, rid string) *trackDetails {
+func trackDetailsForRID(trackDetails []trackDetails, mid, rid string) *trackDetails {
 	for i := range trackDetails {
+		if trackDetails[i].mid != mid {
+			continue
+		}
+
 		for j := range trackDetails[i].rids {
 			if trackDetails[i].rids[j] == rid {
 				return &trackDetails[i]


### PR DESCRIPTION
When there are more than one simulcast media sections in SDP, we need to check mid when parsing detail for the simulcast track.
