### PR TITLE
WHIP-WHEP example improvements

### DIFF
--- a/examples/whip-whep/index.html
+++ b/examples/whip-whep/index.html
@@ -31,6 +31,7 @@
 
     window.doWHEP = () => {
       peerConnection.addTransceiver('video', { direction: 'recvonly' })
+      peerConnection.addTransceiver('audio', { direction: 'recvonly' })
 
       peerConnection.ontrack = function (event) {
         document.getElementById('videoPlayer').srcObject = event.streams[0]
@@ -57,7 +58,7 @@
     }
 
     window.doWHIP = () => {
-      navigator.mediaDevices.getUserMedia({ video: true, audio: false })
+      navigator.mediaDevices.getUserMedia({ video: true, audio: true })
         .then(stream => {
           document.getElementById('videoPlayer').srcObject = stream
           stream.getTracks().forEach(track => peerConnection.addTrack(track, stream))


### PR DESCRIPTION
#### Description

WHIP-WHEP example improvements:

- Add audio support
- Remove redundant logging from dumping SenderReport RTCP packets
- Add OPTIONS method handling for CORS to WHIP and WHEP http handlers
- Configure WHEP the same way as WHIP, using a `MediaEngine`
- Enable TWCC SEQ number sender for WHEP

#### Reference issue
Fixes https://github.com/pion/webrtc/issues/3179