### PR TITLE
docs: example: fix potential deadlock

### DIFF
--- a/examples/data-channels-flow-control/main.go
+++ b/examples/data-channels-flow-control/main.go
@@ -70,7 +70,7 @@ func createOfferer() *webrtc.PeerConnection {
 			err2 := dc.Send(buf)
 			check(err2)
 
-			if dc.BufferedAmount()+uint64(len(buf)) > maxBufferedAmount {
+			if dc.BufferedAmount() > maxBufferedAmount {
 				// Wait until the bufferedAmount becomes lower than the threshold
 				<-sendMoreCh
 			}


### PR DESCRIPTION
#### Description

At the current state of the code the deadlock is not achievable, but if `bufferedAmountLowThreshold` and `maxBufferedAmount` were to get changed up, it could happen.
Example: If `bufferedAmountLowThreshold = 1024`,
`maxBufferedAmount = 1280`, then if a message of len 999 is sent, `BufferedAmount()` could return `999`, and the condition would still evaluate to `true` (999 + 999 > 1280).
Since `bufferedAmountLowThreshold` was never exceeded, the `OnBufferedAmountLow` event would never fire, so we're stuck.

Related: #2474 

#### Reference issue

