### PR TITLE
To cover some cases that attributes are omitted from SDP

### DIFF
--- a/sdp.go
+++ b/sdp.go
@@ -820,10 +820,7 @@ func codecsFromMediaDescription(m *sdp.MediaDescription) (out []RTPCodecParamete
 
 		codec, err := s.GetCodecForPayloadType(uint8(payloadType))
 		if err != nil {
-			if payloadType == 0 {
-				continue
-			}
-			return nil, err
+			continue
 		}
 
 		channels := uint16(0)
@@ -847,6 +844,9 @@ func codecsFromMediaDescription(m *sdp.MediaDescription) (out []RTPCodecParamete
 			RTPCodecCapability: RTPCodecCapability{m.MediaName.Media + "/" + codec.Name, codec.ClockRate, channels, codec.Fmtp, feedback},
 			PayloadType:        PayloadType(payloadType),
 		})
+	}
+	if out == nil {
+		return nil, fmt.Errorf("no valid codecs found")
 	}
 
 	return out, nil


### PR DESCRIPTION
#### Description
Sometimes, when trying to connect to a specific service, the connection fails 
because the media stream's payload type is described in the SDP that comes down through the offer, 
but the codec information does not appear in the attribute. 
The client only needs to negotiate with the options properly described, so I thought I'd fix it like this.

example
```
v=0
o=root 1216600408 1216600408 IN IP4 10.13.129.187
s=AtlasLabs-MediaServer
c=IN IP4 3.35.132.87
t=0 0
m=audio 12852 RTP/AVP 107 8 101
a=rtpmap:107 opus/48000/2
a=fmtp:107 useinbandfec=1
a=rtpmap:101 telephone-event/8000
a=fmtp:101 0-16
a=ptime:20
a=maxptime:20
a=sendrecv
```

`a=rtpmap:8 PCMA/8000` is expected but not included


#### Reference issue
Fixes #...