### PR TITLE
Update lint rules, force testify/assert for tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,9 +131,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
+        - gocognit
         - forbidigo
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands

--- a/api_test.go
+++ b/api_test.go
@@ -14,18 +14,9 @@ import (
 
 func TestNewAPI(t *testing.T) {
 	api := NewAPI()
-
-	if api.settingEngine == nil {
-		t.Error("Failed to init settings engine")
-	}
-
-	if api.mediaEngine == nil {
-		t.Error("Failed to init media engine")
-	}
-
-	if api.interceptorRegistry == nil {
-		t.Error("Failed to init interceptor registry")
-	}
+	assert.NotNil(t, api.settingEngine, "failed to init settings engine")
+	assert.NotNil(t, api.mediaEngine, "failed to init media engine")
+	assert.NotNil(t, api.interceptorRegistry, "failed to init interceptor registry")
 }
 
 func TestNewAPI_Options(t *testing.T) {
@@ -36,13 +27,9 @@ func TestNewAPI_Options(t *testing.T) {
 		WithSettingEngine(s),
 	)
 
-	if !api.settingEngine.detach.DataChannels {
-		t.Error("Failed to set settings engine")
-	}
-
-	if len(api.mediaEngine.audioCodecs) == 0 || len(api.mediaEngine.videoCodecs) == 0 {
-		t.Error("Failed to set media engine")
-	}
+	assert.True(t, api.settingEngine.detach.DataChannels, "failed to set settings engine")
+	assert.NotEmpty(t, api.mediaEngine.audioCodecs, "failed to set audio codecs")
+	assert.NotEmpty(t, api.mediaEngine.videoCodecs, "failed to set video codecs")
 }
 
 func TestNewAPI_OptionsDefaultize(t *testing.T) {

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -41,7 +41,7 @@ func closePair(t *testing.T, pc1, pc2 io.Closer, done <-chan bool) {
 
 	select {
 	case <-time.After(10 * time.Second):
-		t.Fatalf("closePair timed out waiting for done signal")
+		assert.Fail(t, "closePair timed out waiting for done signal")
 	case <-done:
 		closePairNow(t, pc1, pc2)
 	}
@@ -54,15 +54,11 @@ func setUpDataChannelParametersTest(
 	t.Helper()
 
 	offerPC, answerPC, err := newPair()
-	if err != nil {
-		t.Fatalf("Failed to create a PC pair for testing")
-	}
+	assert.NoError(t, err)
 	done := make(chan bool)
 
 	dc, err := offerPC.CreateDataChannel(expectedLabel, options)
-	if err != nil {
-		t.Fatalf("Failed to create a PC pair for testing")
-	}
+	assert.NoError(t, err)
 
 	return offerPC, answerPC, dc, done
 }
@@ -71,9 +67,7 @@ func closeReliabilityParamTest(t *testing.T, pc1, pc2 *PeerConnection, done chan
 	t.Helper()
 
 	err := signalPair(pc1, pc2)
-	if err != nil {
-		t.Fatalf("Failed to signal our PC pair for testing")
-	}
+	assert.NoError(t, err)
 
 	closePair(t, pc1, pc2, done)
 }
@@ -134,9 +128,7 @@ func TestDataChannel_Open(t *testing.T) {
 		defer report()
 
 		offerPC, answerPC, err := newPair()
-		if err != nil {
-			t.Fatalf("Failed to create a PC pair for testing")
-		}
+		assert.NoError(t, err)
 
 		done := make(chan bool)
 		openCalls := make(chan bool, openOnceChannelCapacity)
@@ -161,10 +153,7 @@ func TestDataChannel_Open(t *testing.T) {
 		assert.NoError(t, err)
 
 		dc.OnOpen(func() {
-			e := dc.SendText("Ping")
-			if e != nil {
-				t.Fatalf("Failed to send string on data channel")
-			}
+			assert.NoError(t, dc.SendText("Ping"), "Failed to send string on data channel")
 		})
 
 		assert.NoError(t, signalPair(offerPC, answerPC))
@@ -179,9 +168,7 @@ func TestDataChannel_Open(t *testing.T) {
 		defer report()
 
 		offerPC, answerPC, err := newPair()
-		if err != nil {
-			t.Fatalf("Failed to create a PC pair for testing")
-		}
+		assert.NoError(t, err)
 
 		done := make(chan bool)
 		answerOpenCalls := make(chan bool, openOnceChannelCapacity)
@@ -217,10 +204,7 @@ func TestDataChannel_Open(t *testing.T) {
 
 		offerDC.OnOpen(func() {
 			offerOpenCalls <- true
-			e := offerDC.SendText("Ping")
-			if e != nil {
-				t.Fatalf("Failed to send string on data channel")
-			}
+			assert.NoError(t, offerDC.SendText("Ping"), "Failed to send string on data channel")
 		})
 
 		assert.NoError(t, signalPair(offerPC, answerPC))
@@ -238,9 +222,7 @@ func TestDataChannel_Send(t *testing.T) { //nolint:cyclop
 		defer report()
 
 		offerPC, answerPC, err := newPair()
-		if err != nil {
-			t.Fatalf("Failed to create a PC pair for testing")
-		}
+		assert.NoError(t, err)
 
 		done := make(chan bool)
 
@@ -251,35 +233,25 @@ func TestDataChannel_Send(t *testing.T) { //nolint:cyclop
 				return
 			}
 			d.OnMessage(func(DataChannelMessage) {
-				e := d.Send([]byte("Pong"))
-				if e != nil {
-					t.Fatalf("Failed to send string on data channel")
-				}
+				assert.NoError(t, d.Send([]byte("Pong")), "Failed to send string on data channel")
 			})
 			assert.True(t, d.Ordered(), "Ordered should be set to true")
 		})
 
 		dc, err := offerPC.CreateDataChannel(expectedLabel, nil)
-		if err != nil {
-			t.Fatalf("Failed to create a PC pair for testing")
-		}
+		assert.NoError(t, err)
 
 		assert.True(t, dc.Ordered(), "Ordered should be set to true")
 
 		dc.OnOpen(func() {
-			e := dc.SendText("Ping")
-			if e != nil {
-				t.Fatalf("Failed to send string on data channel")
-			}
+			assert.NoError(t, dc.SendText("Ping"), "Failed to send string on data channel")
 		})
 		dc.OnMessage(func(DataChannelMessage) {
 			done <- true
 		})
 
 		err = signalPair(offerPC, answerPC)
-		if err != nil {
-			t.Fatalf("Failed to signal our PC pair for testing: %+v", err)
-		}
+		assert.NoError(t, err)
 
 		closePair(t, offerPC, answerPC, done)
 	})
@@ -289,9 +261,7 @@ func TestDataChannel_Send(t *testing.T) { //nolint:cyclop
 		defer report()
 
 		offerPC, answerPC, err := newPair()
-		if err != nil {
-			t.Fatalf("Failed to create a PC pair for testing")
-		}
+		assert.NoError(t, err)
 
 		done := make(chan bool)
 
@@ -302,10 +272,7 @@ func TestDataChannel_Send(t *testing.T) { //nolint:cyclop
 				return
 			}
 			d.OnMessage(func(DataChannelMessage) {
-				e := d.Send([]byte("Pong"))
-				if e != nil {
-					t.Fatalf("Failed to send string on data channel")
-				}
+				assert.NoError(t, d.Send([]byte("Pong")), "Failed to send string on data channel")
 			})
 			assert.True(t, d.Ordered(), "Ordered should be set to true")
 		})
@@ -316,9 +283,7 @@ func TestDataChannel_Send(t *testing.T) { //nolint:cyclop
 				// wasm fires completed state multiple times
 				once.Do(func() {
 					dc, createErr := offerPC.CreateDataChannel(expectedLabel, nil)
-					if createErr != nil {
-						t.Fatalf("Failed to create a PC pair for testing")
-					}
+					assert.NoError(t, createErr)
 
 					assert.True(t, dc.Ordered(), "Ordered should be set to true")
 
@@ -329,10 +294,7 @@ func TestDataChannel_Send(t *testing.T) { //nolint:cyclop
 					if e := dc.SendText("Ping"); e != nil {
 						// wasm binding doesn't fire OnOpen (we probably already missed it)
 						dc.OnOpen(func() {
-							e = dc.SendText("Ping")
-							if e != nil {
-								t.Fatalf("Failed to send string on data channel")
-							}
+							assert.NoError(t, dc.SendText("Ping"), "Failed to send string on data channel")
 						})
 					}
 				})
@@ -340,9 +302,7 @@ func TestDataChannel_Send(t *testing.T) { //nolint:cyclop
 		})
 
 		err = signalPair(offerPC, answerPC)
-		if err != nil {
-			t.Fatalf("Failed to signal our PC pair for testing")
-		}
+		assert.NoError(t, err)
 
 		closePair(t, offerPC, answerPC, done)
 	})
@@ -484,14 +444,10 @@ func TestDataChannelParameters(t *testing.T) { //nolint:cyclop
 
 		answerPC.OnDataChannel(func(d *DataChannel) {
 			// Ignore our default channel, exists to force ICE candidates. See signalPair for more info
-			if d.Label() == "initial_data_channel" {
-				return
-			}
-
-			t.Fatal("OnDataChannel must not be fired when negotiated == true")
+			assert.Equal(t, "initial_data_channel", d.Label(), "OnDataChannel must not be fired when negotiated == true")
 		})
 		offerPC.OnDataChannel(func(*DataChannel) {
-			t.Fatal("OnDataChannel must not be fired when negotiated == true")
+			assert.Fail(t, "OnDataChannel must not be fired when negotiated == true")
 		})
 
 		seenAnswerMessage := &atomicBool{}

--- a/dtlsrole_test.go
+++ b/dtlsrole_test.go
@@ -34,9 +34,7 @@ func TestDTLSRole_String(t *testing.T) {
 func TestDTLSRoleFromRemoteSDP(t *testing.T) {
 	parseSDP := func(raw string) *sdp.SessionDescription {
 		parsed := &sdp.SessionDescription{}
-		if err := parsed.Unmarshal([]byte(raw)); err != nil {
-			panic(err)
-		}
+		assert.NoError(t, parsed.Unmarshal([]byte(raw)))
 
 		return parsed
 	}

--- a/icecandidate_test.go
+++ b/icecandidate_test.go
@@ -140,30 +140,18 @@ func TestICECandidate_Convert(t *testing.T) {
 func TestConvertTypeFromICE(t *testing.T) {
 	t.Run("host", func(t *testing.T) {
 		ct, err := convertTypeFromICE(ice.CandidateTypeHost)
-		if err != nil {
-			t.Fatal("failed coverting ice.CandidateTypeHost")
-		}
-		if ct != ICECandidateTypeHost {
-			t.Fatal("should be converted to ICECandidateTypeHost")
-		}
+		assert.NoError(t, err, "failed coverting ice.CandidateTypeHost")
+		assert.Equal(t, ICECandidateTypeHost, ct, "should be converted to ICECandidateTypeHost")
 	})
 	t.Run("srflx", func(t *testing.T) {
 		ct, err := convertTypeFromICE(ice.CandidateTypeServerReflexive)
-		if err != nil {
-			t.Fatal("failed coverting ice.CandidateTypeServerReflexive")
-		}
-		if ct != ICECandidateTypeSrflx {
-			t.Fatal("should be converted to ICECandidateTypeSrflx")
-		}
+		assert.NoError(t, err, "failed coverting ice.CandidateTypeServerReflexive")
+		assert.Equal(t, ICECandidateTypeSrflx, ct, "should be converted to ICECandidateTypeSrflx")
 	})
 	t.Run("prflx", func(t *testing.T) {
 		ct, err := convertTypeFromICE(ice.CandidateTypePeerReflexive)
-		if err != nil {
-			t.Fatal("failed coverting ice.CandidateTypePeerReflexive")
-		}
-		if ct != ICECandidateTypePrflx {
-			t.Fatal("should be converted to ICECandidateTypePrflx")
-		}
+		assert.NoError(t, err, "failed coverting ice.CandidateTypePeerReflexive")
+		assert.Equal(t, ICECandidateTypePrflx, ct, "should be converted to ICECandidateTypePrflx")
 	})
 }
 

--- a/icecandidateinit_test.go
+++ b/icecandidateinit_test.go
@@ -28,21 +28,14 @@ func TestICECandidateInit_Serialization(t *testing.T) {
 
 	for i, tc := range tt {
 		b, err := json.Marshal(tc.candidate)
-		if err != nil {
-			t.Errorf("Failed to marshal %d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "test case %d", i)
 		actualSerialized := string(b)
-		if actualSerialized != tc.serialized {
-			t.Errorf("%d expected %s got %s", i, tc.serialized, actualSerialized)
-		}
+		assert.Equalf(t, tc.serialized, actualSerialized, "test case %d", i)
 
 		var actual ICECandidateInit
 		err = json.Unmarshal(b, &actual)
-		if err != nil {
-			t.Errorf("Failed to unmarshal %d: %v", i, err)
-		}
-
-		assert.Equal(t, tc.candidate, actual, "should match")
+		assert.NoErrorf(t, err, "test case %d", i)
+		assert.Equalf(t, tc.candidate, actual, "test case %d", i)
 	}
 }
 

--- a/icecandidatetype_test.go
+++ b/icecandidatetype_test.go
@@ -24,8 +24,10 @@ func TestICECandidateType(t *testing.T) {
 
 	for i, testCase := range testCases {
 		actual, err := NewICECandidateType(testCase.typeString)
-		if (err != nil) != testCase.shouldFail {
-			t.Error(err)
+		if testCase.shouldFail {
+			assert.Error(t, err, "testCase: %d %v", i, testCase)
+		} else {
+			assert.NoError(t, err, "testCase: %d %v", i, testCase)
 		}
 		assert.Equal(t,
 			testCase.expectedType,

--- a/icegatherer_test.go
+++ b/icegatherer_test.go
@@ -30,13 +30,8 @@ func TestNewICEGatherer_Success(t *testing.T) {
 	}
 
 	gatherer, err := NewAPI().NewICEGatherer(opts)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if gatherer.State() != ICEGathererStateNew {
-		t.Fatalf("Expected gathering state new")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, ICEGathererStateNew, gatherer.State())
 
 	gatherFinished := make(chan struct{})
 	gatherer.OnLocalCandidate(func(i *ICECandidate) {
@@ -45,30 +40,19 @@ func TestNewICEGatherer_Success(t *testing.T) {
 		}
 	})
 
-	if err = gatherer.Gather(); err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, gatherer.Gather())
 
 	<-gatherFinished
 
 	params, err := gatherer.GetLocalParameters()
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
-	if params.UsernameFragment == "" ||
-		params.Password == "" {
-		t.Fatalf("Empty local username or password frag")
-	}
+	assert.NotEmpty(t, params.UsernameFragment, "Empty local username frag")
+	assert.NotEmpty(t, params.Password, "Empty local password")
 
 	candidates, err := gatherer.GetLocalCandidates()
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(candidates) == 0 {
-		t.Fatalf("No candidates gathered")
-	}
+	assert.NoError(t, err)
+	assert.NotEmpty(t, candidates, "No candidates gathered")
 
 	assert.NoError(t, gatherer.Close())
 }
@@ -85,9 +69,7 @@ func TestICEGather_mDNSCandidateGathering(t *testing.T) {
 	s.SetICEMulticastDNSMode(ice.MulticastDNSModeQueryAndGather)
 
 	gatherer, err := NewAPI(WithSettingEngine(s)).NewICEGatherer(ICEGatherOptions{})
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	gotMulticastDNSCandidate, resolveFunc := context.WithCancel(context.Background())
 	gatherer.OnLocalCandidate(func(c *ICECandidate) {
@@ -170,18 +152,14 @@ func TestNewICEGathererSetMediaStreamIdentification(t *testing.T) { //nolint:cyc
 	}
 
 	gatherer, err := NewAPI().NewICEGatherer(opts)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	expectedMid := "5"
 	expectedMLineIndex := uint16(1)
 
 	gatherer.setMediaStreamIdentification(expectedMid, expectedMLineIndex)
 
-	if gatherer.State() != ICEGathererStateNew {
-		t.Fatalf("Expected gathering state new")
-	}
+	assert.Equal(t, ICEGathererStateNew, gatherer.State())
 
 	gatherFinished := make(chan struct{})
 	gatherer.OnLocalCandidate(func(i *ICECandidate) {
@@ -193,30 +171,18 @@ func TestNewICEGathererSetMediaStreamIdentification(t *testing.T) { //nolint:cyc
 		}
 	})
 
-	if err = gatherer.Gather(); err != nil {
-		t.Error(err)
-	}
-
+	assert.NoError(t, gatherer.Gather())
 	<-gatherFinished
 
 	params, err := gatherer.GetLocalParameters()
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
-	if params.UsernameFragment == "" ||
-		params.Password == "" {
-		t.Fatalf("Empty local username or password frag")
-	}
+	assert.NotEmpty(t, params.UsernameFragment, "Empty local username frag")
+	assert.NotEmpty(t, params.Password, "Empty local password")
 
 	candidates, err := gatherer.GetLocalCandidates()
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(candidates) == 0 {
-		t.Fatalf("No candidates gathered")
-	}
+	assert.NoError(t, err)
+	assert.NotEmpty(t, candidates, "No candidates gathered")
 
 	for _, c := range candidates {
 		assert.Equal(t, expectedMid, c.SDPMid)

--- a/iceprotocol_test.go
+++ b/iceprotocol_test.go
@@ -24,8 +24,10 @@ func TestNewICEProtocol(t *testing.T) {
 
 	for i, testCase := range testCases {
 		actual, err := NewICEProtocol(testCase.protoString)
-		if (err != nil) != testCase.shouldFail {
-			t.Error(err)
+		if testCase.shouldFail {
+			assert.Error(t, err, "testCase: %d %v", i, testCase)
+		} else {
+			assert.NoError(t, err, "testCase: %d %v", i, testCase)
 		}
 		assert.Equal(t,
 			testCase.expectedProto,

--- a/icetransport_test.go
+++ b/icetransport_test.go
@@ -82,9 +82,10 @@ func TestICETransport_OnSelectedCandidatePairChange(t *testing.T) {
 	assert.NoError(t, signalPair(pcOffer, pcAnswer))
 	<-iceComplete
 
-	if atomic.LoadInt32(&senderCalledCandidateChange) == 0 {
-		t.Fatalf("Sender ICETransport OnSelectedCandidateChange was never called")
-	}
+	assert.NotEmpty(
+		t, atomic.LoadInt32(&senderCalledCandidateChange),
+		"Sender ICETransport OnSelectedCandidateChange was never called",
+	)
 
 	closePairNow(t, pcOffer, pcAnswer)
 }

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -201,29 +201,21 @@ func Test_Interceptor_BindUnbind(t *testing.T) { //nolint:cyclop
 	assert.NoError(t, receiver.GracefulClose())
 
 	// Bind/UnbindLocal/RemoteStream should be called from one side.
-	if cnt := atomic.LoadUint32(&cntBindLocalStream); cnt != 1 {
-		t.Errorf("BindLocalStreamFn is expected to be called once, but called %d times", cnt)
-	}
-	if cnt := atomic.LoadUint32(&cntUnbindLocalStream); cnt != 1 {
-		t.Errorf("UnbindLocalStreamFn is expected to be called once, but called %d times", cnt)
-	}
-	if cnt := atomic.LoadUint32(&cntBindRemoteStream); cnt != 2 {
-		t.Errorf("BindRemoteStreamFn is expected to be called once, but called %d times", cnt)
-	}
-	if cnt := atomic.LoadUint32(&cntUnbindRemoteStream); cnt != 2 {
-		t.Errorf("UnbindRemoteStreamFn is expected to be called once, but called %d times", cnt)
-	}
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&cntBindLocalStream), "BindLocalStreamFn is expected to be called once")
+	assert.Equal(
+		t, uint32(1), atomic.LoadUint32(&cntUnbindLocalStream), "UnbindLocalStreamFn is expected to be called once",
+	)
+	assert.Equal(
+		t, uint32(2), atomic.LoadUint32(&cntBindRemoteStream), "BindRemoteStreamFn is expected to be called twice",
+	)
+	assert.Equal(
+		t, uint32(2), atomic.LoadUint32(&cntUnbindRemoteStream), "UnbindRemoteStreamFn is expected to be called twice",
+	)
 
 	// BindRTCPWriter/Reader and Close should be called from both side.
-	if cnt := atomic.LoadUint32(&cntBindRTCPWriter); cnt != 2 {
-		t.Errorf("BindRTCPWriterFn is expected to be called twice, but called %d times", cnt)
-	}
-	if cnt := atomic.LoadUint32(&cntBindRTCPReader); cnt != 3 {
-		t.Errorf("BindRTCPReaderFn is expected to be called twice, but called %d times", cnt)
-	}
-	if cnt := atomic.LoadUint32(&cntClose); cnt != 2 {
-		t.Errorf("CloseFn is expected to be called twice, but called %d times", cnt)
-	}
+	assert.Equal(t, uint32(2), atomic.LoadUint32(&cntBindRTCPWriter), "BindRTCPWriterFn is expected to be called twice")
+	assert.Equal(t, uint32(3), atomic.LoadUint32(&cntBindRTCPReader), "BindRTCPReaderFn is expected to be called thrice")
+	assert.Equal(t, uint32(2), atomic.LoadUint32(&cntClose), "CloseFn is expected to be called twice")
 }
 
 func Test_InterceptorRegistry_Build(t *testing.T) {
@@ -438,12 +430,8 @@ func testInterceptorNack(t *testing.T, requestNack bool) { //nolint:cyclop
 	assert.NoError(t, err)
 
 	if requestNack {
-		if !gotNack {
-			t.Errorf("Expected to get a NACK, got none")
-		}
+		assert.True(t, gotNack, "Expected to get a NACK, got none")
 	} else {
-		if gotNack {
-			t.Errorf("Expected to get no NACK, got one")
-		}
+		assert.False(t, gotNack, "Expected to get no NACK, got one")
 	}
 }

--- a/internal/fmtp/fmtp_test.go
+++ b/internal/fmtp/fmtp_test.go
@@ -4,8 +4,9 @@
 package fmtp
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseParameters(t *testing.T) {
@@ -47,9 +48,7 @@ func TestParseParameters(t *testing.T) {
 	} {
 		t.Run(ca.name, func(t *testing.T) {
 			parameters := parseParameters(ca.line)
-			if !reflect.DeepEqual(parameters, ca.parameters) {
-				t.Errorf("expected '%v', got '%v'", ca.parameters, parameters)
-			}
+			assert.Equal(t, ca.parameters, parameters)
 		})
 	}
 }
@@ -132,13 +131,9 @@ func TestParse(t *testing.T) {
 	} {
 		t.Run(ca.name, func(t *testing.T) {
 			f := Parse(ca.mimeType, ca.clockRate, ca.channels, ca.line)
-			if !reflect.DeepEqual(ca.expected, f) {
-				t.Errorf("expected '%v', got '%v'", ca.expected, f)
-			}
 
-			if f.MimeType() != ca.mimeType {
-				t.Errorf("Expected '%v', got '%s'", ca.mimeType, f.MimeType())
-			}
+			assert.Equal(t, ca.expected, f)
+			assert.Equal(t, ca.mimeType, f.MimeType())
 		})
 	}
 }
@@ -704,20 +699,19 @@ func TestMatch(t *testing.T) { //nolint:maintidx
 	} {
 		t.Run(ca.name, func(t *testing.T) {
 			c := ca.a.Match(ca.b)
-			if c != ca.consist {
-				t.Errorf(
-					"'%s' and '%s' are expected to be %s, but treated as %s",
-					ca.a, ca.b, consistString[ca.consist], consistString[c],
-				)
-			}
+			assert.Equal(t, ca.consist, c)
+			assert.Equal(
+				t, ca.consist, c,
+				"'%s' and '%s' are expected to be %s, but treated as %s",
+				ca.a, ca.b, consistString[ca.consist], consistString[c],
+			)
 
 			c = ca.b.Match(ca.a)
-			if c != ca.consist {
-				t.Errorf(
-					"'%s' and '%s' are expected to be %s, but treated as %s",
-					ca.a, ca.b, consistString[ca.consist], consistString[c],
-				)
-			}
+			assert.Equalf(
+				t, ca.consist, c,
+				"'%s' and '%s' are expected to be %s, but treated as %s",
+				ca.b, ca.a, consistString[ca.consist], consistString[c],
+			)
 		})
 	}
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -5,19 +5,14 @@ package util
 
 import (
 	"errors"
-	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMathRandAlpha(t *testing.T) {
-	if len(MathRandAlpha(10)) != 10 {
-		t.Errorf("MathRandAlpha return invalid length")
-	}
-
-	isLetter := regexp.MustCompile(`^[a-zA-Z]+$`).MatchString
-	if !isLetter(MathRandAlpha(10)) {
-		t.Errorf("MathRandAlpha should be AlphaNumeric only")
-	}
+	assert.Len(t, MathRandAlpha(10), 10, "MathRandAlpha should return 10 characters")
+	assert.Regexp(t, `^[a-zA-Z]+$`, MathRandAlpha(10), "MathRandAlpha should be Alpha only")
 }
 
 func TestMultiError(t *testing.T) {
@@ -37,20 +32,13 @@ func TestMultiError(t *testing.T) {
 	})
 	str := "err1\nerr2\nerr3"
 
-	if errs.Error() != str {
-		t.Errorf("String representation doesn't match, expected: %s, got: %s", errs.Error(), str)
-	}
+	assert.Equal(t, str, errs.Error(), "String representation doesn't match")
 
 	errIs, ok := errs.(multiError) //nolint:errorlint
-	if !ok {
-		t.Fatal("FlattenErrs returns non-multiError")
-	}
+	assert.True(t, ok, "FlattenErrs returns non-multiError")
 	for i := 0; i < 3; i++ {
-		if !errIs.Is(rawErrs[i]) {
-			t.Errorf("'%+v' should contains '%v'", errs, rawErrs[i])
-		}
+		assert.Truef(t, errIs.Is(rawErrs[i]), "Should contains this error '%v'", rawErrs[i])
 	}
-	if errIs.Is(rawErrs[3]) {
-		t.Errorf("'%+v' should not contains '%v'", errs, rawErrs[3])
-	}
+
+	assert.Falsef(t, errIs.Is(rawErrs[3]), "Should not contains this error '%v'", rawErrs[3])
 }

--- a/networktype_test.go
+++ b/networktype_test.go
@@ -45,8 +45,10 @@ func TestNetworkType(t *testing.T) {
 
 	for i, testCase := range testCases {
 		actual, err := NewNetworkType(testCase.typeString)
-		if (err != nil) != testCase.shouldFail {
-			t.Error(err)
+		if testCase.shouldFail {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 		assert.Equal(t,
 			testCase.expectedType,

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -101,9 +101,7 @@ func TestPeerConnection_Renegotiation_AddRecvonlyTransceiver(t *testing.T) {
 			defer report()
 
 			pcOffer, pcAnswer, err := newPair()
-			if err != nil {
-				t.Fatal(err)
-			}
+			assert.NoError(t, err)
 
 			_, err = pcOffer.AddTransceiverFromKind(
 				RTPCodecTypeVideo,
@@ -162,16 +160,12 @@ func TestPeerConnection_Renegotiation_AddTrack(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	haveRenegotiated := &atomicBool{}
 	onTrackFired, onTrackFiredFunc := context.WithCancel(context.Background())
 	pcAnswer.OnTrack(func(*TrackRemote, *RTPReceiver) {
-		if !haveRenegotiated.get() {
-			t.Fatal("OnTrack was called before renegotiation")
-		}
+		assert.True(t, haveRenegotiated.get(), "OnTrack was called before renegotiation")
 		onTrackFiredFunc()
 	})
 
@@ -250,9 +244,7 @@ func TestPeerConnection_Renegotiation_AddTrack_Multiple(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	pcAnswer.OnTrack(func(track *TrackRemote, _ *RTPReceiver) {
 		onTrackCount[track.ID()]++
@@ -289,17 +281,13 @@ func TestPeerConnection_Renegotiation_AddTrack_Rename(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	haveRenegotiated := &atomicBool{}
 	onTrackFired, onTrackFiredFunc := context.WithCancel(context.Background())
 	var atomicRemoteTrack atomic.Value
 	pcOffer.OnTrack(func(track *TrackRemote, _ *RTPReceiver) {
-		if !haveRenegotiated.get() {
-			t.Fatal("OnTrack was called before renegotiation")
-		}
+		assert.True(t, haveRenegotiated.get(), "OnTrack was called before renegotiation")
 		onTrackFiredFunc()
 		atomicRemoteTrack.Store(track)
 	})
@@ -560,9 +548,7 @@ func TestPeerConnection_Renegotiation_RemoveTrack(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	_, err = pcAnswer.AddTransceiverFromKind(
 		RTPCodecTypeVideo,
@@ -609,9 +595,7 @@ func TestPeerConnection_RoleSwitch(t *testing.T) {
 	defer report()
 
 	pcFirstOfferer, pcSecondOfferer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	onTrackFired, onTrackFiredFunc := context.WithCancel(context.Background())
 	pcFirstOfferer.OnTrack(func(*TrackRemote, *RTPReceiver) {
@@ -663,9 +647,7 @@ func TestPeerConnection_Renegotiation_Trickle(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	_, err = pcOffer.CreateDataChannel("test-channel", nil)
 	assert.NoError(t, err)
@@ -718,9 +700,7 @@ func TestPeerConnection_Renegotiation_SetLocalDescription(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	onTrackFired, onTrackFiredFunc := context.WithCancel(context.Background())
 	pcOffer.OnTrack(func(*TrackRemote, *RTPReceiver) {
@@ -797,9 +777,7 @@ func TestPeerConnection_Renegotiation_NoApplication(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	pcOfferConnected, pcOfferConnectedCancel := context.WithCancel(context.Background())
 	pcOffer.OnICEConnectionStateChange(func(i ICEConnectionState) {
@@ -928,9 +906,8 @@ func TestNegotiationCreateDataChannel(t *testing.T) {
 	})
 
 	// Create DataChannel, wait until OnNegotiationNeeded is fired
-	if _, err = pc.CreateDataChannel("testChannel", nil); err != nil {
-		t.Error(err.Error())
-	}
+	_, err = pc.CreateDataChannel("testChannel", nil)
+	assert.NoError(t, err)
 
 	// Wait until OnNegotiationNeeded is fired
 	wg.Wait()
@@ -1224,9 +1201,7 @@ func TestPeerConnection_Regegotiation_ReuseTransceiver(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	vp8Track, err := NewTrackLocalStaticRTP(RTPCodecCapability{MimeType: MimeTypeVP8}, "foo", "bar")
 	assert.NoError(t, err)
@@ -1360,9 +1335,7 @@ func TestPeerConnection_Regegotiation_AnswerAddsTrack(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	tracksCh := make(chan *TrackRemote)
 	pcOffer.OnTrack(func(track *TrackRemote, _ *RTPReceiver) {
@@ -1412,9 +1385,7 @@ func TestNegotiationNeededWithRecvonlyTrack(t *testing.T) {
 	defer report()
 
 	pcOffer, pcAnswer, err := newPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -1424,13 +1395,8 @@ func TestNegotiationNeededWithRecvonlyTrack(t *testing.T) {
 		RTPCodecTypeVideo,
 		RTPTransceiverInit{Direction: RTPTransceiverDirectionRecvonly},
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := signalPair(pcOffer, pcAnswer); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
+	assert.NoError(t, signalPair(pcOffer, pcAnswer))
 
 	onDataChannel, onDataChannelCancel := context.WithCancel(context.Background())
 	pcAnswer.OnDataChannel(func(*DataChannel) {

--- a/pkg/media/rtpdump/rtpdump_test.go
+++ b/pkg/media/rtpdump/rtpdump_test.go
@@ -4,11 +4,11 @@
 package rtpdump
 
 import (
-	"errors"
 	"net"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHeaderRoundTrip(t *testing.T) {
@@ -31,18 +31,11 @@ func TestHeaderRoundTrip(t *testing.T) {
 		},
 	} {
 		d, err := test.Header.Marshal()
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 
 		var hdr Header
-		if err := hdr.Unmarshal(d); err != nil {
-			t.Fatal(err)
-		}
-
-		if got, want := hdr, test.Header; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal(%v.Marshal()) = %v, want identical", got, want)
-		}
+		assert.NoError(t, hdr.Unmarshal(d))
+		assert.Equal(t, test.Header, hdr)
 	}
 }
 
@@ -69,13 +62,8 @@ func TestMarshalHeader(t *testing.T) {
 		},
 	} {
 		data, err := test.Header.Marshal()
-		if got, want := err, test.WantErr; !errors.Is(got, want) {
-			t.Fatalf("Marshal(%q) err=%v, want %v", test.Name, got, want)
-		}
-
-		if got, want := data, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Marshal(%q) = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIs(t, err, test.WantErr)
+		assert.Equal(t, test.Want, data)
 	}
 }
 
@@ -106,17 +94,11 @@ func TestPacketRoundTrip(t *testing.T) {
 		},
 	} {
 		packet, err := test.Packet.Marshal()
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 
 		var pkt Packet
-		if err := pkt.Unmarshal(packet); err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, pkt.Unmarshal(packet))
 
-		if got, want := pkt, test.Packet; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal(%v.Marshal()) = %v, want identical", got, want)
-		}
+		assert.Equal(t, test.Packet, pkt)
 	}
 }

--- a/rtpsender_test.go
+++ b/rtpsender_test.go
@@ -65,7 +65,7 @@ func Test_RTPSender_ReplaceTrack(t *testing.T) { //nolint:cyclop
 				assert.Equal(t, track.Codec().MimeType, MimeTypeH264)
 				seenPacketBCancel()
 			default:
-				t.Fatalf("Unexpected RTP Data % 02x", pkt.Payload[len(pkt.Payload)-1])
+				assert.Failf(t, "Unexpected RTP", "Data % 02x", pkt.Payload[len(pkt.Payload)-1])
 			}
 		}
 	})

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -742,9 +742,9 @@ func TestPopulateSDP(t *testing.T) { //nolint:cyclop,maintidx
 			}
 			for _, a := range desc.Attributes {
 				if strings.Contains(a.Key, "rtpmap") {
-					if a.Value == "98 VP9/90000" {
-						t.Fatal("vp9 should not be present in sdp")
-					} else if a.Value == "96 VP8/90000" {
+					assert.NotEqual(t, a.Value, "98 VP9/90000", "vp9 should not be present in sdp")
+
+					if a.Value == "96 VP8/90000" {
 						foundVP8 = true
 					}
 				}

--- a/stats_go_test.go
+++ b/stats_go_test.go
@@ -38,9 +38,7 @@ func TestStatsTimestampTime(t *testing.T) {
 			WantTime:  time.Unix(0, 1e3),
 		},
 	} {
-		if got, want := test.Timestamp.Time(), test.WantTime.UTC(); got != want {
-			t.Fatalf("StatsTimestamp(%v).Time() = %v, want %v", test.Timestamp, got, want)
-		}
+		assert.Equal(t, test.WantTime.UTC(), test.Timestamp.Time())
 	}
 }
 
@@ -1171,7 +1169,7 @@ func waitWithTimeout(t *testing.T, wg *sync.WaitGroup) {
 	case <-done:
 		break
 	case <-timeout:
-		t.Fatal("timed out waiting for waitgroup")
+		assert.Fail(t, "timed out waiting for waitgroup")
 	}
 }
 


### PR DESCRIPTION
#### Description
Use testify's assert package instead of the standard library's testing package.

#### Reference issue
https://github.com/pion/.goassets/pull/222