### PR TITLE
Fix interceptor.RTCPReaderFunc typo

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -508,7 +508,7 @@ func (t *DTLSTransport) streamsForSSRC(ssrc SSRC, streamInfo interceptor.StreamI
 		return nil, nil, nil, nil, err
 	}
 
-	rtcpInterceptor := t.api.interceptor.BindRTCPReader(interceptor.RTPReaderFunc(func(in []byte, a interceptor.Attributes) (n int, attributes interceptor.Attributes, err error) {
+	rtcpInterceptor := t.api.interceptor.BindRTCPReader(interceptor.RTCPReaderFunc(func(in []byte, a interceptor.Attributes) (n int, attributes interceptor.Attributes, err error) {
 		n, err = rtcpReadStream.Read(in)
 		return n, a, err
 	}))

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -325,7 +325,7 @@ func (r *RTPSender) Send(parameters RTPSendParameters) error {
 		)
 
 		trackEncoding.rtcpInterceptor = r.api.interceptor.BindRTCPReader(
-			interceptor.RTPReaderFunc(func(in []byte, a interceptor.Attributes) (n int, attributes interceptor.Attributes, err error) {
+			interceptor.RTCPReaderFunc(func(in []byte, a interceptor.Attributes) (n int, attributes interceptor.Attributes, err error) {
 				n, err = trackEncoding.srtpStream.Read(in)
 				return n, a, err
 			}),


### PR DESCRIPTION
#### Description

#### Reference issue
Fixes interceptor.RTCPReaderFunc typo
Although interceptor.RTCPReaderFunc and interceptor.RTPReaderFunc have the same signature, at interceptor.BindRTCPReader should use interceptor.RTCPReaderFunc
