### PR TITLE
Update CertificateFromPEM to support OpenSSL

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -191,33 +191,55 @@ func (c Certificate) collectStats(report *statsReportCollector) error {
 
 // CertificateFromPEM creates a fresh certificate based on a string containing
 // pem blocks fort the private key and x509 certificate.
-func CertificateFromPEM(pems string) (*Certificate, error) {
-	// decode & parse the certificate
-	block, more := pem.Decode([]byte(pems))
-	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, errCertificatePEMFormatError
-	}
-	certBytes := make([]byte, base64.StdEncoding.DecodedLen(len(block.Bytes)))
-	n, err := base64.StdEncoding.Decode(certBytes, block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode ceritifcate: %w", err)
-	}
-	cert, err := x509.ParseCertificate(certBytes[:n])
-	if err != nil {
-		return nil, fmt.Errorf("failed parsing ceritifcate: %w", err)
-	}
-	// decode & parse the private key
-	block, _ = pem.Decode(more)
-	if block == nil || block.Type != "PRIVATE KEY" {
-		return nil, errCertificatePEMFormatError
-	}
-	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse private key: %w", err)
-	}
-	x := CertificateFromX509(privateKey, cert)
+func CertificateFromPEM(pems string) (*Certificate, error) { //nolint: cyclop
+	var cert *x509.Certificate
+	var privateKey crypto.PrivateKey
 
-	return &x, nil
+	var block *pem.Block
+	more := []byte(pems)
+	for {
+		var err error
+		block, more = pem.Decode(more)
+		if block == nil {
+			break
+		}
+
+		// decode & parse the certificate
+		switch block.Type {
+		case "CERTIFICATE":
+			if cert != nil {
+				return nil, errCertificatePEMMultipleCert
+			}
+			cert, err = x509.ParseCertificate(block.Bytes)
+			// If parsing failed using block.Bytes, then parse the bytes as base64 and try again
+			if err != nil {
+				var n int
+				certBytes := make([]byte, base64.StdEncoding.DecodedLen(len(block.Bytes)))
+				n, err = base64.StdEncoding.Decode(certBytes, block.Bytes)
+				if err == nil {
+					cert, err = x509.ParseCertificate(certBytes[:n])
+				}
+			}
+		case "PRIVATE KEY":
+			if privateKey != nil {
+				return nil, errCertificatePEMMultiplePriv
+			}
+			privateKey, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+		}
+
+		// Report errors from parsing either the private key or the certificate
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode %s: %w", block.Type, err)
+		}
+	}
+
+	if cert == nil || privateKey == nil {
+		return nil, errCertificatePEMMissing
+	}
+
+	ret := CertificateFromX509(privateKey, cert)
+
+	return &ret, nil
 }
 
 // PEM returns the certificate encoded as two pem block: once for the X509

--- a/errors.go
+++ b/errors.go
@@ -275,7 +275,9 @@ var (
 	errICETransportNotInNew = errors.New("ICETransport can only be called in ICETransportStateNew")
 	errICETransportClosed   = errors.New("ICETransport closed")
 
-	errCertificatePEMFormatError = errors.New("bad Certificate PEM format")
+	errCertificatePEMMultipleCert = errors.New("failed parsing certificate, more than 1 CERTIFICATE block in pems")
+	errCertificatePEMMultiplePriv = errors.New("failed parsing certificate, more than 1 PRIVATE KEY block in pems")
+	errCertificatePEMMissing      = errors.New("failed parsing certificate, pems must contain both a CERTIFICATE block and a PRIVATE KEY block") // nolint: lll
 
 	errRTPTooShort = errors.New("not long enough to be a RTP Packet")
 


### PR DESCRIPTION
Update CertificateFromPEM to be a loop over the PEM blocks. This allows decoding the private key before decoding the certificate. Tries to parse the certificate block directly but if that errors, then it also tries to base64 decode the certificate block.

Fixes #3042
