### PR TITLE
Rewrite VP8 isKeyFrame check

### DIFF
--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -159,9 +159,9 @@ func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 			return err
 		}
 
-		isKeyFrame := vp8Packet.Payload[0] & 0x01
+		isKeyFrame := (vp8Packet.Payload[0] & 0x01) == 0
 		switch {
-		case !i.seenKeyFrame && isKeyFrame == 1:
+		case !i.seenKeyFrame && !isKeyFrame:
 			return nil
 		case i.currentFrame == nil && vp8Packet.S != 1:
 			return nil


### PR DESCRIPTION
#### Description
[RFC 6386](https://www.rfc-editor.org/rfc/rfc6386#section-9.1) describes the least significant bit of the first byte of the header as:
```
A 1-bit frame type (0 for key frames, 1 for interframes).
```

The change is functionally a no-op, but the naming implies the wrong logic (you would assume `isKeyFrame == 1` means it is a key frame, but the opposite is true).

#### Reference issue
Fixes #...
