### PR TITLE
Add WithRTPTimestamp to set  initial RTP timestamp

### DIFF
--- a/track_local_static_test.go
+++ b/track_local_static_test.go
@@ -425,3 +425,44 @@ func Test_TrackLocalStatic_Payloader(t *testing.T) {
 
 	closePairNow(t, offerer, answerer)
 }
+
+func Test_TrackLocalStatic_Timestamp(t *testing.T) {
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	initialTimestamp := uint32(12345)
+	track, err := NewTrackLocalStaticSample(
+		RTPCodecCapability{MimeType: MimeTypeVP8},
+		"video",
+		"pion",
+		WithRTPTimestamp(initialTimestamp),
+	)
+	assert.NoError(t, err)
+
+	pcOffer, pcAnswer, err := newPair()
+	assert.NoError(t, err)
+
+	_, err = pcOffer.AddTrack(track)
+	assert.NoError(t, err)
+
+	onTrackFired, onTrackFiredFunc := context.WithCancel(context.Background())
+	pcAnswer.OnTrack(func(trackRemote *TrackRemote, _ *RTPReceiver) {
+		pkt, _, err := trackRemote.ReadRTP()
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, pkt.Timestamp, initialTimestamp)
+		// Allow for ~10 dropped packets
+		assert.LessOrEqual(t, pkt.Timestamp, initialTimestamp+30000)
+
+		onTrackFiredFunc()
+	})
+
+	assert.NoError(t, signalPair(pcOffer, pcAnswer))
+
+	sendVideoUntilDone(t, onTrackFired.Done(), []*TrackLocalStaticSample{track})
+
+	<-onTrackFired.Done()
+	closePairNow(t, pcOffer, pcAnswer)
+}


### PR DESCRIPTION
#### Description

Move to the new RTP API newPacketizerWithOptions, add WithRTPTimestamp To make it possible to set the initial RTP timestamp for the track.

#### Reference issue
Fixes https://github.com/pion/rtp/issues/111