### PR TITLE
Close interceptor after PeerConnection is closed

### DIFF
--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -187,7 +187,8 @@ func Test_Interceptor_BindUnbind(t *testing.T) {
 		}
 	}()
 
-	closePairNow(t, sender, receiver)
+	assert.NoError(t, sender.GracefulClose())
+	assert.NoError(t, receiver.GracefulClose())
 
 	// Bind/UnbindLocal/RemoteStream should be called from one side.
 	if cnt := atomic.LoadUint32(&cntBindLocalStream); cnt != 1 {

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2209,8 +2209,6 @@ func (pc *PeerConnection) close(shouldGracefullyClose bool) error {
 	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #3)
 	pc.signalingState.Set(SignalingStateClosed)
 
-	closeErrs = append(closeErrs, pc.api.interceptor.Close())
-
 	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #4)
 	pc.mu.Lock()
 	for _, t := range pc.rtpTransceivers {
@@ -2246,6 +2244,9 @@ func (pc *PeerConnection) close(shouldGracefullyClose bool) error {
 	pc.updateConnectionState(pc.ICEConnectionState(), pc.dtlsTransport.State())
 
 	closeErrs = append(closeErrs, doGracefulCloseOps()...)
+
+	// Interceptor closes at the end to prevent Bind from being called after interceptor is closed
+	closeErrs = append(closeErrs, pc.api.interceptor.Close())
 
 	return util.FlattenErrs(closeErrs)
 }


### PR DESCRIPTION
The following panic was encountered in the [stats interceptor](https://github.com/pion/interceptor/tree/master/pkg/stats):

```
panic: sync: WaitGroup is reused before previous Wait has returned

sync.(*WaitGroup).Wait(0xc08227bce0?)
go/_std_1.22/src/sync/waitgroup.go:118 +0x74
github.com/pion/interceptor/pkg/stats.(*Interceptor).Close(0xc08ff1de20?)
github.com/pion/interceptor.(*Chain).Close(0xc0423bbb90?)
github.com/pion/webrtc/v4.(*PeerConnection).close(0xc0423bbb80, 0x0)
github.com/pion/webrtc/v4.(*PeerConnection).Close(...)
github.com/pion/webrtc/v4.(*PeerConnection).startTransports.func1.1()
```

It occurs because [wg.Add](https://github.com/pion/interceptor/blob/master/pkg/stats/interceptor.go#L133) is called after [wg.Wait](https://github.com/pion/interceptor/blob/master/pkg/stats/interceptor.go#L144). This implies that `Bind` was called after the interceptor had already been closed, which appears to be incorrect.

I was able to reproduce this issue in tests, but the reproduction is highly flaky (it might only work on my machine with the provided constants) and takes a long time to run. As a result, it doesn't seem practical to include it as a test case:

https://gist.github.com/aalekseevx/5b31eed4fe3e524502217cc02273345e

The proposed solution is to ensure that `interceptor.close()` is called only after the peer connection is fully closed—whether in a graceful or non-graceful manner—so that no track can be added afterward.