### PR TITLE
Properly handle non-media probes

### DIFF
--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -225,12 +225,59 @@ func Test_InterceptorRegistry_Build(t *testing.T) {
 		},
 	})
 
-	peerConnectionA, err := NewAPI(WithInterceptorRegistry(ir)).NewPeerConnection(Configuration{})
-	assert.NoError(t, err)
-
-	peerConnectionB, err := NewAPI(WithInterceptorRegistry(ir)).NewPeerConnection(Configuration{})
+	peerConnectionA, peerConnectionB, err := NewAPI(WithInterceptorRegistry(ir)).newPair(Configuration{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, 2, registryBuildCount)
 	closePairNow(t, peerConnectionA, peerConnectionB)
+}
+
+func Test_Interceptor_ZeroSSRC(t *testing.T) {
+	to := test.TimeOut(time.Second * 20)
+	defer to.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	track, err := NewTrackLocalStaticRTP(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+	assert.NoError(t, err)
+
+	offerer, answerer, err := newPair()
+	assert.NoError(t, err)
+
+	_, err = offerer.AddTrack(track)
+	assert.NoError(t, err)
+
+	probeReceiverCreated := make(chan struct{})
+
+	go func() {
+		sequenceNumber := uint16(0)
+		for range time.NewTicker(time.Millisecond * 20).C {
+			track.mu.Lock()
+			if len(track.bindings) == 1 {
+				_, err = track.bindings[0].writeStream.WriteRTP(&rtp.Header{
+					Version:        2,
+					SSRC:           0,
+					SequenceNumber: sequenceNumber,
+				}, []byte{0, 1, 2, 3, 4, 5})
+				assert.NoError(t, err)
+			}
+			sequenceNumber++
+			track.mu.Unlock()
+
+			if nonMediaBandwidthProbe, ok := answerer.nonMediaBandwidthProbe.Load().(*RTPReceiver); ok {
+				assert.Equal(t, len(nonMediaBandwidthProbe.Tracks()), 1)
+				close(probeReceiverCreated)
+				return
+			}
+		}
+	}()
+
+	assert.NoError(t, signalPair(offerer, answerer))
+
+	peerConnectionConnected := untilConnectionState(PeerConnectionStateConnected, offerer, answerer)
+	peerConnectionConnected.Wait()
+
+	<-probeReceiverCreated
+	closePairNow(t, offerer, answerer)
 }

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -1528,7 +1528,7 @@ func TestPeerConnection_Simulcast_RTX(t *testing.T) {
 					SequenceNumber: sequenceNumber,
 					PayloadType:    96,
 					Padding:        true,
-					SSRC:           uint32(i),
+					SSRC:           uint32(i + 1),
 				},
 				Payload: []byte{0x00, 0x02},
 			}
@@ -1547,7 +1547,7 @@ func TestPeerConnection_Simulcast_RTX(t *testing.T) {
 					Version:        2,
 					SequenceNumber: sequenceNumber,
 					PayloadType:    96,
-					SSRC:           uint32(i),
+					SSRC:           uint32(i + 1),
 				},
 				Payload: []byte{0x00},
 			}
@@ -1591,7 +1591,7 @@ func TestPeerConnection_Simulcast_RTX(t *testing.T) {
 					Version:        2,
 					SequenceNumber: sequenceNumber,
 					PayloadType:    96,
-					SSRC:           uint32(i),
+					SSRC:           uint32(i + 1),
 				},
 				Payload: []byte{0x00},
 			}

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -1046,7 +1046,7 @@ func TestPeerConnection_Renegotiation_Simulcast(t *testing.T) {
 			for ssrc, rid := range rids {
 				header := &rtp.Header{
 					Version:        2,
-					SSRC:           uint32(ssrc),
+					SSRC:           uint32(ssrc + 1),
 					SequenceNumber: sequenceNumber,
 					PayloadType:    96,
 				}

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -201,7 +201,7 @@ func (r *RTPReceiver) startReceive(parameters RTPReceiveParameters) error {
 
 		var t *trackStreams
 		for idx, ts := range r.tracks {
-			if ts.track != nil && parameters.Encodings[i].SSRC != 0 && ts.track.SSRC() == parameters.Encodings[i].SSRC {
+			if ts.track != nil && ts.track.SSRC() == parameters.Encodings[i].SSRC {
 				t = &r.tracks[idx]
 				break
 			}
@@ -210,12 +210,10 @@ func (r *RTPReceiver) startReceive(parameters RTPReceiveParameters) error {
 			return fmt.Errorf("%w: %d", errRTPReceiverWithSSRCTrackStreamNotFound, parameters.Encodings[i].SSRC)
 		}
 
-		if parameters.Encodings[i].SSRC != 0 {
-			t.streamInfo = createStreamInfo("", parameters.Encodings[i].SSRC, 0, codec, globalParams.HeaderExtensions)
-			var err error
-			if t.rtpReadStream, t.rtpInterceptor, t.rtcpReadStream, t.rtcpInterceptor, err = r.transport.streamsForSSRC(parameters.Encodings[i].SSRC, *t.streamInfo); err != nil {
-				return err
-			}
+		t.streamInfo = createStreamInfo("", parameters.Encodings[i].SSRC, 0, codec, globalParams.HeaderExtensions)
+		var err error
+		if t.rtpReadStream, t.rtpInterceptor, t.rtcpReadStream, t.rtcpInterceptor, err = r.transport.streamsForSSRC(parameters.Encodings[i].SSRC, *t.streamInfo); err != nil {
+			return err
 		}
 
 		if rtxSsrc := parameters.Encodings[i].RTX.SSRC; rtxSsrc != 0 {


### PR DESCRIPTION
libwebrtc has started sending media probes on an unannounced SSRC(0). This adds a special case to accept SSRC 0 and Read the RTP packets. This causes the TWCC reports to properly be generated.
