### PR TITLE
Export unexported functions

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -236,6 +236,11 @@ func (t *DTLSTransport) startSRTP() error {
 	return nil
 }
 
+// GetSRTPSession returns the SRTP session
+func (t *DTLSTransport) GetSRTPSession() (*srtp.SessionSRTP, error) {
+       return t.getSRTPSession()
+}
+
 func (t *DTLSTransport) getSRTPSession() (*srtp.SessionSRTP, error) {
 	if value, ok := t.srtpSession.Load().(*srtp.SessionSRTP); ok {
 		return value, nil


### PR DESCRIPTION
#### Description
For performance reasons, some projects need to bypass part of the standard pion path and access the SRTP session directly. This PR exports the GetSRTPSession().
Related to: [https://github.com/pion/srtp/pull/259](https://github.com/pion/srtp/pull/259)

