### PR TITLE
dtlstransport: Add ExtendedMasterSecret, ClientCAs, RootCAs, ClientAuth

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -316,7 +316,7 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 			}(),
 			ClientAuth:         dtls.RequireAnyClientCert,
 			LoggerFactory:      t.api.settingEngine.LoggerFactory,
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: !t.api.settingEngine.dtls.disableInsecureSkipVerify,
 		}, nil
 	}
 
@@ -331,10 +331,17 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 		dtlsConfig.ReplayProtectionWindow = int(*t.api.settingEngine.replayProtection.DTLS)
 	}
 
+	if t.api.settingEngine.dtls.clientAuth != nil {
+		dtlsConfig.ClientAuth = *t.api.settingEngine.dtls.clientAuth
+	}
+
 	dtlsConfig.FlightInterval = t.api.settingEngine.dtls.retransmissionInterval
 	dtlsConfig.InsecureSkipVerifyHello = t.api.settingEngine.dtls.insecureSkipHelloVerify
 	dtlsConfig.EllipticCurves = t.api.settingEngine.dtls.ellipticCurves
 	dtlsConfig.ConnectContextMaker = t.api.settingEngine.dtls.connectContextMaker
+	dtlsConfig.ExtendedMasterSecret = t.api.settingEngine.dtls.extendedMasterSecret
+	dtlsConfig.ClientCAs = t.api.settingEngine.dtls.clientCAs
+	dtlsConfig.RootCAs = t.api.settingEngine.dtls.rootCAs
 
 	// Connect as DTLS Client/Server, function is blocking and we
 	// must not hold the DTLSTransport lock

--- a/settingengine.go
+++ b/settingengine.go
@@ -8,6 +8,7 @@ package webrtc
 
 import (
 	"context"
+	"crypto/x509"
 	"io"
 	"net"
 	"time"
@@ -61,10 +62,15 @@ type SettingEngine struct {
 		SRTCP *uint
 	}
 	dtls struct {
-		insecureSkipHelloVerify bool
-		retransmissionInterval  time.Duration
-		ellipticCurves          []dtlsElliptic.Curve
-		connectContextMaker     func() (context.Context, func())
+		insecureSkipHelloVerify   bool
+		disableInsecureSkipVerify bool
+		retransmissionInterval    time.Duration
+		ellipticCurves            []dtlsElliptic.Curve
+		connectContextMaker       func() (context.Context, func())
+		extendedMasterSecret      dtls.ExtendedMasterSecretType
+		clientAuth                *dtls.ClientAuthType
+		clientCAs                 *x509.CertPool
+		rootCAs                   *x509.CertPool
 	}
 	sctp struct {
 		maxReceiveBufferSize uint32
@@ -368,6 +374,12 @@ func (e *SettingEngine) SetDTLSInsecureSkipHelloVerify(skip bool) {
 	e.dtls.insecureSkipHelloVerify = skip
 }
 
+// SetDTLSDisableInsecureSkipVerify sets the disable skip insecure verify flag for DTLS.
+// This controls whether a client verifies the server's certificate chain and host name.
+func (e *SettingEngine) SetDTLSDisableInsecureSkipVerify(disable bool) {
+	e.dtls.disableInsecureSkipVerify = disable
+}
+
 // SetDTLSEllipticCurves sets the elliptic curves for DTLS.
 func (e *SettingEngine) SetDTLSEllipticCurves(ellipticCurves ...dtlsElliptic.Curve) {
 	e.dtls.ellipticCurves = ellipticCurves
@@ -382,6 +394,26 @@ func (e *SettingEngine) SetDTLSEllipticCurves(ellipticCurves ...dtlsElliptic.Cur
 //	}
 func (e *SettingEngine) SetDTLSConnectContextMaker(connectContextMaker func() (context.Context, func())) {
 	e.dtls.connectContextMaker = connectContextMaker
+}
+
+// SetDTLSExtendedMasterSecret sets the extended master secret type for DTLS.
+func (e *SettingEngine) SetDTLSExtendedMasterSecret(extendedMasterSecret dtls.ExtendedMasterSecretType) {
+	e.dtls.extendedMasterSecret = extendedMasterSecret
+}
+
+// SetDTLSClientAuth sets the client auth type for DTLS.
+func (e *SettingEngine) SetDTLSClientAuth(clientAuth dtls.ClientAuthType) {
+	e.dtls.clientAuth = &clientAuth
+}
+
+// SetDTLSClientCAs sets the client CA certificate pool for DTLS certificate verification.
+func (e *SettingEngine) SetDTLSClientCAs(clientCAs *x509.CertPool) {
+	e.dtls.clientCAs = clientCAs
+}
+
+// SetDTLSRootCAs sets the root CA certificate pool for DTLS certificate verification.
+func (e *SettingEngine) SetDTLSRootCAs(rootCAs *x509.CertPool) {
+	e.dtls.rootCAs = rootCAs
 }
 
 // SetSCTPMaxReceiveBufferSize sets the maximum receive buffer size.


### PR DESCRIPTION
#### Description

These changes add the following options to the `SettingsEngine`, in order to allow connections to verify certificates:
- `disableInsecureSkipVerify`: disables the insecure skip verify flag for DTLS.
- `extendedMasterSecret`: sets the extended master secret type for DTLS.
- `clientAuth`: sets the client auth type for DTLS.
- `clientCAs`: sets the client CA certificate pool for DTLS certificate verification.
- `rootCAs`: sets the root CA certificate pool for DTLS certificate verification.

#### Reference issue
None
