### PR TITLE
handle the case where TrackRemote payload type is 0 (PCMU)

### DIFF
--- a/track_remote.go
+++ b/track_remote.go
@@ -153,7 +153,8 @@ func (t *TrackRemote) checkAndUpdateTrack(b []byte) error {
 		return errRTPTooShort
 	}
 
-	if payloadType := PayloadType(b[1] & rtpPayloadTypeBitmask); payloadType != t.PayloadType() {
+	payloadType := PayloadType(b[1] & rtpPayloadTypeBitmask)
+	if payloadType != t.PayloadType() || len(t.params.Codecs) == 0 {
 		t.mu.Lock()
 		defer t.mu.Unlock()
 


### PR DESCRIPTION
#### Description
In the case where a remote track is sending PCMU with payload type 0, `checkAndUpdateTrack` will fail to update the track codec and params (because `t.PayloadType()` is already 0). Add an extra check to handle this case.