### PR TITLE
Add RTOMax settings

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -58,6 +58,8 @@ type SCTPTransport struct {
 
 	api *API
 	log logging.LeveledLogger
+	// maximum retransmission timeout
+	rtoMax float64
 }
 
 // NewSCTPTransport creates a new SCTPTransport.
@@ -105,11 +107,12 @@ func (r *SCTPTransport) Start(SCTPCapabilities) error {
 	if dtlsTransport == nil || dtlsTransport.conn == nil {
 		return errSCTPTransportDTLS
 	}
-
+	rtoMax := float64(r.api.settingEngine.sctp.rtoMax) / float64(time.Millisecond)
 	sctpAssociation, err := sctp.Client(sctp.Config{
 		NetConn:              dtlsTransport.conn,
 		MaxReceiveBufferSize: r.api.settingEngine.sctp.maxReceiveBufferSize,
 		LoggerFactory:        r.api.settingEngine.LoggerFactory,
+		RTOMax:               rtoMax,
 	})
 	if err != nil {
 		return err

--- a/settingengine.go
+++ b/settingengine.go
@@ -76,6 +76,7 @@ type SettingEngine struct {
 	}
 	sctp struct {
 		maxReceiveBufferSize uint32
+		rtoMax               time.Duration
 	}
 	sdpMediaLevelFingerprints                 bool
 	answeringDTLSRole                         DTLSRole
@@ -440,4 +441,10 @@ func (e *SettingEngine) SetSCTPMaxReceiveBufferSize(maxReceiveBufferSize uint32)
 // This allow usage of Ciphers that are reserved for private usage.
 func (e *SettingEngine) SetDTLSCustomerCipherSuites(customCipherSuites func() []dtls.CipherSuite) {
 	e.dtls.customCipherSuites = customCipherSuites
+}
+
+// SetSCTPRTOMax sets the maximum retransmission timeout.
+// Leave this 0 for the default timeout.
+func (e *SettingEngine) SetSCTPRTOMax(rtoMax time.Duration) {
+	e.sctp.rtoMax = rtoMax
 }

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -269,3 +269,12 @@ func TestSetSCTPMaxReceiverBufferSize(t *testing.T) {
 	s.SetSCTPMaxReceiveBufferSize(expSize)
 	assert.Equal(t, expSize, s.sctp.maxReceiveBufferSize)
 }
+
+func TestSetSCTPRTOMax(t *testing.T) {
+	s := SettingEngine{}
+	assert.Equal(t, time.Duration(0), s.sctp.rtoMax)
+
+	expSize := time.Second
+	s.SetSCTPRTOMax(expSize)
+	assert.Equal(t, expSize, s.sctp.rtoMax)
+}


### PR DESCRIPTION
#### Description

For this to work, you'll need https://github.com/pion/sctp/pull/303 to get sctp level support for configurable rtoMAX
Adding RTOMax to SettingEngine and passing it on when creating an sctp Client. This will allow low-bandwidth time critical apps to limit the retransmission timeout and better perform under congestion.

#### Reference issue
https://github.com/pion/sctp/issues/181
