### PR TITLE
Improvement to rtp-to-webrtc Example

### DIFF
--- a/examples/rtp-to-webrtc/main.go
+++ b/examples/rtp-to-webrtc/main.go
@@ -34,6 +34,15 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	// Increase the UDP receive buffer size
+	// Default UDP buffer sizes vary on different operating systems
+	bufferSize := 300000 // 300KB
+	err = listener.SetReadBuffer(bufferSize)
+	if err != nil {
+		panic(err)
+	}
+
 	defer func() {
 		if err = listener.Close(); err != nil {
 			panic(err)


### PR DESCRIPTION
#### Description

The default UDP buffer size on certain operating systems is too small (Windows 10/11 is ~32KB, Ubuntu 22.04 is ~208KB). This results in severe video freezing and packet-loss. This small feature increases the UDP receive buffer size to 300KB.

The main purpose of this is to make new users/developers aware that buffers may need to be increased on a case-by-case basis (since it isn't very well documented online).

#### Reference issue
Fixes #2496 
