### PR TITLE
Fix deadlock in DataChannel with mutex unlock

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -464,10 +464,12 @@ func (d *DataChannel) DetachWithDeadline() (datachannel.ReadWriteCloserDeadliner
 	d.mu.Lock()
 
 	if !d.api.settingEngine.detach.DataChannels {
+		d.mu.Unlock()
 		return nil, errDetachNotEnabled
 	}
 
 	if d.dataChannel == nil {
+		d.mu.Unlock()
 		return nil, errDetachBeforeOpened
 	}
 

--- a/datachannel_go_test.go
+++ b/datachannel_go_test.go
@@ -822,3 +822,30 @@ func TestDataChannelClose(t *testing.T) {
 		assert.NoError(t, answerPC.Close())
 	})
 }
+
+func TestDataChannel_DetachErrors(t *testing.T) {
+	t.Run("error errDetachNotEnabled", func(t *testing.T) {
+		s := SettingEngine{}
+		offer, answer, err := NewAPI(WithSettingEngine(s)).newPair(Configuration{})
+		assert.NoError(t, err)
+		dc, err := offer.CreateDataChannel("data", nil)
+		assert.NoError(t, err)
+		_, err = dc.Detach()
+		assert.ErrorIs(t, err, errDetachNotEnabled)
+		assert.NoError(t, offer.Close())
+		assert.NoError(t, answer.Close())
+	})
+
+	t.Run("error errDetachBeforeOpened", func(t *testing.T) {
+		s := SettingEngine{}
+		s.DetachDataChannels()
+		offer, answer, err := NewAPI(WithSettingEngine(s)).newPair(Configuration{})
+		assert.NoError(t, err)
+		dc, err := offer.CreateDataChannel("data", nil)
+		assert.NoError(t, err)
+		_, err = dc.Detach()
+		assert.ErrorIs(t, err, errDetachBeforeOpened)
+		assert.NoError(t, offer.Close())
+		assert.NoError(t, answer.Close())
+	})
+}


### PR DESCRIPTION
This fixes a regression bug introduced in commit https://github.com/pion/webrtc/commit/835ac3b08ef5dfd0f6c0b047cdeea635258a21e3, where this line was removed: https://github.com/pion/webrtc/commit/835ac3b08ef5dfd0f6c0b047cdeea635258a21e3#diff-b8da7f3e746d55a2fe2a4295ae5fe5cf76b9512d7665201285143e25ab3bd3b9L423.

Related issue https://github.com/pion/webrtc/issues/3005