### PR TITLE
Move ErrCodecAlreadyRegistered to errors.go

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -149,6 +149,9 @@ var (
 	//  needs at least one configured codec.
 	ErrSenderWithNoCodecs = errors.New("unable to populate media section, RTPSender created with no codecs")
 
+	// ErrCodecAlreadyRegistered indicates that a codec has already been registered for the same payload type.
+	ErrCodecAlreadyRegistered = errors.New("codec already registered for same payload type")
+
 	// ErrRTPSenderNewTrackHasIncorrectKind indicates that the new track is of a different kind than the previous/original.
 	ErrRTPSenderNewTrackHasIncorrectKind = errors.New("new track must be of the same kind as previous")
 

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -56,9 +56,6 @@ const (
 	MimeTypeFlexFEC = "video/flexfec"
 )
 
-// ErrCodecAlreadyRegistered indicates that a codec has already been registered for the same payload type.
-var ErrCodecAlreadyRegistered = fmt.Errorf("codec already registered for same payload type")
-
 type mediaEngineHeaderExtension struct {
 	uri              string
 	isAudio, isVideo bool


### PR DESCRIPTION
#### Description
Move ErrCodecAlreadyRegistered to errors.go

#### Reference issue

Chore Cleanup after this PR https://github.com/pion/webrtc/pull/3016
