### PR TITLE
Fire OnBufferedAmountLow in a goroutine

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -707,9 +707,13 @@ func (d *DataChannel) OnBufferedAmountLow(f func()) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.onBufferedAmountLow = f
+	d.onBufferedAmountLow = func() {
+		go f()
+	}
 	if d.dataChannel != nil {
-		d.dataChannel.OnBufferedAmountLow(f)
+		d.dataChannel.OnBufferedAmountLow(func() {
+			go f()
+		})
 	}
 }
 

--- a/examples/data-channels-flow-control/main.go
+++ b/examples/data-channels-flow-control/main.go
@@ -86,8 +86,6 @@ func createOfferer() *webrtc.PeerConnection {
 
 	// This callback is made when the current bufferedAmount becomes lower than the threshold
 	dataChannel.OnBufferedAmountLow(func() {
-		// Make sure to not block this channel or perform long running operations in this callback
-		// This callback is executed by pion/sctp. If this callback is blocking it will stop operations
 		select {
 		case sendMoreCh <- struct{}{}:
 		default:


### PR DESCRIPTION
If a user blocks this routine it would stop inbound message handling in SCTP. To reduce the sharp edge fire it in a goroutine so users don't need to worry about blocking.

`data-channels-flow-control` exhibited no differences in throughput from this change.

Resolves #846
