### PR TITLE
Added missing lock

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2880,6 +2880,9 @@ func (pc *PeerConnection) generateMatchedSDP(
 		}
 	}
 
+	pc.sctpTransport.lock.Lock()
+	defer pc.sctpTransport.lock.Unlock()
+
 	var bundleGroup *string
 	// If we are offering also include unmatched local transceivers
 	if includeUnmatched { //nolint:nestif


### PR DESCRIPTION
My tests executed with race detector enabled found that code tries to read value of `pc.sctpTransport.dataChannelsRequested` without lock.