### PR TITLE
Fix deprecated golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,8 @@
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   misspell:
     locale: US
   exhaustive:
@@ -110,6 +111,7 @@ linters:
 
 issues:
   exclude-use-default: false
+  exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
     - path: (examples|main\.go|_test\.go)
@@ -121,6 +123,3 @@ issues:
     - path: cmd
       linters:
         - forbidigo
-
-run:
-  skip-dirs-use-default: false


### PR DESCRIPTION
Executing `golangci-lint run` using old config generates the following warnings:

WARN [config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`. 
WARN [config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`.

#### Description
Before change:
<img width="1123" alt="Screenshot 2024-04-01 at 20 59 13" src="https://github.com/pion/webrtc/assets/50456/e3287f79-5923-4e94-9168-ef812e7e6b8f">

After change:
<img width="1124" alt="Screenshot 2024-04-01 at 21 26 42" src="https://github.com/pion/webrtc/assets/50456/06bf550e-06c6-44c5-9a91-36ffdc9760ea">


#### Reference issue
No issue filed for this warning.
