### PR TITLE
Cleanup statsGetter after peer is closed

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -69,6 +69,11 @@ func lookupStats(id string) (stats.Getter, bool) {
 	return nil, false
 }
 
+// cleanupStats removes the stats getter for a given peerconnection.statsId.
+func cleanupStats(id string) {
+	statsGetter.Delete(id)
+}
+
 // key: string (peerconnection.statsId), value: stats.Getter
 var statsGetter sync.Map // nolint:gochecknoglobals
 

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2481,6 +2481,9 @@ func (pc *PeerConnection) close(shouldGracefullyClose bool) error { //nolint:cyc
 
 	closeErrs = append(closeErrs, doGracefulCloseOps()...) //nolint:makezero // todo fix
 
+	pc.statsGetter = nil
+	cleanupStats(pc.statsID)
+
 	// Interceptor closes at the end to prevent Bind from being called after interceptor is closed
 	closeErrs = append(closeErrs, pc.api.interceptor.Close()) //nolint:makezero // todo fix
 


### PR DESCRIPTION
#### Description

Cleanup statsGetter after peer is closed to prevent memory leaks.