### PR TITLE
Hold pc.mu while populating local candidates

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2114,10 +2114,11 @@ func (pc *PeerConnection) addRTPTransceiver(t *RTPTransceiver) {
 // by the ICEAgent since the offer or answer was created.
 func (pc *PeerConnection) CurrentLocalDescription() *SessionDescription {
 	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
 	localDescription := pc.currentLocalDescription
 	iceGather := pc.iceGatherer
 	iceGatheringState := pc.ICEGatheringState()
-	pc.mu.Unlock()
 	return populateLocalCandidates(localDescription, iceGather, iceGatheringState)
 }
 
@@ -2127,10 +2128,11 @@ func (pc *PeerConnection) CurrentLocalDescription() *SessionDescription {
 // PeerConnection is in the stable state, the value is null.
 func (pc *PeerConnection) PendingLocalDescription() *SessionDescription {
 	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
 	localDescription := pc.pendingLocalDescription
 	iceGather := pc.iceGatherer
 	iceGatheringState := pc.ICEGatheringState()
-	pc.mu.Unlock()
 	return populateLocalCandidates(localDescription, iceGather, iceGatheringState)
 }
 


### PR DESCRIPTION
This prevents a race with `checkNegotiationNeeded` that inspects attributes of the SDP's MediaDescriptions. It's a hard to reproduce race but it has happened.