### PR TITLE
Support TrackLocal RTX

### DIFF
--- a/sdp.go
+++ b/sdp.go
@@ -389,7 +389,13 @@ func addSenderSDP(
 
 		sendParameters := sender.GetParameters()
 		for _, encoding := range sendParameters.Encodings {
+			if encoding.RTX.SSRC != 0 {
+				media = media.WithValueAttribute(sdp.AttrKeySSRCGroup, fmt.Sprintf("FID %d %d", encoding.SSRC, encoding.RTX.SSRC))
+			}
 			media = media.WithMediaSource(uint32(encoding.SSRC), track.StreamID() /* cname */, track.StreamID() /* streamLabel */, track.ID())
+			if encoding.RTX.SSRC != 0 {
+				media = media.WithMediaSource(uint32(encoding.RTX.SSRC), track.StreamID() /* cname */, track.StreamID() /* streamLabel */, track.ID())
+			}
 			if !isPlanB {
 				media = media.WithPropertyAttribute("msid:" + track.StreamID() + " " + track.ID())
 			}

--- a/settingengine.go
+++ b/settingengine.go
@@ -92,6 +92,7 @@ type SettingEngine struct {
 	srtpProtectionProfiles                    []dtls.SRTPProtectionProfile
 	receiveMTU                                uint
 	iceMaxBindingRequests                     *uint16
+	trackLocalRtx                             bool
 }
 
 // getReceiveMTU returns the configured MTU. If SettingEngine's MTU is configured to 0 it returns the default
@@ -436,4 +437,9 @@ func (e *SettingEngine) SetSCTPMaxReceiveBufferSize(maxReceiveBufferSize uint32)
 // This allow usage of Ciphers that are reserved for private usage.
 func (e *SettingEngine) SetDTLSCustomerCipherSuites(customCipherSuites func() []dtls.CipherSuite) {
 	e.dtls.customCipherSuites = customCipherSuites
+}
+
+// SetTrackLocalRtx allows track local use RTX.
+func (e *SettingEngine) SetTrackLocalRtx(enable bool) {
+	e.trackLocalRtx = enable
 }

--- a/track_local.go
+++ b/track_local.go
@@ -44,8 +44,9 @@ type TrackLocalContext interface {
 }
 
 type baseTrackLocalContext struct {
-	id              string
-	params          RTPParameters
+	id     string
+	params RTPParameters
+
 	ssrc            SSRC
 	writeStream     TrackLocalWriter
 	rtcpInterceptor interceptor.RTCPReader


### PR DESCRIPTION
#### Description

RetransmittedPacketsReceived/PacketsLost can be accurately measured, if use distinct SSRC to transmit RTX.

See Also: https://github.com/pion/interceptor/pull/229 

#### Reference issue
Supports TrackLocal RTX
