### PR TITLE
Copy PaddingSize from rtp.Packet to Header

### DIFF
--- a/track_local_static.go
+++ b/track_local_static.go
@@ -194,6 +194,11 @@ func (s *TrackLocalStaticRTP) writeRTP(packet *rtp.Packet) error {
 	for _, b := range s.bindings {
 		packet.Header.SSRC = uint32(b.ssrc)
 		packet.Header.PayloadType = uint8(b.payloadType)
+		// b.writeStream.WriteRTP below expects header and payload separately, so value of Packet.PaddingSize
+		// would be lost. Copy it to Packet.Header.PaddingSize to avoid that problem.
+		if packet.PaddingSize != 0 && packet.Header.PaddingSize == 0 {
+			packet.Header.PaddingSize = packet.PaddingSize
+		}
 		if _, err := b.writeStream.WriteRTP(&packet.Header, packet.Payload); err != nil {
 			writeErrs = append(writeErrs, err)
 		}

--- a/track_local_static_test.go
+++ b/track_local_static_test.go
@@ -323,6 +323,7 @@ func Test_TrackLocalStatic_Padding(t *testing.T) {
 			assert.NoError(t, e)
 			assert.True(t, p.Padding)
 			assert.Equal(t, p.PaddingSize, byte(255))
+			assert.Equal(t, p.Header.PaddingSize, byte(255))
 		}
 
 		onTrackFiredFunc()


### PR DESCRIPTION
#### Description
Updated version of `pion/srtp` was picked to `pion/webrtc` a bit earlier today, it fixes #2403 for applications which uses new field `rtp.Packet.Header.PaddingSize`. This PR adds extra change to fix it too for applications who use old field `rtp.Packet.PaddingSize`.

One more PR for `pion/rtp` is need to remove workaround used by `Test_TrackLocalStatic_Padding` test, I will create it after this one is merged.

#### Reference issue
Fixes #2403
