### PR TITLE
Docs: correct `OnBufferedAmountLow` condition

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -578,7 +578,7 @@ func (d *DataChannel) SetBufferedAmountLowThreshold(th uint64) {
 }
 
 // OnBufferedAmountLow sets an event handler which is invoked when
-// the number of bytes of outgoing data becomes lower than the
+// the number of bytes of outgoing data becomes lower than or equal to the
 // BufferedAmountLowThreshold.
 func (d *DataChannel) OnBufferedAmountLow(f func()) {
 	d.mu.Lock()

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -246,7 +246,7 @@ func (d *DataChannel) SetBufferedAmountLowThreshold(th uint64) {
 }
 
 // OnBufferedAmountLow sets an event handler which is invoked when
-// the number of bytes of outgoing data becomes lower than the
+// the number of bytes of outgoing data becomes lower than or equal to the
 // BufferedAmountLowThreshold.
 func (d *DataChannel) OnBufferedAmountLow(f func()) {
 	if d.onBufferedAmountLow != nil {


### PR DESCRIPTION
#### Description

This is in line with
* the docs for `BufferedAmountLowThreshold` ("When the bufferedAmount decreases from above this threshold to equal or below it")
* The actual code in `pion/sctp`: https://github.com/pion/sctp/blob/d6446e3b0d0495d9974e68fec9b7fdb79c018ca1/stream.go#L422
* The Web WebRTC spec: https://w3c.github.io/webrtc-pc/#event-datachannel-bufferedamountlow

This came up in [this discussion](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/merge_requests/144#note_2903094).

Related: #2473.

#### Reference issue

