### PR TITLE
Avoid dropping packets immediately in mux

### DIFF
--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -15,8 +15,13 @@ import (
 	"github.com/pion/transport/v3/packetio"
 )
 
-// The maximum amount of data that can be buffered before returning errors.
-const maxBufferSize = 1000 * 1000 // 1MB
+const (
+	// The maximum amount of data that can be buffered before returning errors.
+	maxBufferSize = 1000 * 1000 // 1MB
+
+	// How many total pending packets can be cached
+	maxPendingPackets = 15
+)
 
 // Config collects the arguments to mux.Mux construction into
 // a single structure
@@ -33,6 +38,8 @@ type Mux struct {
 	endpoints  map[*Endpoint]MatchFunc
 	bufferSize int
 	closedCh   chan struct{}
+
+	pendingPackets [][]byte
 
 	log logging.LeveledLogger
 }
@@ -65,6 +72,8 @@ func (m *Mux) NewEndpoint(f MatchFunc) *Endpoint {
 	m.lock.Lock()
 	m.endpoints[e] = f
 	m.lock.Unlock()
+
+	go m.handlePendingPackets(e, f)
 
 	return e
 }
@@ -127,6 +136,11 @@ func (m *Mux) readLoop() {
 }
 
 func (m *Mux) dispatch(buf []byte) error {
+	if len(buf) == 0 {
+		m.log.Warnf("Warning: mux: unable to dispatch zero length packet")
+		return nil
+	}
+
 	var endpoint *Endpoint
 
 	m.lock.Lock()
@@ -139,11 +153,16 @@ func (m *Mux) dispatch(buf []byte) error {
 	m.lock.Unlock()
 
 	if endpoint == nil {
-		if len(buf) > 0 {
-			m.log.Warnf("Warning: mux: no endpoint for packet starting with %d", buf[0])
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
+		if len(m.pendingPackets) >= maxPendingPackets {
+			m.log.Warnf("Warning: mux: no endpoint for packet starting with %d, not adding to queue size(%d)", buf[0], len(m.pendingPackets))
 		} else {
-			m.log.Warnf("Warning: mux: no endpoint for zero length packet")
+			m.log.Warnf("Warning: mux: no endpoint for packet starting with %d, adding to queue size(%d)", buf[0], len(m.pendingPackets))
+			m.pendingPackets = append(m.pendingPackets, append([]byte{}, buf...))
 		}
+
 		return nil
 	}
 
@@ -156,4 +175,21 @@ func (m *Mux) dispatch(buf []byte) error {
 	}
 
 	return err
+}
+
+func (m *Mux) handlePendingPackets(endpoint *Endpoint, matchFunc MatchFunc) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	pendingPackets := make([][]byte, len(m.pendingPackets))
+	for _, buf := range m.pendingPackets {
+		if matchFunc(buf) {
+			if _, err := endpoint.buffer.Write(buf); err != nil {
+				m.log.Warnf("Warning: mux: error writing packet to endpoint from pending queue: %s", err)
+			}
+		} else {
+			pendingPackets = append(pendingPackets, buf)
+		}
+	}
+	m.pendingPackets = pendingPackets
 }


### PR DESCRIPTION
#### Description
As discussed in [this](https://gophers.slack.com/archives/CAK2124AG/p1703996245888079) thread on the Gophers Slack, internal/mux needs a pending queue for packets that would dropped in some situations. (e.g. ICE transport blocks until it is in a connected state, losing any DTLS packets received in the meantime)

Sorry, I accidentally closed the issue before. I've reopened an issue with fixes.

#### Reference issue
N/A