### PR TITLE
Add collection for inbound-rtp stats

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -7,6 +7,7 @@
 package webrtc
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/pion/interceptor"
@@ -14,6 +15,7 @@ import (
 	"github.com/pion/interceptor/pkg/nack"
 	"github.com/pion/interceptor/pkg/report"
 	"github.com/pion/interceptor/pkg/rfc8888"
+	"github.com/pion/interceptor/pkg/stats"
 	"github.com/pion/interceptor/pkg/twcc"
 	"github.com/pion/rtp"
 	"github.com/pion/sdp/v3"
@@ -35,8 +37,40 @@ func RegisterDefaultInterceptors(mediaEngine *MediaEngine, interceptorRegistry *
 		return err
 	}
 
+	if err := ConfigureStatsInterceptor(interceptorRegistry); err != nil {
+		return err
+	}
+
 	return ConfigureTWCCSender(mediaEngine, interceptorRegistry)
 }
+
+// ConfigureStatsInterceptor will setup everything necessary for generating RTP stream statistics.
+func ConfigureStatsInterceptor(interceptorRegistry *interceptor.Registry) error {
+	statsInterceptor, err := stats.NewInterceptor()
+	if err != nil {
+		return err
+	}
+	statsInterceptor.OnNewPeerConnection(func(id string, stats stats.Getter) {
+		statsGetter.Store(id, stats)
+	})
+	interceptorRegistry.Add(statsInterceptor)
+
+	return nil
+}
+
+// lookupStats returns the stats getter for a given peerconnection.statsId.
+func lookupStats(id string) (stats.Getter, bool) {
+	if value, exists := statsGetter.Load(id); exists {
+		if getter, ok := value.(stats.Getter); ok {
+			return getter, true
+		}
+	}
+
+	return nil, false
+}
+
+// key: string (peerconnection.statsId), value: stats.Getter
+var statsGetter sync.Map // nolint:gochecknoglobals
 
 // ConfigureRTCPReports will setup everything necessary for generating Sender and Receiver Reports.
 func ConfigureRTCPReports(interceptorRegistry *interceptor.Registry) error {

--- a/rtpreceiver_test.go
+++ b/rtpreceiver_test.go
@@ -8,13 +8,17 @@ package webrtc
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/pion/interceptor"
+	"github.com/pion/interceptor/pkg/stats"
+	"github.com/pion/logging"
 	"github.com/pion/transport/v3/test"
 	"github.com/pion/webrtc/v4/pkg/media"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Assert that SetReadDeadline works as expected
@@ -64,3 +68,70 @@ func Test_RTPReceiver_SetReadDeadline(t *testing.T) {
 	assert.NoError(t, wan.Stop())
 	closePairNow(t, sender, receiver)
 }
+
+// TestRTPReceiver_CollectStats_Mapping validates that collectStats maps
+// interceptor/pkg/stats values into InboundRTPStreamStats.
+func TestRTPReceiver_CollectStats_Mapping(t *testing.T) {
+	ssrc := SSRC(1234)
+	now := time.Now()
+	pr := uint64(math.MaxUint32) + 42
+	pl := int64(math.MaxInt32) + 7
+	jitter := 0.123
+	bytes := uint64(98765)
+	hdrBytes := uint64(4321)
+	fir := uint32(3)
+	pli := uint32(5)
+	nack := uint32(7)
+
+	fg := &fakeGetter{s: stats.Stats{
+		InboundRTPStreamStats: stats.InboundRTPStreamStats{
+			ReceivedRTPStreamStats: stats.ReceivedRTPStreamStats{
+				PacketsReceived: pr,
+				PacketsLost:     pl,
+				Jitter:          jitter,
+			},
+			LastPacketReceivedTimestamp: now,
+			HeaderBytesReceived:         hdrBytes,
+			BytesReceived:               bytes,
+			FIRCount:                    fir,
+			PLICount:                    pli,
+			NACKCount:                   nack,
+		},
+	}}
+
+	// Minimal RTPReceiver with one track
+	r := &RTPReceiver{
+		kind: RTPCodecTypeVideo,
+		log:  logging.NewDefaultLoggerFactory().NewLogger("RTPReceiverTest"),
+	}
+	tr := newTrackRemote(RTPCodecTypeVideo, ssrc, 0, "", r)
+	r.tracks = []trackStreams{{track: tr}}
+
+	collector := newStatsReportCollector()
+	r.collectStats(collector, fg)
+	report := collector.Ready()
+
+	// Fetch the generated inbound-rtp stat by ID
+	statID := "inbound-rtp-1234"
+	got, ok := report[statID]
+	require.True(t, ok, "missing inbound stat")
+
+	inbound, ok := got.(InboundRTPStreamStats)
+	require.True(t, ok)
+
+	// Wrap-around semantics for casts
+	assert.Equal(t, uint32(pr), inbound.PacketsReceived) //nolint:gosec
+	assert.Equal(t, int32(pl), inbound.PacketsLost)      //nolint:gosec
+	assert.Equal(t, jitter, inbound.Jitter)
+	assert.Equal(t, bytes, inbound.BytesReceived)
+	assert.Equal(t, hdrBytes, inbound.HeaderBytesReceived)
+	assert.Equal(t, fir, inbound.FIRCount)
+	assert.Equal(t, pli, inbound.PLICount)
+	assert.Equal(t, nack, inbound.NACKCount)
+	// Timestamp should be set (millisecond precision)
+	assert.Greater(t, float64(inbound.LastPacketReceivedTimestamp), 0.0)
+}
+
+type fakeGetter struct{ s stats.Stats }
+
+func (f *fakeGetter) Get(uint32) *stats.Stats { return &f.s }


### PR DESCRIPTION
### Summary

Implement receiver-side stats for each primary SSRC: emits InboundRTPStreamStats with key fields (ssrc, kind, mid, transportId, codecId) and prepares for populating counters (packetsReceived, packetsLost, jitter, bytesReceived, framesDecoded, etc.). 

Out of scope: 
- This is not getting audio playout stats (media-playout). This will be implemented in a separate PR.

### Issue

Resolves pion/webrtc#3134


### How To Test

1. Run `TestPeerConnection_GetStats` in `stats_go_test.go`.

or 

1. Run a simple receive example and inspect stats:
2. Start any example that receives media (e.g., examples/stats/main.go).
3. Establish a call and let media flow for a few seconds.
4. Call pc.GetStats() and verify:
- At least one object with type == "inbound-rtp" per primary SSRC.
- Fields ssrc, kind, mid, transportId ("iceTransport"), and codecId are present.
- Key counters (packets/bytes/jitter/frames) show expected, increasing values as traffic flows.