### PR TITLE
Improve `DataChannel.Detach()` docstring

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -438,8 +438,11 @@ func (d *DataChannel) ensureOpen() error {
 	return nil
 }
 
-// Detach allows you to detach the underlying datachannel. This provides
-// an idiomatic API to work with, however it disables the OnMessage callback.
+// Detach allows you to detach the underlying datachannel.
+// This provides an idiomatic API to work with
+// (`io.ReadWriteCloser` with its `.Read()` and `.Write()` methods,
+// as opposed to `.Send()` and `.OnMessage`),
+// however it disables the OnMessage callback.
 // Before calling Detach you have to enable this behavior by calling
 // webrtc.DetachDataChannels(). Combining detached and normal data channels
 // is not supported.


### PR DESCRIPTION
#### Description

It wasn't clear (at least to me)
what "idiomatic API" it's referring to.

But, judging from the `data-channels-detach` example comments,
this is what it's made for.
https://github.com/pion/webrtc/blob/f29ef99b220beb906c60e7f1aebac6c02498daf9/examples/data-channels-detach/main.go#L4

#### Reference issue
None.