### PR TITLE
Resolve undeclared SSRC using the payload type

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -211,7 +211,7 @@ var (
 		"remoteDescription contained media section without mid value",
 	)
 	errPeerConnRemoteDescriptionNil                  = errors.New("remoteDescription has not been set yet")
-	errPeerConnSingleMediaSectionHasExplicitSSRC     = errors.New("single media section has an explicit SSRC")
+	errMediaSectionHasExplictSSRCAttribute           = errors.New("media section has an explicit SSRC")
 	errPeerConnRemoteSSRCAddTransceiver              = errors.New("could not add transceiver for remote SSRC")
 	errPeerConnSimulcastMidRTPExtensionRequired      = errors.New("mid RTP Extensions required for Simulcast")
 	errPeerConnSimulcastStreamIDRTPExtensionRequired = errors.New("stream id RTP Extensions required for Simulcast")


### PR DESCRIPTION
#### Description

Introduces a fallback mechanism to handle undeclared SSRCs from multiple sections using the RTP stream's payload type. For legacy clients without MID extension support, it documents the existing behavior for handling undeclared SSRCs in single media sections.

This matches the behavior with chrome and Firefox. https://chromium.googlesource.com/external/webrtc/+/refs/heads/master/call/rtp_demuxer.cc#372

#### Reference issue

resolves #3065
