### PR TITLE
Fix data race of RTX packet

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,6 +8,7 @@ Aaron Boushley <boushley@pretzelaux.com>
 Aaron France <aaron.l.france@gmail.com>
 Adam Kiss <masterada@gmail.com>
 Aditya Kumar <k.aditya00@gmail.com>
+Adrian Cable <6544927+adriancable@users.noreply.github.com>
 Adrian Cable <adrian.cable@gmail.com>
 adwpc <adwpc@hotmail.com>
 aggresss <aggresss@163.com>
@@ -200,6 +201,7 @@ Steffen Vogel <post@steffenvogel.de>
 stephanrotolante <stephanrotolante@gmail.com>
 streamer45 <cstcld91@gmail.com>
 Suhas Gaddam <suhas.g.2011@gmail.com>
+sukun <sukunrt@gmail.com>
 Suzuki Takeo <takeo@stko.info>
 sylba2050 <masataka.hisasue@optim.co.jp>
 Tarrence van As <tarrencev@users.noreply.github.com>

--- a/track_remote.go
+++ b/track_remote.go
@@ -131,6 +131,7 @@ func (t *TrackRemote) Read(b []byte) (n int, attributes interceptor.Attributes, 
 	if rtxPacketReceived := r.readRTX(t); rtxPacketReceived != nil {
 		n = copy(b, rtxPacketReceived.pkt)
 		attributes = rtxPacketReceived.attributes
+		rtxPacketReceived.release()
 		err = nil
 	} else {
 		// If there's no separate RTX track (or there's a separate RTX track but no RTX packet waiting), wait for and return


### PR DESCRIPTION
When the TrackRemote.Read reads a rtx packet from the channel and copying the data from the buffer, the buffer can be written by the goroutine of receiveForRTX at the same time, use a buffer pool to fix it.