### PR TITLE
Add SetFireOnTrackBeforeFirstRTP

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1245,6 +1245,10 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 			return
 		}
 
+		if pc.api.settingEngine.fireOnTrackBeforeFirstRTP {
+			pc.onTrack(t, receiver)
+			return
+		}
 		go func(track *TrackRemote) {
 			b := make([]byte, pc.api.settingEngine.getReceiveMTU())
 			n, _, err := track.peek(b)

--- a/settingengine.go
+++ b/settingengine.go
@@ -101,6 +101,7 @@ type SettingEngine struct {
 	srtpProtectionProfiles                    []dtls.SRTPProtectionProfile
 	receiveMTU                                uint
 	iceMaxBindingRequests                     *uint16
+	fireOnTrackBeforeFirstRTP                 bool
 }
 
 // getReceiveMTU returns the configured MTU. If SettingEngine's MTU is configured to 0 it returns the default
@@ -490,4 +491,13 @@ func (e *SettingEngine) SetSCTPRTOMax(rtoMax time.Duration) {
 // - Implement custom CandidatePair switching logic
 func (e *SettingEngine) SetICEBindingRequestHandler(bindingRequestHandler func(m *stun.Message, local, remote ice.Candidate, pair *ice.CandidatePair) bool) {
 	e.iceBindingRequestHandler = bindingRequestHandler
+}
+
+// SetFireOnTrackBeforeFirstRTP sets if firing the OnTrack event should happen
+// before any RTP packets are received. Setting this to true will
+// have the Track's Codec and PayloadTypes be initially set to their
+// zero values in the OnTrack handler.
+// Note: This does not yet affect simulcast tracks.
+func (e *SettingEngine) SetFireOnTrackBeforeFirstRTP(fireOnTrackBeforeFirstRTP bool) {
+	e.fireOnTrackBeforeFirstRTP = fireOnTrackBeforeFirstRTP
 }


### PR DESCRIPTION
This will allow getting OnTrack events before RTP packets are received (non-simulcast)