### PR TITLE
Extended stats metrics

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -569,7 +569,32 @@ type InboundRTPStreamStats struct {
 	PerDSCPPacketsReceived map[string]uint32 `json:"perDscpPacketsReceived"`
 
 	// Identifies the decoder implementation used. This is useful for diagnosing interoperability issues.
+	// Does not exist for audio.
 	DecoderImplementation string `json:"decoderImplementation"`
+
+	// PauseCount is the total number of video pauses experienced by this receiver.
+	// Video is considered to be paused if time passed since last rendered frame exceeds 5 seconds.
+	// PauseCount is incremented when a frame is rendered after such a pause. Does not exist for audio.
+	PauseCount uint32 `json:"pauseCount"`
+
+	// TotalPausesDuration is the total duration of pauses (for definition of pause see PauseCount), in seconds.
+	// Does not exist for audio.
+	TotalPausesDuration float64 `json:"totalPausesDuration"`
+
+	// FreezeCount is the total number of video freezes experienced by this receiver.
+	// It is a freeze if frame duration, which is time interval between two consecutively rendered frames,
+	// is equal or exceeds Max(3 * avg_frame_duration_ms, avg_frame_duration_ms + 150),
+	// where avg_frame_duration_ms is linear average of durations of last 30 rendered frames.
+	// Does not exist for audio.
+	FreezeCount uint32 `json:"freezeCount"`
+
+	// TotalFreezesDuration is the total duration of rendered frames which are considered as frozen
+	// (for definition of freeze see freezeCount), in seconds. Does not exist for audio.
+	TotalFreezesDuration float64 `json:"totalFreezesDuration"`
+
+	// PowerEfficientDecoder indicates whether the decoder currently used is considered power efficient
+	// by the user agent. Does not exist for audio.
+	PowerEfficientDecoder bool `json:"powerEfficientDecoder"`
 }
 
 func (s InboundRTPStreamStats) statsMarker() {}
@@ -811,7 +836,15 @@ type OutboundRTPStreamStats struct {
 	Active bool `json:"active"`
 
 	// Identifies the encoder implementation used. This is useful for diagnosing interoperability issues.
+	// Does not exist for audio.
 	EncoderImplementation string `json:"encoderImplementation"`
+
+	// PowerEfficientEncoder indicates whether the encoder currently used is considered power efficient.
+	// by the user agent. Does not exist for audio.
+	PowerEfficientEncoder bool `json:"powerEfficientEncoder"`
+
+	// ScalabilityMode identifies the layering mode used for video encoding. Does not exist for audio.
+	ScalabilityMode string `json:"scalabilityMode"`
 }
 
 func (s OutboundRTPStreamStats) statsMarker() {}

--- a/stats_go_test.go
+++ b/stats_go_test.go
@@ -145,6 +145,11 @@ func getStatsSamples() []statSample {
 			"123": 23,
 		},
 		DecoderImplementation: "libvpx",
+		PauseCount:            48,
+		TotalPausesDuration:   48.123,
+		FreezeCount:           49,
+		TotalFreezesDuration:  49.321,
+		PowerEfficientDecoder: true,
 	}
 	inboundRTPStreamStatsJSON := `
 {
@@ -212,7 +217,12 @@ func getStatsSamples() []statSample {
   "perDscpPacketsReceived": {
     "123": 23
   },
-  "decoderImplementation": "libvpx"
+  "decoderImplementation": "libvpx",
+  "pauseCount": 48,
+  "totalPausesDuration": 48.123,
+  "freezeCount": 49,
+  "totalFreezesDuration": 49.321,
+  "powerEfficientDecoder": true
 }
 `
 	outboundRTPStreamStats := OutboundRTPStreamStats{
@@ -268,6 +278,8 @@ func getStatsSamples() []statSample {
 		},
 		Active:                true,
 		EncoderImplementation: "libvpx",
+		PowerEfficientEncoder: true,
+		ScalabilityMode:       "L1T1",
 	}
 	outboundRTPStreamStatsJSON := `
 {
@@ -322,7 +334,9 @@ func getStatsSamples() []statSample {
     "123": 23
   },
   "active": true,
-  "encoderImplementation": "libvpx"
+  "encoderImplementation": "libvpx",
+  "powerEfficientEncoder": true,
+  "scalabilityMode": "L1T1"
 }
 `
 	remoteInboundRTPStreamStats := RemoteInboundRTPStreamStats{


### PR DESCRIPTION
According to w3c:

InboundRTPStreamStats:

- https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-pausecount
- https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-totalpausesduration
- https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-freezecount
- https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-totalfreezesduration
- https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-powerefficientdecoder

OutboundRTPStreamStats:

- https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-powerefficientencoder
- https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-scalabilitymode


