### PR TITLE
Fix concurrent pc.GracefulClose

### DIFF
--- a/peerconnection_close_test.go
+++ b/peerconnection_close_test.go
@@ -7,6 +7,8 @@
 package webrtc
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -180,7 +182,7 @@ func TestPeerConnection_Close_DuringICE(t *testing.T) {
 	}
 }
 
-func TestPeerConnection_CloseWithIncomingMessages(t *testing.T) {
+func TestPeerConnection_GracefulCloseWithIncomingMessages(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 20)
 	defer lim.Stop()
@@ -285,5 +287,43 @@ func TestPeerConnection_GracefulCloseWhileOpening(t *testing.T) {
 	err = pcAnswer.GracefulClose()
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPeerConnection_GracefulCloseConcurrent(t *testing.T) {
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	for _, mixed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mixed_graceful=%t", mixed), func(t *testing.T) {
+			report := test.CheckRoutinesStrict(t)
+			defer report()
+
+			pc, err := NewPeerConnection(Configuration{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			const gracefulCloseConcurrency = 50
+			var wg sync.WaitGroup
+			wg.Add(gracefulCloseConcurrency)
+			for i := 0; i < gracefulCloseConcurrency; i++ {
+				go func() {
+					defer wg.Done()
+					assert.NoError(t, pc.GracefulClose())
+				}()
+			}
+			if !mixed {
+				if err := pc.Close(); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := pc.GracefulClose(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			wg.Wait()
+		})
 	}
 }


### PR DESCRIPTION
@dgottlieb found an issue in the wild where if concurrent GracefulCloses happen, my wonky atomic bool logic could go awry and cause a leak of sorts and no actual graceful closure. I took some time to clean up the naming and comments in this code while working on the fix which is mainly to wrap a lock around the two bool operations, but also to have a more stringent series of operations when Graceful and normal close are overlapping.