### PR TITLE
WASM: `JSValue()` to get underlying JS object

### DIFF
--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -33,6 +33,11 @@ type DataChannel struct {
 	api *API
 }
 
+// JSValue returns the underlying RTCDataChannel
+func (d *DataChannel) JSValue() js.Value {
+	return d.underlying
+}
+
 // OnOpen sets an event handler which is invoked when
 // the underlying data transport has been established (or re-established).
 func (d *DataChannel) OnOpen(f func()) {

--- a/dtlstransport_js.go
+++ b/dtlstransport_js.go
@@ -17,6 +17,11 @@ type DTLSTransport struct {
 	underlying js.Value
 }
 
+// JSValue returns the underlying RTCDtlsTransport
+func (r *DTLSTransport) JSValue() js.Value {
+	return r.underlying
+}
+
 // ICETransport returns the currently-configured *ICETransport or nil
 // if one has not been configured
 func (r *DTLSTransport) ICETransport() *ICETransport {

--- a/icetransport_js.go
+++ b/icetransport_js.go
@@ -15,6 +15,11 @@ type ICETransport struct {
 	underlying js.Value
 }
 
+// JSValue returns the underlying RTCIceTransport
+func (t *ICETransport) JSValue() js.Value {
+	return t.underlying
+}
+
 // GetSelectedCandidatePair returns the selected candidate pair on which packets are sent
 // if there is no selected pair nil is returned
 func (t *ICETransport) GetSelectedCandidatePair() (*ICECandidatePair, error) {

--- a/rtpreceiver_js.go
+++ b/rtpreceiver_js.go
@@ -13,3 +13,8 @@ type RTPReceiver struct {
 	// Pointer to the underlying JavaScript RTCRTPReceiver object.
 	underlying js.Value
 }
+
+// JSValue returns the underlying RTCRtpReceiver
+func (r *RTPReceiver) JSValue() js.Value {
+	return r.underlying
+}

--- a/rtpsender_js.go
+++ b/rtpsender_js.go
@@ -13,3 +13,8 @@ type RTPSender struct {
 	// Pointer to the underlying JavaScript RTCRTPSender object.
 	underlying js.Value
 }
+
+// JSValue returns the underlying RTCRtpSender
+func (s *RTPSender) JSValue() js.Value {
+	return s.underlying
+}

--- a/rtptransceiver_js.go
+++ b/rtptransceiver_js.go
@@ -16,6 +16,11 @@ type RTPTransceiver struct {
 	underlying js.Value
 }
 
+// JSValue returns the underlying RTCRtpTransceiver
+func (r *RTPTransceiver) JSValue() js.Value {
+	return r.underlying
+}
+
 // Direction returns the RTPTransceiver's current direction
 func (r *RTPTransceiver) Direction() RTPTransceiverDirection {
 	return NewRTPTransceiverDirection(r.underlying.Get("direction").String())

--- a/sctptransport_js.go
+++ b/sctptransport_js.go
@@ -14,6 +14,11 @@ type SCTPTransport struct {
 	underlying js.Value
 }
 
+// JSValue returns the underlying RTCSctpTransport
+func (r *SCTPTransport) JSValue() js.Value {
+	return r.underlying
+}
+
 // Transport returns the DTLSTransport instance the SCTPTransport is sending over.
 func (r *SCTPTransport) Transport() *DTLSTransport {
 	underlying := r.underlying.Get("transport")


### PR DESCRIPTION
#### Description

...for all remaining objects, and not just PeerConnection.

Basically I grepped for all `underlying\s*js\.Value` occurrences.

This is a follow-up to https://github.com/pion/webrtc/pull/1220
(461892201168299a5254a5ae803369bfacec337f).

The most important one would be `DataChannel.JSValue()`,
but others might also come in handy for some Pion users.

And in general this commit sets an example for future changes,
should another struct be added that has an underlying JS value.

#### Reference issue

None
