### PR TITLE
Drop reference to detached datachannels

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2018,6 +2018,9 @@ func (pc *PeerConnection) CreateDataChannel(label string, options *DataChannelIn
 
 	pc.sctpTransport.lock.Lock()
 	pc.sctpTransport.dataChannels = append(pc.sctpTransport.dataChannels, d)
+	if d.ID() != nil {
+		pc.sctpTransport.dataChannelIDsUsed[*d.ID()] = struct{}{}
+	}
 	pc.sctpTransport.dataChannelsRequested++
 	pc.sctpTransport.lock.Unlock()
 

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -10,11 +10,15 @@ import "testing"
 
 func TestGenerateDataChannelID(t *testing.T) {
 	sctpTransportWithChannels := func(ids []uint16) *SCTPTransport {
-		ret := &SCTPTransport{dataChannels: []*DataChannel{}}
+		ret := &SCTPTransport{
+			dataChannels:       []*DataChannel{},
+			dataChannelIDsUsed: make(map[uint16]struct{}),
+		}
 
 		for i := range ids {
 			id := ids[i]
 			ret.dataChannels = append(ret.dataChannels, &DataChannel{id: &id})
+			ret.dataChannelIDsUsed[id] = struct{}{}
 		}
 
 		return ret
@@ -45,6 +49,9 @@ func TestGenerateDataChannelID(t *testing.T) {
 		}
 		if *idPtr != testCase.result {
 			t.Errorf("Wrong id: %d expected %d", *idPtr, testCase.result)
+		}
+		if _, ok := testCase.s.dataChannelIDsUsed[*idPtr]; !ok {
+			t.Errorf("expected new id to be added to the map: %d", *idPtr)
 		}
 	}
 }


### PR DESCRIPTION
This allows users of detached datachannels to garbage collect resources associated with the datachannel and the sctp stream. There is no functional change here.

Fixes #2672 
