### PR TITLE
Add Advertising / Reading ICE trickle support

### DIFF
--- a/offeransweroptions.go
+++ b/offeransweroptions.go
@@ -9,6 +9,10 @@ type OfferAnswerOptions struct {
 	// VoiceActivityDetection allows the application to provide information
 	// about whether it wishes voice detection feature to be enabled or disabled.
 	VoiceActivityDetection bool
+	// ICETricklingSupported indicates whether the ICE agent should use trickle ICE
+	// If set, the "a=ice-options:trickle ice2" attribute is added to the generated SDP payload.
+	// (See https://datatracker.ietf.org/doc/html/rfc9725#section-4.3.3)
+	ICETricklingSupported bool
 }
 
 // AnswerOptions structure describes the options used to control the answer


### PR DESCRIPTION
#### Description
Figured I'd try my hand at dealing with this. I'll be honest and say I don't FULLY understand what this is for, since pion already supports trickle ICE, but since this IS part of the spec, might as well.

This is nowhere near done (I will also have to do a pull request to the SDP repo to finish the feature), but I do have some questions

- [ ] the "a=ice-options:tickle" seem to be related to ice2? Whatever that is (see https://datatracker.ietf.org/doc/html/rfc9725#section-4.3.3) Does that mean I have to tack on ice2 to the attribute?
- [ ] how exactly would i add the attribute? I guess I just add a constant here and be done with it https://github.com/pion/sdp/blob/c395deb80b693c4a4f5b28d1ce435f27fa2bc40e/jsep.go#L14

#### Reference issue
Fixes https://github.com/pion/webrtc/issues/2898
