### PR TITLE
fix: fix slice init length

### DIFF
--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -193,7 +193,7 @@ func (m *Mux) handlePendingPackets(endpoint *Endpoint, matchFunc MatchFunc) {
 				m.log.Warnf("Warning: mux: error writing packet to endpoint from pending queue: %s", err)
 			}
 		} else {
-			pendingPackets = append(pendingPackets, buf)
+			pendingPackets = append(pendingPackets, 0, buf)
 		}
 	}
 	m.pendingPackets = pendingPackets


### PR DESCRIPTION
#### Description


The intention here should be to initialize a slice with a capacity of len(m.pendingPackets)  rather than initializing the length of this slice.


#### Reference issue
Fixes #...
