### PR TITLE
Improve RTCP Read

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -44,6 +44,8 @@ const (
 
 	incomingUnhandledRTPSsrc = "Incoming unhandled RTP ssrc(%d), OnTrack will not be fired. %v"
 
+	useReadSimulcast = "Use ReadSimulcast(rid) instead of Read() when multiple tracks are present"
+
 	generatedCertificateOrigin = "WebRTC"
 
 	// AttributeRtxPayloadType is the interceptor attribute added when Read()


### PR DESCRIPTION
Notify to use ReadSimulcast with rid when multiple tracks are present in RTPReceiver

#### Description

Note: The end-user is using `receiver.ReadRTCP()` instead of `receiver.ReadSimulcastRTCP(track.RID())` for handling simulcast.

The simulcast is configured with three encodings:
```
{ rid: '360', scaleResolutionDownBy: 3.0, maxBitrate: 150_000 },
{ rid: '640', scaleResolutionDownBy: 2.0, maxBitrate: 400_000 },
{ rid: '1024', scaleResolutionDownBy: 1.0, maxBitrate: 1_000_000 }
 ```
 
When the ontrack event is fired in the expected order — for example: 360 -> 640 -> 1024 
Everything seems working fine. No panic occurs, and RTCP packets are read successfully for all simulcast tracks.

<img width="1115" height="118" alt="Screenshot from 2025-07-24 18-36-57" src="https://github.com/user-attachments/assets/9fb63b85-097e-4cd9-8be2-937eb2cef1af" />

RTCP is read three times, but internally, all reads point to track[0] (RID 360). 
So while it seems like RTCP is being read for all simulcast layers, it’s actually reading only from the first track each time
This gives the false impression that everything is working, but in reality, RTCP for RID 640 and 1024 is not being read at all.

Trigger a panic only when the ontrack events fire in an unexpected (random) order for example: 640 -> 360 -> 1024

<img width="1081" height="71" alt="Screenshot from 2025-07-24 18-38-40" src="https://github.com/user-attachments/assets/13b00b3b-2a9f-4f2d-a897-4c7e657adedd" /> 

In this case, when trying to read RTCP for RID 640, it incorrectly maps to track[0] (which corresponds to RID 360). Since the RTCP interceptor for that track hasn't been set up yet, a panic occurs and is not properly handled.



#### Reference issue
Fixes #...
