### PR TITLE
Use local+remote codecs to generate RTCP Feedback

### DIFF
--- a/rtpcodec.go
+++ b/rtpcodec.go
@@ -136,3 +136,16 @@ func findRTXPayloadType(needle PayloadType, haystack []RTPCodecParameters) Paylo
 
 	return PayloadType(0)
 }
+
+func rtcpFeedbackIntersection(a, b []RTCPFeedback) (out []RTCPFeedback) {
+	for _, aFeedback := range a {
+		for _, bFeeback := range b {
+			if aFeedback.Type == bFeeback.Type && aFeedback.Parameter == bFeeback.Parameter {
+				out = append(out, aFeedback)
+				break
+			}
+		}
+	}
+
+	return
+}

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -78,6 +78,7 @@ func (t *RTPTransceiver) getCodecs() []RTPCodecParameters {
 			if codec.PayloadType == 0 {
 				codec.PayloadType = c.PayloadType
 			}
+			codec.RTCPFeedback = rtcpFeedbackIntersection(codec.RTCPFeedback, c.RTCPFeedback)
 			filteredCodecs = append(filteredCodecs, codec)
 		}
 	}


### PR DESCRIPTION
Update MediaEngine codec creation to take into account remote and local rtcp-fb. Before we would incorrectly always take the remote rtcp-fb and ignore local.

Resolves #2943
Resolves #2944
Resolves #1968

