### PR TITLE
Return object icluding stat id for selected pair

### DIFF
--- a/icetransport.go
+++ b/icetransport.go
@@ -67,7 +67,7 @@ func (t *ICETransport) GetSelectedCandidatePair() (*ICECandidatePair, error) {
 		return nil, err
 	}
 
-	return &ICECandidatePair{Local: &local, Remote: &remote}, nil
+	return NewICECandidatePair(&local, &remote), nil
 }
 
 // NewICETransport creates a new NewICETransport.


### PR DESCRIPTION
Returning the object with stat id is useful when cross-referencing stats.
