### PR TITLE
Fix RTPSender.SetReadDeadline crash

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -244,6 +244,7 @@ var (
 	errRTPSenderTrackNil             = errors.New("Track must not be nil")
 	errRTPSenderDTLSTransportNil     = errors.New("DTLSTransport must not be nil")
 	errRTPSenderSendAlreadyCalled    = errors.New("Send has already been called")
+	errRTPSenderSendNotCalled        = errors.New("Send has not been called")
 	errRTPSenderStopped              = errors.New("Sender has already been stopped")
 	errRTPSenderTrackRemoved         = errors.New("Sender Track has been removed or replaced to nil")
 	errRTPSenderRidNil               = errors.New("Sender cannot add encoding as rid is empty")

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -470,6 +470,10 @@ func (r *RTPSender) ReadSimulcastRTCP(rid string) ([]rtcp.Packet, interceptor.At
 // SetReadDeadline sets the deadline for the Read operation.
 // Setting to zero means no deadline.
 func (r *RTPSender) SetReadDeadline(t time.Time) error {
+	if r.trackEncodings[0].srtpStream == nil {
+		return errRTPSenderSendNotCalled
+	}
+
 	return r.trackEncodings[0].srtpStream.SetReadDeadline(t)
 }
 


### PR DESCRIPTION
Add nil pointer check when calling SetReadDeadline. I don't believe this can happen with WebRTC, but is possible with `ortc`.

A future improvement would be to cache the `SetReadDeadline` call. At this time the complexity seems to outweight the reward.

Resolves #2889