### PR TITLE
Fix checkNegotiationNeeded panic after ReplaceTrack(nil)

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -400,6 +400,14 @@ func (pc *PeerConnection) checkNegotiationNeeded() bool { //nolint:gocognit
 					return true
 				}
 				track := sender.Track()
+				if track == nil {
+					// Situation when sender's track is nil could happen when
+					// a) replaceTrack(nil) is called
+					// b) removeTrack() is called, changing the transceiver's direction to inactive
+					// As t.Direction() in this branch is either sendrecv or sendonly, we believe (a) option is the case
+					// As calling replaceTrack does not require renegotiation, we skip check for this transceiver
+					continue
+				}
 				if !okMsid || descMsid != track.StreamID()+" "+track.ID() {
 					return true
 				}

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -1323,3 +1323,29 @@ func TestNegotiationNeededWithRecvonlyTrack(t *testing.T) {
 
 	closePairNow(t, pcOffer, pcAnswer)
 }
+
+func TestNegotiationNotNeededAfterReplaceTrackNil(t *testing.T) {
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	pcOffer, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	pcAnswer, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	tr, err := pcOffer.AddTransceiverFromKind(RTPCodecTypeAudio)
+	assert.NoError(t, err)
+
+	assert.NoError(t, signalPair(pcOffer, pcAnswer))
+
+	assert.NoError(t, tr.Sender().ReplaceTrack(nil))
+
+	assert.False(t, pcOffer.checkNegotiationNeeded())
+
+	assert.NoError(t, pcOffer.Close())
+	assert.NoError(t, pcAnswer.Close())
+}


### PR DESCRIPTION
#### Description

I have encountered the following application panic with peerConnection using OnNegotiationNeeded handler:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1677cea]

goroutine 1346 [running]:
github.com/pion/webrtc/v3.(*PeerConnection).checkNegotiationNeeded(0xc0006bb680)
        /-S/vendor/github.com/pion/webrtc/v3/peerconnection.go:403 +0x16ca
github.com/pion/webrtc/v3.(*PeerConnection).negotiationNeededOp(0xc0006bb680)
        /-S/vendor/github.com/pion/webrtc/v3/peerconnection.go:342 +0x10e
github.com/pion/webrtc/v3.(*operations).start(0xc0017fb398)
        /-S/vendor/github.com/pion/webrtc/v3/operations.go:93 +0x63
created by github.com/pion/webrtc/v3.(*operations).Enqueue
        /-S/vendor/github.com/pion/webrtc/v3/operations.go:41 +0x1e5
```