### PR TITLE
Added SCTPTransport.BufferedAmount

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -430,3 +430,14 @@ func (r *SCTPTransport) association() *sctp.Association {
 
 	return association
 }
+
+// BufferedAmount returns total amount (in bytes) of currently buffered user data.
+func (r *SCTPTransport) BufferedAmount() int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.sctpAssociation == nil {
+		return 0
+	}
+
+	return r.sctpAssociation.BufferedAmount()
+}


### PR DESCRIPTION
It simplifies tracking amount of unsent data for all data channels, including ones in closing state. Especially useful for IoT apps which use multiple data channels and have to monitor memory usage.
