### PR TITLE
Fix pion2pion example readme

### DIFF
--- a/examples/pion-to-pion/README.md
+++ b/examples/pion-to-pion/README.md
@@ -7,12 +7,12 @@ The `answer` side acts like a HTTP server and should therefore be ran first.
 ## Instructions
 First run `answer`:
 ```sh
-go install github.com/pion/webrtc/v4/examples/pion-to-pion/answer
+go install github.com/pion/webrtc/v4/examples/pion-to-pion/answer@latest
 answer
 ```
 Next, run `offer`:
 ```sh
-go install github.com/pion/webrtc/v4/examples/pion-to-pion/offer
+go install github.com/pion/webrtc/v4/examples/pion-to-pion/offer@latest
 offer
 ```
 


### PR DESCRIPTION
#### Description
This PR updates the pion-to-pion example README to include `@latest`, aligning it with other examples.
To install the module without being inside the WebRTC repository, explicitly specifying the version is required.

For reference, see other examples, e.g., [reflect example](https://github.com/amanakin/webrtc/tree/master/examples/reflect).