### PR TITLE
Implement `GetRemoteCertificate` for `DTLSTransport` in wasm

### DIFF
--- a/dtlstransport_js.go
+++ b/dtlstransport_js.go
@@ -34,3 +34,31 @@ func (r *DTLSTransport) ICETransport() *ICETransport {
 		underlying: underlying,
 	}
 }
+
+func (t *DTLSTransport) GetRemoteCertificate() []byte {
+	if t.underlying.IsNull() || t.underlying.IsUndefined() {
+		return nil
+	}
+
+	// Firefox does not support getRemoteCertificates: https://bugzilla.mozilla.org/show_bug.cgi?id=1805446
+	jsGet := t.underlying.Get("getRemoteCertificates")
+	if jsGet.IsUndefined() || jsGet.IsNull() {
+		return nil
+	}
+
+	jsCerts := t.underlying.Call("getRemoteCertificates")
+	if jsCerts.Length() == 0 {
+		return nil
+	}
+
+	buf := jsCerts.Index(0)
+	u8 := js.Global().Get("Uint8Array").New(buf)
+
+	if u8.Length() == 0 {
+		return nil
+	}
+
+	cert := make([]byte, u8.Length())
+	js.CopyBytesToGo(cert, u8)
+	return cert
+}


### PR DESCRIPTION
#### Description

Implements basic support for `GetRemoteCertificate` using [`getRemoteCertificates`](https://caniuse.com/mdn-api_rtcdtlstransport_getremotecertificates)

I'm not sure how to write tests for it, do I mock JS globals?

#### Reference issue

Partially addresses https://github.com/libp2p/go-libp2p/issues/3277