### PR TITLE
Gracefully close connecting channels

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -320,8 +320,13 @@ func (d *DataChannel) onMessage(msg DataChannelMessage) {
 
 func (d *DataChannel) handleOpen(dc *datachannel.DataChannel, isRemote, isAlreadyNegotiated bool) {
 	d.mu.Lock()
-	if d.isGracefulClosed {
+	if d.isGracefulClosed { // The channel was closed during the connecting state
 		d.mu.Unlock()
+		if err := dc.Close(); err != nil {
+			d.log.Errorf("Failed to close DataChannel that was closed during connecting state %v", err.Error())
+		}
+		d.onClose()
+
 		return
 	}
 	d.dataChannel = dc


### PR DESCRIPTION
#### Description

This PR fixes an issue where calling `dataChannel.Close` on 'connecting' state channels didn't work as expected; It adds the ability to reject data channels directly from the `OnDataConnection` handler.

#### Reference issue

Fixes https://github.com/pion/webrtc/issues/2659
