### PR TITLE
Add Encoder/Decoder info to stats

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -567,6 +567,9 @@ type InboundRTPStreamStats struct {
 	// these numbers are not expected to match the numbers seen on sending. Not all
 	// OSes make this information available.
 	PerDSCPPacketsReceived map[string]uint32 `json:"perDscpPacketsReceived"`
+
+	// Identifies the decoder implementation used. This is useful for diagnosing interoperability issues.
+	DecoderImplementation string `json:"decoderImplementation"`
 }
 
 func (s InboundRTPStreamStats) statsMarker() {}
@@ -806,6 +809,9 @@ type OutboundRTPStreamStats struct {
 	// Active indicates whether this RTP stream is configured to be sent or disabled. Note that an
 	// active stream can still not be sending, e.g. when being limited by network conditions.
 	Active bool `json:"active"`
+
+	// Identifies the encoder implementation used. This is useful for diagnosing interoperability issues.
+	EncoderImplementation string `json:"encoderImplementation"`
 }
 
 func (s OutboundRTPStreamStats) statsMarker() {}

--- a/stats_go_test.go
+++ b/stats_go_test.go
@@ -144,6 +144,7 @@ func getStatsSamples() []statSample {
 		PerDSCPPacketsReceived: map[string]uint32{
 			"123": 23,
 		},
+		DecoderImplementation: "libvpx",
 	}
 	inboundRTPStreamStatsJSON := `
 {
@@ -210,7 +211,8 @@ func getStatsSamples() []statSample {
   "packetsDuplicated": 22,
   "perDscpPacketsReceived": {
     "123": 23
-  }
+  },
+  "decoderImplementation": "libvpx"
 }
 `
 	outboundRTPStreamStats := OutboundRTPStreamStats{
@@ -264,7 +266,8 @@ func getStatsSamples() []statSample {
 		PerDSCPPacketsSent: map[string]uint32{
 			"123": 23,
 		},
-		Active: true,
+		Active:                true,
+		EncoderImplementation: "libvpx",
 	}
 	outboundRTPStreamStatsJSON := `
 {
@@ -318,7 +321,8 @@ func getStatsSamples() []statSample {
   "perDscpPacketsSent": {
     "123": 23
   },
-  "active": true
+  "active": true,
+  "encoderImplementation": "libvpx"
 }
 `
 	remoteInboundRTPStreamStats := RemoteInboundRTPStreamStats{


### PR DESCRIPTION
According to w3c:

https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-encoderimplementation
https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-decoderimplementation