### PR TITLE
Fix matching codecs with different rate or channels

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -246,7 +246,10 @@ func (m *MediaEngine) RegisterDefaultCodecs() error {
 // addCodec will append codec if it not exists.
 func (m *MediaEngine) addCodec(codecs []RTPCodecParameters, codec RTPCodecParameters) []RTPCodecParameters {
 	for _, c := range codecs {
-		if c.MimeType == codec.MimeType && c.PayloadType == codec.PayloadType {
+		if c.MimeType == codec.MimeType &&
+			fmtp.ClockRateEqual(c.MimeType, c.ClockRate, codec.ClockRate) &&
+			fmtp.ChannelsEqual(c.MimeType, c.Channels, codec.Channels) &&
+			c.PayloadType == codec.PayloadType {
 			return codecs
 		}
 	}
@@ -459,7 +462,12 @@ func (m *MediaEngine) matchRemoteCodec(
 		codecs = m.audioCodecs
 	}
 
-	remoteFmtp := fmtp.Parse(remoteCodec.RTPCodecCapability.MimeType, remoteCodec.RTPCodecCapability.SDPFmtpLine)
+	remoteFmtp := fmtp.Parse(
+		remoteCodec.RTPCodecCapability.MimeType,
+		remoteCodec.RTPCodecCapability.ClockRate,
+		remoteCodec.RTPCodecCapability.Channels,
+		remoteCodec.RTPCodecCapability.SDPFmtpLine)
+
 	if apt, hasApt := remoteFmtp.Parameter("apt"); hasApt { //nolint:nestif
 		payloadType, err := strconv.ParseUint(apt, 10, 8)
 		if err != nil {

--- a/rtpcodec.go
+++ b/rtpcodec.go
@@ -108,19 +108,34 @@ func codecParametersFuzzySearch(
 	needle RTPCodecParameters,
 	haystack []RTPCodecParameters,
 ) (RTPCodecParameters, codecMatchType) {
-	needleFmtp := fmtp.Parse(needle.RTPCodecCapability.MimeType, needle.RTPCodecCapability.SDPFmtpLine)
+	needleFmtp := fmtp.Parse(
+		needle.RTPCodecCapability.MimeType,
+		needle.RTPCodecCapability.ClockRate,
+		needle.RTPCodecCapability.Channels,
+		needle.RTPCodecCapability.SDPFmtpLine)
 
-	// First attempt to match on MimeType + SDPFmtpLine
+	// First attempt to match on MimeType + ClockRate + Channels + SDPFmtpLine
 	for _, c := range haystack {
-		cfmtp := fmtp.Parse(c.RTPCodecCapability.MimeType, c.RTPCodecCapability.SDPFmtpLine)
+		cfmtp := fmtp.Parse(
+			c.RTPCodecCapability.MimeType,
+			c.RTPCodecCapability.ClockRate,
+			c.RTPCodecCapability.Channels,
+			c.RTPCodecCapability.SDPFmtpLine)
+
 		if needleFmtp.Match(cfmtp) {
 			return c, codecMatchExact
 		}
 	}
 
-	// Fallback to just MimeType
+	// Fallback to just MimeType + ClockRate + Channels
 	for _, c := range haystack {
-		if strings.EqualFold(c.RTPCodecCapability.MimeType, needle.RTPCodecCapability.MimeType) {
+		if strings.EqualFold(c.RTPCodecCapability.MimeType, needle.RTPCodecCapability.MimeType) &&
+			fmtp.ClockRateEqual(c.RTPCodecCapability.MimeType,
+				c.RTPCodecCapability.ClockRate,
+				needle.RTPCodecCapability.ClockRate) &&
+			fmtp.ChannelsEqual(c.RTPCodecCapability.MimeType,
+				c.RTPCodecCapability.Channels,
+				needle.RTPCodecCapability.Channels) {
 			return c, codecMatchPartial
 		}
 	}


### PR DESCRIPTION
#### Description

In pion/webrtc, currently codecs are matched regardless of the clock rate and the channel count, and this makes impossible to fully support codecs that might have a clock rate or channel count different than the default one, in particular LPCM, PCMU, PCMA and multiopus (the last one is a custom Opus variant present in the Chrome source code to support multichannel Opus).

For instance, let's suppose a peer (receiver) wants to receive an audio track encoded with LPCM, 48khz sample rate and 2 channels. This receiver doesn't know the audio codec yet, therefore it advertises all supported sample rates in the SDP:

```
LPCM/44100
LPCM/48000
LPCM/44100/2
LPCM/48000/2
```

The other peer (sender) receives the SDP, but since the clock rate and channel count are not taken into consideration when matching codecs, the sender codec `LPCM/48000/2` is wrongly associated with the receiver codec `LPCM/44100`. The result is that the audio track cannot be decoded correctly from the receiver side.

This patch fixes the issue and has been running smoothly in MediaMTX for almost a year.

Unfortunately, in lots of examples and tests, clock rate and/or channels are not present (and in fact they are producing horrible SDPs that contain `VP8/0` instead of `VP8/90000` and are incompatible with lots of servers) therefore this new check causes troubles in existing code. In order to maintain compatibility, default clock rates and channels are provided for most codecs.

In the future, it might be better to update examples (i can do it in a future patch) and remove the exception.