### PR TITLE
Answer to paused simucalst stream correctly

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -22,6 +22,8 @@ const (
 
 	sdpAttributeRid = "rid"
 
+	sdpAttributeSimulcast = "simulcast"
+
 	rtpOutboundMTU = 1200
 
 	rtpPayloadTypeBitmask = 0x7F


### PR DESCRIPTION
#### Description
If the publisher sends an offer with paused simulcast stream like `a=simucalst:send 1;~2;~3`, the sfu needs to respond with paused stream too, otherwise, it will make the publisher's inactive encoding to become active unintentionally.

#### Reference issue
Fixes #...
