### PR TITLE
Document the "empty defaults" behaviour of NewAPI fn

### DIFF
--- a/api.go
+++ b/api.go
@@ -25,6 +25,10 @@ type API struct {
 }
 
 // NewAPI Creates a new API object for keeping semi-global settings to WebRTC objects
+//
+// WARNING: the resulting API won't work the same as the default webrtc.NewPeerConnection()
+// until default codecs and interceptors are configured. For an example of how to do that,
+// see the body of the webrtc.NewPeerConnection() function.
 func NewAPI(options ...func(*API)) *API {
 	a := &API{
 		interceptor:         &interceptor.NoOp{},


### PR DESCRIPTION
#### Description

I think `webrtc.NewAPI` docstring needs needs an **ALL CAPS BOLD WARNING TEXT**  and a link to an example of how to set it up to so that the resulting `webrtc.NewPeerConnection()`s will behave exactly the same as the ones you get from the default `webrtc.NewPeerConnection()`.

#### Reference issue
Fixes https://github.com/pion/webrtc/issues/2516
