### PR TITLE
Fix missing RTX codec when using SetCodecPreferences

### DIFF
--- a/rtpcodec.go
+++ b/rtpcodec.go
@@ -143,7 +143,7 @@ func codecParametersFuzzySearch(
 	return RTPCodecParameters{}, codecMatchNone
 }
 
-// Given a CodecParameters find the RTX CodecParameters if one exists.
+// Given a CodecParameters find the RTX Payload if one exists.
 func findRTXPayloadType(needle PayloadType, haystack []RTPCodecParameters) PayloadType {
 	aptStr := fmt.Sprintf("apt=%d", needle)
 	for _, c := range haystack {
@@ -153,6 +153,18 @@ func findRTXPayloadType(needle PayloadType, haystack []RTPCodecParameters) Paylo
 	}
 
 	return PayloadType(0)
+}
+
+// Given a CodecParameters find the RTX CodecParameters if one exists.
+func findRTXPCodec(needle PayloadType, haystack []RTPCodecParameters) *RTPCodecParameters {
+	aptStr := fmt.Sprintf("apt=%d", needle)
+	for _, c := range haystack {
+		if aptStr == c.SDPFmtpLine {
+			return &c
+		}
+	}
+
+	return nil
 }
 
 func rtcpFeedbackIntersection(a, b []RTCPFeedback) (out []RTCPFeedback) {

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -86,6 +86,17 @@ func (t *RTPTransceiver) getCodecs() []RTPCodecParameters {
 		}
 	}
 
+	// check if direction is specified
+	if t.direction.Load() != nil {
+		for _, c := range filteredCodecs {
+			if rtxCodec := findRTXPCodec(c.PayloadType, mediaEngineCodecs); rtxCodec != nil {
+				if _, matchType := codecParametersFuzzySearch(*rtxCodec, filteredCodecs); matchType == codecMatchNone {
+					filteredCodecs = append(filteredCodecs, *rtxCodec)
+				}
+			}
+		}
+	}
+
 	return filteredCodecs
 }
 


### PR DESCRIPTION
#### Description

When you specify the codecs that you want to use, we need to add the RTX codec related to the specified codecs

#### Reference issue
Fixes #2996