### PR TITLE
Fix ivf timestamps

### DIFF
--- a/pkg/media/ivfreader/ivfreader.go
+++ b/pkg/media/ivfreader/ivfreader.go
@@ -52,7 +52,8 @@ type IVFFrameHeader struct {
 type IVFReader struct {
 	stream               io.Reader
 	bytesReadSuccesfully int64
-	fileHeader           *IVFFileHeader
+	timebaseDenominator  uint32
+	timebaseNumerator    uint32
 }
 
 // NewWith returns a new IVF reader and IVF file header
@@ -70,7 +71,8 @@ func NewWith(in io.Reader) (*IVFReader, *IVFFileHeader, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	reader.fileHeader = header
+	reader.timebaseDenominator = header.TimebaseDenominator
+	reader.timebaseNumerator = header.TimebaseNumerator
 
 	return reader, header, nil
 }
@@ -83,7 +85,7 @@ func (i *IVFReader) ResetReader(reset func(bytesRead int64) io.Reader) {
 }
 
 func (i *IVFReader) ptsToTimestamp(pts uint64) uint64 {
-	return pts * uint64(i.fileHeader.TimebaseDenominator) / uint64(i.fileHeader.TimebaseNumerator)
+	return pts * uint64(i.timebaseDenominator) / uint64(i.timebaseNumerator)
 }
 
 // ParseNextFrame reads from stream and returns IVF frame payload, header,

--- a/pkg/media/ivfreader/ivfreader.go
+++ b/pkg/media/ivfreader/ivfreader.go
@@ -24,6 +24,7 @@ var (
 	errIncompleteFileHeader  = errors.New("incomplete file header")
 	errSignatureMismatch     = errors.New("IVF signature mismatch")
 	errUnknownIVFVersion     = errors.New("IVF version unknown, parser may not parse correctly")
+	errInvalidMediaTimebase  = errors.New("invalid media timebase")
 )
 
 // IVFFileHeader 32-byte header for IVF files
@@ -70,6 +71,9 @@ func NewWith(in io.Reader) (*IVFReader, *IVFFileHeader, error) {
 	header, err := reader.parseFileHeader()
 	if err != nil {
 		return nil, nil, err
+	}
+	if header.TimebaseDenominator == 0 {
+		return nil, nil, errInvalidMediaTimebase
 	}
 	reader.timebaseDenominator = header.TimebaseDenominator
 	reader.timebaseNumerator = header.TimebaseNumerator

--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -109,10 +109,10 @@ func (i *IVFWriter) writeHeader() error {
 	return err
 }
 
-func (i *IVFWriter) writeFrame(frame []byte, timestamp uint64) error {
+func (i *IVFWriter) writeFrame(frame []byte) error {
 	frameHeader := make([]byte, 12)
 	binary.LittleEndian.PutUint32(frameHeader[0:], uint32(len(frame))) // Frame length
-	binary.LittleEndian.PutUint64(frameHeader[4:], timestamp)          // PTS
+	binary.LittleEndian.PutUint64(frameHeader[4:], i.count)            // PTS
 	i.count++
 
 	if _, err := i.ioWriter.Write(frameHeader); err != nil {
@@ -153,7 +153,7 @@ func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 			return nil
 		}
 
-		if err := i.writeFrame(i.currentFrame, uint64(packet.Header.Timestamp)); err != nil {
+		if err := i.writeFrame(i.currentFrame); err != nil {
 			return err
 		}
 		i.currentFrame = nil
@@ -169,7 +169,7 @@ func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 		}
 
 		for j := range obus {
-			if err := i.writeFrame(obus[j], uint64(packet.Header.Timestamp)); err != nil {
+			if err := i.writeFrame(obus[j]); err != nil {
 				return err
 			}
 		}

--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -37,6 +37,11 @@ type IVFWriter struct {
 
 	isVP8, isAV1 bool
 
+	timebaseDenominator uint32
+	timebaseNumerator   uint32
+	firstFrameTimestamp uint32
+	clockRate           uint64
+
 	// VP8
 	currentFrame []byte
 
@@ -65,8 +70,11 @@ func NewWith(out io.Writer, opts ...Option) (*IVFWriter, error) {
 	}
 
 	writer := &IVFWriter{
-		ioWriter:     out,
-		seenKeyFrame: false,
+		ioWriter:            out,
+		seenKeyFrame:        false,
+		timebaseDenominator: 30,
+		timebaseNumerator:   1,
+		clockRate:           90000,
 	}
 
 	for _, o := range opts {
@@ -98,21 +106,25 @@ func (i *IVFWriter) writeHeader() error {
 		copy(header[8:], "AV01")
 	}
 
-	binary.LittleEndian.PutUint16(header[12:], 640) // Width in pixels
-	binary.LittleEndian.PutUint16(header[14:], 480) // Height in pixels
-	binary.LittleEndian.PutUint32(header[16:], 30)  // Framerate denominator
-	binary.LittleEndian.PutUint32(header[20:], 1)   // Framerate numerator
-	binary.LittleEndian.PutUint32(header[24:], 900) // Frame count, will be updated on first Close() call
-	binary.LittleEndian.PutUint32(header[28:], 0)   // Unused
+	binary.LittleEndian.PutUint16(header[12:], 640)                   // Width in pixels
+	binary.LittleEndian.PutUint16(header[14:], 480)                   // Height in pixels
+	binary.LittleEndian.PutUint32(header[16:], i.timebaseDenominator) // Framerate denominator
+	binary.LittleEndian.PutUint32(header[20:], i.timebaseNumerator)   // Framerate numerator
+	binary.LittleEndian.PutUint32(header[24:], 900)                   // Frame count, will be updated on first Close() call
+	binary.LittleEndian.PutUint32(header[28:], 0)                     // Unused
 
 	_, err := i.ioWriter.Write(header)
 	return err
 }
 
-func (i *IVFWriter) writeFrame(frame []byte) error {
+func (i *IVFWriter) timestampToPts(timestamp uint64) uint64 {
+	return timestamp * uint64(i.timebaseNumerator) / uint64(i.timebaseDenominator)
+}
+
+func (i *IVFWriter) writeFrame(frame []byte, timestamp uint64) error {
 	frameHeader := make([]byte, 12)
 	binary.LittleEndian.PutUint32(frameHeader[0:], uint32(len(frame))) // Frame length
-	binary.LittleEndian.PutUint64(frameHeader[4:], i.count)            // PTS
+	binary.LittleEndian.PutUint64(frameHeader[4:], i.timestampToPts(timestamp))
 	i.count++
 
 	if _, err := i.ioWriter.Write(frameHeader); err != nil {
@@ -129,6 +141,11 @@ func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 	} else if len(packet.Payload) == 0 {
 		return nil
 	}
+
+	if i.count == 0 {
+		i.firstFrameTimestamp = packet.Header.Timestamp
+	}
+	relativeTstampMs := 1000 * uint64(packet.Header.Timestamp) / i.clockRate
 
 	if i.isVP8 {
 		vp8Packet := codecs.VP8Packet{}
@@ -153,7 +170,7 @@ func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 			return nil
 		}
 
-		if err := i.writeFrame(i.currentFrame); err != nil {
+		if err := i.writeFrame(i.currentFrame, relativeTstampMs); err != nil {
 			return err
 		}
 		i.currentFrame = nil
@@ -169,7 +186,7 @@ func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 		}
 
 		for j := range obus {
-			if err := i.writeFrame(obus[j]); err != nil {
+			if err := i.writeFrame(obus[j], relativeTstampMs); err != nil {
 				return err
 			}
 		}

--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -145,7 +145,7 @@ func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 	if i.count == 0 {
 		i.firstFrameTimestamp = packet.Header.Timestamp
 	}
-	relativeTstampMs := 1000 * uint64(packet.Header.Timestamp) / i.clockRate
+	relativeTstampMs := 1000 * uint64(packet.Header.Timestamp-i.firstFrameTimestamp) / i.clockRate
 
 	if i.isVP8 {
 		vp8Packet := codecs.VP8Packet{}

--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -123,8 +123,8 @@ func (i *IVFWriter) timestampToPts(timestamp uint64) uint64 {
 
 func (i *IVFWriter) writeFrame(frame []byte, timestamp uint64) error {
 	frameHeader := make([]byte, 12)
-	binary.LittleEndian.PutUint32(frameHeader[0:], uint32(len(frame))) // Frame length
-	binary.LittleEndian.PutUint64(frameHeader[4:], i.timestampToPts(timestamp))
+	binary.LittleEndian.PutUint32(frameHeader[0:], uint32(len(frame)))          // Frame length
+	binary.LittleEndian.PutUint64(frameHeader[4:], i.timestampToPts(timestamp)) // PTS
 	i.count++
 
 	if _, err := i.ioWriter.Write(frameHeader); err != nil {

--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -29,6 +29,8 @@ const (
 	ivfFileHeaderSignature = "DKIF"
 )
 
+var errInvalidMediaTimebase = errors.New("invalid media timebase")
+
 // IVFWriter is used to take RTP packets and write them to an IVF on disk
 type IVFWriter struct {
 	ioWriter     io.Writer
@@ -89,6 +91,10 @@ func NewWith(out io.Writer, opts ...Option) (*IVFWriter, error) {
 
 	if err := writer.writeHeader(); err != nil {
 		return nil, err
+	}
+
+	if writer.timebaseDenominator == 0 {
+		return nil, errInvalidMediaTimebase
 	}
 	return writer, nil
 }

--- a/pkg/media/ivfwriter/ivfwriter_test.go
+++ b/pkg/media/ivfwriter/ivfwriter_test.go
@@ -5,7 +5,6 @@ package ivfwriter
 
 import (
 	"bytes"
-	"encoding/binary"
 	"io"
 	"testing"
 
@@ -258,25 +257,19 @@ func TestIVFWriter_AV1(t *testing.T) {
 	t.Run("Unfragmented", func(t *testing.T) {
 		buffer := &bytes.Buffer{}
 
-		expectedTimestamp := uint32(3653407706)
+		writer, err := NewWith(buffer, WithCodec(mimeTypeAV1))
+		assert.NoError(t, err)
 
-		// the timestamp is an uint32, 4 bytes from offset 36
-		expectedPayloadWithTimestamp := []byte{
+		assert.NoError(t, writer.WriteRTP(&rtp.Packet{Payload: []byte{0x00, 0x01, 0xFF}}))
+		assert.NoError(t, writer.Close())
+		assert.Equal(t, buffer.Bytes(), []byte{
 			0x44, 0x4b, 0x49, 0x46, 0x0, 0x0, 0x20,
 			0x0, 0x41, 0x56, 0x30, 0x31, 0x80, 0x2,
 			0xe0, 0x1, 0x1e, 0x0, 0x0, 0x0, 0x1, 0x0,
 			0x0, 0x0, 0x84, 0x3, 0x0, 0x0, 0x0, 0x0,
-			0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0xda, 0x93, 0xc2,
-			0xd9, 0x0, 0x0, 0x0, 0x0, 0xff,
-		}
-
-		writer, err := NewWith(buffer, WithCodec(mimeTypeAV1))
-		assert.NoError(t, err)
-
-		assert.NoError(t, writer.WriteRTP(&rtp.Packet{Header: rtp.Header{Timestamp: expectedTimestamp}, Payload: []byte{0x00, 0x01, 0xFF}}))
-		assert.NoError(t, writer.Close())
-		assert.Equal(t, expectedPayloadWithTimestamp, buffer.Bytes())
-		assert.Equal(t, expectedTimestamp, binary.LittleEndian.Uint32(expectedPayloadWithTimestamp[36:40]))
+			0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0xff,
+		})
 	})
 
 	t.Run("Fragmented", func(t *testing.T) {


### PR DESCRIPTION
#### Description
IVFwriter produces incorrect timestamps leading to unplayable video with the changes introduced in https://github.com/pion/webrtc/pull/2853.

The confusion lies in the different timestamps.
The RTP timestamp refects the sampling clock for the media stream. This timestamp increments based on the sampling rate.
The PTS of a media stream represents the presentation time in the time base units.

#### Example
v3 first captured packets from examples/save-to-disk (`ffprobe -select_streams v -show_packets -show_entries packet=pts,pts_time,dts,dts_time,duration,duration_time,size,pos -of default output.ivf`)
```
[PACKET]
pts=0
pts_time=0.000000
dts=0
dts_time=0.000000
duration=1
duration_time=0.033333
size=2749
pos=32
[/PACKET]
[PACKET]
pts=1
pts_time=0.033333
dts=1
dts_time=0.033333
duration=1
duration_time=0.033333
size=61
pos=2793
[/PACKET]
[PACKET]
pts=2
pts_time=0.066667
dts=2
dts_time=0.066667
duration=1
duration_time=0.033333
size=46
pos=2866
[/PACKET]
[PACKET]
pts=3
pts_time=0.100000
dts=3
dts_time=0.100000
duration=1
duration_time=0.033333
size=222
pos=2924
[/PACKET]
```

v4 first captured packets from examples/save-to-disk (prior to this PR)
```
[PACKET]
pts=556350009
pts_time=18545000.300000
dts=556350009
dts_time=18545000.300000
duration=1
duration_time=0.033333
size=2712
pos=32
[/PACKET]
[PACKET]
pts=556353159
pts_time=18545105.300000
dts=556353159
dts_time=18545105.300000
duration=1
duration_time=0.033333
size=64
pos=2756
[/PACKET]
[PACKET]
pts=556356129
pts_time=18545204.300000
dts=556356129
dts_time=18545204.300000
duration=1
duration_time=0.033333
size=229
pos=2832
[/PACKET]
```

v4 first captured packets with this PR
```[PACKET]
pts=0
pts_time=0.000000
dts=0
dts_time=0.000000
duration=1
duration_time=0.033333
size=2851
pos=32
[/PACKET]
[PACKET]
pts=1
pts_time=0.033333
dts=1
dts_time=0.033333
duration=1
duration_time=0.033333
size=61
pos=2895
[/PACKET]
[PACKET]
pts=2
pts_time=0.066667
dts=2
dts_time=0.066667
duration=1
duration_time=0.033333
size=232
pos=2968
[/PACKET]
```
