### PR TITLE
Fix save to disk examples

### DIFF
--- a/examples/save-to-disk-av1/README.md
+++ b/examples/save-to-disk-av1/README.md
@@ -14,7 +14,7 @@ go install github.com/pion/webrtc/v4/examples/save-to-disk-av1@latest
 ```
 
 ### Open save-to-disk-av1 example page
-[jsfiddle.net](https://jsfiddle.net/xjcve6d3/) you should see your Webcam, two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
+[jsfiddle.net](https://jsfiddle.net/8jv91r25/) you should see your Webcam, two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
 
 ### Run save-to-disk-av1, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.

--- a/examples/save-to-disk/README.md
+++ b/examples/save-to-disk/README.md
@@ -16,7 +16,7 @@ go install github.com/pion/webrtc/v4/examples/save-to-disk@latest
 ```
 
 ### Open save-to-disk example page
-[jsfiddle.net](https://jsfiddle.net/s179hacu/) you should see your Webcam, two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
+[jsfiddle.net](https://jsfiddle.net/2nwt1vjq/) you should see your Webcam, two text-areas and two buttons: `Copy browser SDP to clipboard`, `Start Session`.
 
 ### Run save-to-disk, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser's Session Description. Press `Copy browser SDP to clipboard` or copy the base64 string manually.

--- a/examples/save-to-disk/jsfiddle/demo.js
+++ b/examples/save-to-disk/jsfiddle/demo.js
@@ -24,9 +24,7 @@ navigator.mediaDevices.getUserMedia({ video: true, audio: true })
 
 pc.oniceconnectionstatechange = e => log(pc.iceConnectionState)
 pc.onicecandidate = event => {
-  if (event.candidate === null) {
-    document.getElementById('localSessionDescription').value = btoa(JSON.stringify(pc.localDescription))
-  }
+  document.getElementById('localSessionDescription').value = btoa(JSON.stringify(pc.localDescription))
 }
 
 window.startSession = () => {


### PR DESCRIPTION
#### Description

Fix a bug where the session description would be displayed if the media permission was resolved instantly.
Fix the jsfiddle for save to AV1 example example: do not request audio.