### PR TITLE
Added support for SRTP_NULL_HMAC_SHA1_80 cipher

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -377,6 +377,8 @@ func (t *DTLSTransport) Start(remoteParameters DTLSParameters) error {
 		t.srtpProtectionProfile = srtp.ProtectionProfileAeadAes256Gcm
 	case dtls.SRTP_AES128_CM_HMAC_SHA1_80:
 		t.srtpProtectionProfile = srtp.ProtectionProfileAes128CmHmacSha1_80
+	case dtls.SRTP_NULL_HMAC_SHA1_80:
+		t.srtpProtectionProfile = srtp.ProtectionProfileNullHmacSha1_80
 	default:
 		t.onStateChange(DTLSTransportStateFailed)
 		return ErrNoSRTPProtectionProfile


### PR DESCRIPTION
Added support for SRTP_NULL_HMAC_SHA1_80 protection profile (cipher). It is disabled by default. You need to use SettingEngine and set list of allowed SRTP protection profiles using its SetSRTPProtectionProfiles function called with dtls.SRTP_NULL_HMAC_SHA1_80 as a parameter. You need to do this for both pion peers. For non-pion ones you may need to enable it somewhere too, as NULL cipher is usually disabled for security reasons.

#### Reference issue
Fixes #2273
