### PR TITLE
Retract v3.2.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.20.0
 )
+
+// SCTP ZeroChecksum implementation has a interoperability bug
+// 3.2.28 can only work against itself, not other versions of webrtc
+retract v3.2.28


### PR DESCRIPTION
The SCTP implementation used in v3.2.28 fails to establish a connection with other WebRTC implementations. The implementation of ZeroChecksum assumes incorrectly that the feature is bi-directional

SCTP ZeroChecksum is actually a uni-directional feature which causes the Assocations to be unable to communicate.