### PR TITLE
Reduce Mux logging on Close

### DIFF
--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -33,15 +33,15 @@ type Config struct {
 
 // Mux allows multiplexing
 type Mux struct {
-	lock       sync.RWMutex
 	nextConn   net.Conn
-	endpoints  map[*Endpoint]MatchFunc
 	bufferSize int
-	closedCh   chan struct{}
+	lock       sync.Mutex
+	endpoints  map[*Endpoint]MatchFunc
 
 	pendingPackets [][]byte
 
-	log logging.LeveledLogger
+	closedCh chan struct{}
+	log      logging.LeveledLogger
 }
 
 // NewMux creates a new Mux


### PR DESCRIPTION
This removes warning logs like:
```
Warning: mux: no endpoint for packet starting with 21
```
when closing the connection. 

Replace RWMutex with Mutex because there's only 1 goroutine reading. 

