### PR TITLE
Fix race when closing ICE Transport

### DIFF
--- a/icetransport.go
+++ b/icetransport.go
@@ -221,7 +221,7 @@ func (t *ICETransport) stop(shouldGracefullyClose bool) error {
 	gatherer := t.gatherer
 	t.lock.Unlock()
 
-	if t.mux != nil {
+	if mux != nil {
 		var closeErrs []error
 		if shouldGracefullyClose && gatherer != nil {
 			// we can't access icegatherer/icetransport.Close via


### PR DESCRIPTION
Struct member is copied to stack already, `stop` just incorrectly was referencing the member.

Found in CI
