### PR TITLE
Change time.Sleep to time.Ticker in insertable streams example

### DIFF
--- a/examples/insertable-streams/main.go
+++ b/examples/insertable-streams/main.go
@@ -84,8 +84,12 @@ func main() {
 
 		// Send our video file frame at a time. Pace our sending so we send it at the same speed it should be played back as.
 		// This isn't required since the video is timestamped, but we will such much higher loss if we send all at once.
-		sleepTime := time.Millisecond * time.Duration((float32(header.TimebaseNumerator)/float32(header.TimebaseDenominator))*1000)
-		for {
+		//
+		// It is important to use a time.Ticker instead of time.Sleep because
+		// * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
+		// * works around latency issues with Sleep (see https://github.com/golang/go/issues/44343)
+		ticker := time.NewTicker(time.Millisecond * time.Duration((float32(header.TimebaseNumerator)/float32(header.TimebaseDenominator))*1000))
+		for ; true; <-ticker.C {
 			frame, _, ivfErr := ivf.ParseNextFrame()
 			if errors.Is(ivfErr, io.EOF) {
 				fmt.Printf("All frames parsed and sent")
@@ -101,7 +105,6 @@ func main() {
 				frame[i] ^= cipherKey
 			}
 
-			time.Sleep(sleepTime)
 			if ivfErr = videoTrack.WriteSample(media.Sample{Data: frame, Duration: time.Second}); ivfErr != nil {
 				panic(ivfErr)
 			}


### PR DESCRIPTION
#### Description
Hello, 

While looking at the WebRTC examples, I came across the following comment in the "play-from-disk" example:

(line 196-198)
```
// It is important to use a time.Ticker instead of time.Sleep because
// * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
// * works around latency issues with Sleep (see https://github.com/golang/go/issues/44343)
```

However, the "insertable streams" example still uses time.Sleep. I changed the code of the example to use time.Ticker like the "play-from-disk" example.

#### Reference issue
Fixes #2835 
