### PR TITLE
FEC mimeType

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -54,6 +54,12 @@ const (
 	// MimeTypeFlexFEC FEC MIME Type
 	// Note: Matching should be case insensitive.
 	MimeTypeFlexFEC = "video/flexfec"
+	// MimeTypeFlexFEC03 FlexFEC03 MIME Type
+	// Note: Matching should be case insensitive.
+	MimeTypeFlexFEC03 = "video/flexfec-03"
+	// MimeTypeUlpFEC UlpFEC MIME Type
+	// Note: Matching should be case insensitive.
+	MimeTypeUlpFEC = "video/ulpfec"
 )
 
 type mediaEngineHeaderExtension struct {


### PR DESCRIPTION
#### Description

Add const mime type for flexfec03, flexfec20 and ulpfec (flexfec03 and ulpfec is currently supported by most browsers, and pion is currently in the process of getting flexfec03 and flexfec20 implemented).