### PR TITLE
Fix H264Writer writing 0 length payloads

### DIFF
--- a/pkg/media/h264writer/h264writer.go
+++ b/pkg/media/h264writer/h264writer.go
@@ -62,7 +62,7 @@ func (h *H264Writer) WriteRTP(packet *rtp.Packet) error {
 	}
 
 	data, err := h.cachedPacket.Unmarshal(packet.Payload)
-	if err != nil {
+	if err != nil || len(data) == 0 {
 		return err
 	}
 


### PR DESCRIPTION
Before we would call Write even if no bytes were available.