### PR TITLE
Allow multiple negotiated A/V codecs respectively

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -490,10 +490,10 @@ func (m *MediaEngine) updateFromRemoteDescription(desc sdp.SessionDescription) e
 	for _, media := range desc.MediaDescriptions {
 		var typ RTPCodecType
 		switch {
-		case !m.negotiatedAudio && strings.EqualFold(media.MediaName.Media, "audio"):
+		case strings.EqualFold(media.MediaName.Media, "audio"):
 			m.negotiatedAudio = true
 			typ = RTPCodecTypeAudio
-		case !m.negotiatedVideo && strings.EqualFold(media.MediaName.Media, "video"):
+		case strings.EqualFold(media.MediaName.Media, "video"):
 			m.negotiatedVideo = true
 			typ = RTPCodecTypeVideo
 		default:

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -72,7 +72,7 @@ type RTPReceiver struct {
 	rtxPool sync.Pool
 }
 
-// NewRTPReceiver constructs a new RTPReceiver
+// NewRTPReceiver constructs a new RTPReceiver //
 func (api *API) NewRTPReceiver(kind RTPCodecType, transport *DTLSTransport) (*RTPReceiver, error) {
 	if transport == nil {
 		return nil, errRTPReceiverDTLSTransportNil

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -72,7 +72,7 @@ type RTPReceiver struct {
 	rtxPool sync.Pool
 }
 
-// NewRTPReceiver constructs a new RTPReceiver //
+// NewRTPReceiver constructs a new RTPReceiver
 func (api *API) NewRTPReceiver(kind RTPCodecType, transport *DTLSTransport) (*RTPReceiver, error) {
 	if transport == nil {
 		return nil, errRTPReceiverDTLSTransportNil


### PR DESCRIPTION
#### Description

Pion currently restricts the negotiated audio codec and negotiated video codec to the first exact / partial matches it finds in a remote description.

This causes issues in the following scenario:

- Call `RegisterCodec()`.
- Call `AddTransceiver()` for multiple video codecs / multiple audio codecs.
- Pion instance receives a remote description, call `SetRemoteDescription()` => This updates the list of negotiated codecs.
- Pion instance creates an answer, call `CreateAnswer()`.
- Pion instance sets the local description, call `SetLocalDescription` => There is a conflict here between what transceivers have been configured and the negotiated codecs filtered down from the remote description.

#### Reference issue
Fixes #...
