### PR TITLE
Fix SCTPTransport OnClose test

### DIFF
--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -66,6 +66,8 @@ func TestSCTPTransportOnClose(t *testing.T) {
 	offerPC, answerPC, err := newPair()
 	require.NoError(t, err)
 
+	defer closePairNow(t, offerPC, answerPC)
+
 	answerPC.OnDataChannel(func(dc *DataChannel) {
 		dc.OnMessage(func(_ DataChannelMessage) {
 			if err1 := dc.Send([]byte("hello")); err1 != nil {


### PR DESCRIPTION
We need to close both the ends here for all the goroutines to complete. 

The corresponding commit in v3 is here: https://github.com/pion/webrtc/pull/2861/commits/484d89ad38ea47a460fd86db2351823622897932