### PR TITLE
Provide SCTP Association OnClose callback

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -45,6 +45,7 @@ type SCTPTransport struct {
 	// OnStateChange  func()
 
 	onErrorHandler func(error)
+	onCloseHandler func(error)
 
 	sctpAssociation            *sctp.Association
 	onDataChannelHandler       func(*DataChannel)
@@ -176,6 +177,7 @@ func (r *SCTPTransport) acceptDataChannels(a *sctp.Association) {
 		dataChannels = append(dataChannels, dc.dataChannel)
 	}
 	r.lock.RUnlock()
+
 ACCEPT:
 	for {
 		dc, err := datachannel.Accept(a, &datachannel.Config{
@@ -185,6 +187,9 @@ ACCEPT:
 			if !errors.Is(err, io.EOF) {
 				r.log.Errorf("Failed to accept data channel: %v", err)
 				r.onError(err)
+				r.onClose(err)
+			} else {
+				r.onClose(nil)
 			}
 			return
 		}
@@ -232,9 +237,12 @@ ACCEPT:
 			MaxRetransmits:    maxRetransmits,
 		}, r, r.api.settingEngine.LoggerFactory.NewLogger("ortc"))
 		if err != nil {
+			// This data channel is invalid. Close it an log an error.
+			dc.Close()
 			r.log.Errorf("Failed to accept data channel: %v", err)
 			r.onError(err)
-			return
+			// We've received a datachannel with invalid configuration. We can still receive other datachannels.
+			continue ACCEPT
 		}
 
 		<-r.onDataChannel(rtcDC)
@@ -251,8 +259,7 @@ ACCEPT:
 	}
 }
 
-// OnError sets an event handler which is invoked when
-// the SCTP connection error occurs.
+// OnError sets an event handler which is invoked when the SCTP Association errors.
 func (r *SCTPTransport) OnError(f func(err error)) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -262,6 +269,23 @@ func (r *SCTPTransport) OnError(f func(err error)) {
 func (r *SCTPTransport) onError(err error) {
 	r.lock.RLock()
 	handler := r.onErrorHandler
+	r.lock.RUnlock()
+
+	if handler != nil {
+		go handler(err)
+	}
+}
+
+// OnClose sets an event handler which is invoked when the SCTP Association closes.
+func (r *SCTPTransport) OnClose(f func(err error)) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.onCloseHandler = f
+}
+
+func (r *SCTPTransport) onClose(err error) {
+	r.lock.RLock()
+	handler := r.onCloseHandler
 	r.lock.RUnlock()
 
 	if handler != nil {

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -6,7 +6,13 @@
 
 package webrtc
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestGenerateDataChannelID(t *testing.T) {
 	sctpTransportWithChannels := func(ids []uint16) *SCTPTransport {
@@ -53,5 +59,63 @@ func TestGenerateDataChannelID(t *testing.T) {
 		if _, ok := testCase.s.dataChannelIDsUsed[*idPtr]; !ok {
 			t.Errorf("expected new id to be added to the map: %d", *idPtr)
 		}
+	}
+}
+
+func TestSCTPTransportOnClose(t *testing.T) {
+	offerPC, answerPC, err := newPair()
+	require.NoError(t, err)
+
+	answerPC.OnDataChannel(func(dc *DataChannel) {
+		dc.OnMessage(func(msg DataChannelMessage) {
+			dc.Send([]byte("hello"))
+		})
+	})
+
+	recvMsg := make(chan struct{}, 1)
+	offerPC.OnConnectionStateChange(func(state PeerConnectionState) {
+		if state == PeerConnectionStateConnected {
+			defer func() {
+				offerPC.OnConnectionStateChange(nil)
+			}()
+
+			dc, createErr := offerPC.CreateDataChannel(expectedLabel, nil)
+			if createErr != nil {
+				t.Errorf("Failed to create a PC pair for testing")
+				return
+			}
+			dc.OnMessage(func(msg DataChannelMessage) {
+				if !bytes.Equal(msg.Data, []byte("hello")) {
+					t.Error("invalid msg received")
+				}
+				recvMsg <- struct{}{}
+			})
+			dc.OnOpen(func() {
+				dc.Send([]byte("hello"))
+			})
+		}
+	})
+
+	err = signalPair(offerPC, answerPC)
+	require.NoError(t, err)
+
+	select {
+	case <-recvMsg:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	// setup SCTP OnClose callback
+	ch := make(chan error, 1)
+	answerPC.SCTP().OnClose(func(err error) {
+		ch <- err
+	})
+
+	offerPC.Close() // This will trigger sctp onclose callback on remote
+
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
 	}
 }


### PR DESCRIPTION
The only way to detect a remote connection close is to check the state of the SCTP transport.
See:
https://github.com/w3c/webrtc-pc/issues/1799#issuecomment-373394934

>In case it wasn't clear, I'm arguing for an exception for data
channels, saying pc1.close() should fire close on both ends of a data channel, because A) that is useful, and the only way to detect remote closing of a peer connection, and B) it's a workaround for the fact that closing of peer connections isn't advertised to the other end.

Depending on datachannel close to notify us requires out of band protocol agreement as datachannels can be closed by the remote for other reasons. Having access to the SCTP layer we can provide an accurate SCTP Assocation closed event.

