### PR TITLE
When looking for simulcast IDs, don't forget to check the packet we already have

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1784,7 +1784,20 @@ func (pc *PeerConnection) handleIncomingSSRC(rtpStream io.Reader, ssrc SSRC) err
 		return err
 	}
 
+	// try to read simulcast IDs from the packet we already have
 	var mid, rid, rsid string
+	if _, _, err = handleUnknownRTPPacket(
+		b[:i], uint8(midExtensionID), //nolint:gosec // G115
+		uint8(streamIDExtensionID),       //nolint:gosec // G115
+		uint8(repairStreamIDExtensionID), //nolint:gosec // G115
+		&mid,
+		&rid,
+		&rsid,
+	); err != nil {
+		return err
+	}
+
+	// if the first packet didn't contain simuilcast IDs, then probe more packets
 	var paddingOnly bool
 	for readCount := 0; readCount <= simulcastProbeCount; readCount++ {
 		if mid == "" || (rid == "" && rsid == "") {


### PR DESCRIPTION
#### Description

The code that looks for Simulcast IDs (mid and rid) currently ignores the first packet.

Fix: check the first packet (that we already have) as well.

Technically it's better when the sending party includes Simulcast IDs on some number of packets after establishing the connection, but this fix helps when the sending party doesn't do that (which might happen).

Since we already have the first packet in `b[:i]`, we just need to call the function that extracts those IDs from the packet - `handleUnknownRTPPacket` - before entering the loop which reads more packets.

