### PR TITLE
Fix addCodec to return error if payload type exists in codecs list

### DIFF
--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -592,6 +592,26 @@ func TestMediaEngineDoubleRegister(t *testing.T) {
 	assert.Equal(t, len(mediaEngine.audioCodecs), 1)
 }
 
+// If a user attempts to register a codec with same payload but with different
+// codec we should just discard duplicate calls.
+func TestMediaEngineDoubleRegisterDifferentCodec(t *testing.T) {
+	mediaEngine := MediaEngine{}
+
+	assert.NoError(t, mediaEngine.RegisterCodec(
+		RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeG722, 8000, 0, "", nil},
+			PayloadType:        111,
+		}, RTPCodecTypeAudio))
+
+	assert.Error(t, ErrCodecAlreadyRegistered, mediaEngine.RegisterCodec(
+		RTPCodecParameters{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeOpus, 48000, 0, "", nil},
+			PayloadType:        111,
+		}, RTPCodecTypeAudio))
+
+	assert.Equal(t, len(mediaEngine.audioCodecs), 1)
+}
+
 // The cloned MediaEngine instance should be able to update negotiated header extensions.
 func TestUpdateHeaderExtenstionToClonedMediaEngine(t *testing.T) {
 	src := MediaEngine{}

--- a/rtptransceiver_test.go
+++ b/rtptransceiver_test.go
@@ -18,8 +18,8 @@ func Test_RTPTransceiver_SetCodecPreferences(t *testing.T) {
 	api := NewAPI(WithMediaEngine(mediaEngine))
 	assert.NoError(t, mediaEngine.RegisterDefaultCodecs())
 
-	mediaEngine.pushCodecs(mediaEngine.videoCodecs, RTPCodecTypeVideo)
-	mediaEngine.pushCodecs(mediaEngine.audioCodecs, RTPCodecTypeAudio)
+	assert.NoError(t, mediaEngine.pushCodecs(mediaEngine.videoCodecs, RTPCodecTypeVideo))
+	assert.NoError(t, mediaEngine.pushCodecs(mediaEngine.audioCodecs, RTPCodecTypeAudio))
 
 	tr := RTPTransceiver{kind: RTPCodecTypeVideo, api: api, codecs: mediaEngine.videoCodecs}
 	assert.EqualValues(t, mediaEngine.videoCodecs, tr.getCodecs())

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -683,8 +683,8 @@ func TestPopulateSDP(t *testing.T) { //nolint:cyclop,maintidx
 		me := &MediaEngine{}
 		assert.NoError(t, me.RegisterDefaultCodecs())
 		api := NewAPI(WithMediaEngine(me))
-		me.pushCodecs(me.videoCodecs, RTPCodecTypeVideo)
-		me.pushCodecs(me.audioCodecs, RTPCodecTypeAudio)
+		assert.NoError(t, me.pushCodecs(me.videoCodecs, RTPCodecTypeVideo))
+		assert.NoError(t, me.pushCodecs(me.audioCodecs, RTPCodecTypeAudio))
 
 		tr := &RTPTransceiver{kind: RTPCodecTypeVideo, api: api, codecs: me.videoCodecs}
 		tr.setDirection(RTPTransceiverDirectionRecvonly)


### PR DESCRIPTION
#### Description
This PR adds changes to return an error if the codec already exists on the codecs list. This way now the implementing party should take care of duplicate codecs addition if the payload type is the same.
#### Reference issue
Fixes #3015
