### PR TITLE
SampleBuilder: Remove deprecated functions

### DIFF
--- a/pkg/media/samplebuilder/samplebuilder.go
+++ b/pkg/media/samplebuilder/samplebuilder.go
@@ -330,17 +330,6 @@ func (s *SampleBuilder) Pop() *media.Sample {
 	return result
 }
 
-// PopWithTimestamp compiles pushed RTP packets into media samples and then
-// returns the next valid sample with its associated RTP timestamp (or nil, 0 if
-// no sample is compiled).
-func (s *SampleBuilder) PopWithTimestamp() (*media.Sample, uint32) {
-	sample := s.Pop()
-	if sample == nil {
-		return nil, 0
-	}
-	return sample, sample.PacketTimestamp
-}
-
 // seqnumDistance computes the distance between two sequence numbers
 func seqnumDistance(x, y uint16) uint16 {
 	diff := int16(x - y)

--- a/pkg/media/samplebuilder/samplebuilder.go
+++ b/pkg/media/samplebuilder/samplebuilder.go
@@ -353,12 +353,6 @@ func timestampDistance(x, y uint32) uint32 {
 // An Option configures a SampleBuilder.
 type Option func(o *SampleBuilder)
 
-// WithPartitionHeadChecker is obsolete, it does nothing.
-func WithPartitionHeadChecker(interface{}) Option {
-	return func(o *SampleBuilder) {
-	}
-}
-
 // WithPacketReleaseHandler set a callback when the builder is about to release
 // some packet.
 func WithPacketReleaseHandler(h func(*rtp.Packet)) Option {

--- a/pkg/media/samplebuilder/samplebuilder_test.go
+++ b/pkg/media/samplebuilder/samplebuilder_test.go
@@ -26,6 +26,7 @@ type sampleBuilderTest struct {
 type fakeDepacketizer struct {
 	headChecker bool
 	headBytes   []byte
+	alwaysHead  bool
 }
 
 func (f *fakeDepacketizer) Unmarshal(r []byte) ([]byte, error) {
@@ -42,6 +43,10 @@ func (f *fakeDepacketizer) IsPartitionHead(payload []byte) bool {
 	// skip padding
 	if len(payload) < 1 {
 		return false
+	}
+
+	if f.alwaysHead {
+		return true
 	}
 
 	for _, b := range f.headBytes {
@@ -465,16 +470,11 @@ func TestSampleBuilderWithPacketHeadHandler(t *testing.T) {
 	assert.Equal(t, 2, headCount, "two sample heads should have been inspected")
 }
 
-type truePartitionHeadChecker struct{}
-
-func (f *truePartitionHeadChecker) IsPartitionHead([]byte) bool {
-	return true
-}
-
 func TestSampleBuilderData(t *testing.T) {
-	s := New(10, &fakeDepacketizer{}, 1,
-		WithPartitionHeadChecker(&truePartitionHeadChecker{}),
-	)
+	s := New(10, &fakeDepacketizer{
+		headChecker: true,
+		alwaysHead:  true,
+	}, 1)
 	j := 0
 	for i := 0; i < 0x20000; i++ {
 		p := rtp.Packet{

--- a/pkg/media/samplebuilder/samplebuilder_test.go
+++ b/pkg/media/samplebuilder/samplebuilder_test.go
@@ -465,15 +465,6 @@ func TestSampleBuilderWithPacketHeadHandler(t *testing.T) {
 	assert.Equal(t, 2, headCount, "two sample heads should have been inspected")
 }
 
-func TestPopWithTimestamp(t *testing.T) {
-	t.Run("Crash on nil", func(t *testing.T) {
-		s := New(0, &fakeDepacketizer{}, 1)
-		sample, timestamp := s.PopWithTimestamp()
-		assert.Nil(t, sample)
-		assert.Equal(t, uint32(0), timestamp)
-	})
-}
-
 type truePartitionHeadChecker struct{}
 
 func (f *truePartitionHeadChecker) IsPartitionHead([]byte) bool {
@@ -495,11 +486,11 @@ func TestSampleBuilderData(t *testing.T) {
 		}
 		s.Push(&p)
 		for {
-			sample, ts := s.PopWithTimestamp()
+			sample := s.Pop()
 			if sample == nil {
 				break
 			}
-			assert.Equal(t, ts, uint32(j+42), "timestamp")
+			assert.Equal(t, sample.PacketTimestamp, uint32(j+42), "timestamp")
 			assert.Equal(t, len(sample.Data), 1, "data length")
 			assert.Equal(t, byte(j), sample.Data[0], "data")
 			j++


### PR DESCRIPTION
Sample returned by `Pop()` contains `PacketTimestamp` field now, so `PopWithTimestamp()` is redundant.
As we're now preparing v4, it's good time to remove it.

---

Use Sample.PacketTimestamp field instead.
    
Migration example:
```diff
- sample, timestamp := s.PopWithTimestamp()
+ sample := s.Pop()
+ timestamp := sample.PacketTimestamp
```

---

SampleBuilder: Remove WithPartitionHeadChecker

Deprecated by https://github.com/pion/webrtc/pull/1928