### PR TITLE
RTX attribute constants should be public

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -32,10 +32,12 @@ const (
 
 	sdesRepairRTPStreamIDURI = "urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id"
 
-	// Attributes returned when Read() returns an RTX packet from a separate RTX stream (distinct SSRC)
-	attributeRtxPayloadType    = "rtx_payload_type"
-	attributeRtxSsrc           = "rtx_ssrc"
-	attributeRtxSequenceNumber = "rtx_sequence_number"
+	// AttributeRtxPayloadType is the interceptor attribute added when Read() returns an RTX packet containing the RTX stream payload type
+	AttributeRtxPayloadType = "rtx_payload_type"
+	// AttributeRtxSsrc is the interceptor attribute added when Read() returns an RTX packet containing the RTX stream SSRC
+	AttributeRtxSsrc = "rtx_ssrc"
+	// AttributeRtxSequenceNumber is the interceptor attribute added when Read() returns an RTX packet containing the RTX stream sequence number
+	AttributeRtxSequenceNumber = "rtx_sequence_number"
 )
 
 func defaultSrtpProtectionProfiles() []dtls.SRTPProtectionProfile {

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -463,9 +463,9 @@ func (r *RTPReceiver) receiveForRtx(ssrc SSRC, rsid string, streamInfo *intercep
 				continue
 			}
 
-			attributes.Set(attributeRtxPayloadType, b[1]&0x7F)
-			attributes.Set(attributeRtxSequenceNumber, binary.BigEndian.Uint16(b[2:4]))
-			attributes.Set(attributeRtxSsrc, binary.BigEndian.Uint32(b[8:12]))
+			attributes.Set(AttributeRtxPayloadType, b[1]&0x7F)
+			attributes.Set(AttributeRtxSequenceNumber, binary.BigEndian.Uint16(b[2:4]))
+			attributes.Set(AttributeRtxSsrc, binary.BigEndian.Uint32(b[8:12]))
 
 			b[1] = (b[1] & 0x80) | uint8(track.track.PayloadType())
 			b[2] = b[headerLength]


### PR DESCRIPTION
My earlier PR #2592 added support for distinct-SSRC RTX packets, returning RTX packet info in the attributes. But, the constants for the attribute names (which should be part of the public API) were erroneously made private due to a typo. This fixes that.
