### PR TITLE
Add AudioPlayoutStatsProvider interface for getting media-playout stats

### DIFF
--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -413,6 +413,7 @@ func (r *RTPReceiver) collectStats(collector *statsReportCollector, statsGetter 
 		mid = r.tr.Mid()
 	}
 	now := statsTimestampNow()
+	nowTime := now.Time()
 	for trackIndex := range r.tracks {
 		remoteTrack := r.tracks[trackIndex].track
 		if remoteTrack == nil {
@@ -465,6 +466,22 @@ func (r *RTPReceiver) collectStats(collector *statsReportCollector, statsGetter 
 		}
 
 		collector.Collect(inboundID, inboundStats)
+
+		if remoteTrack.Kind() == RTPCodecTypeAudio {
+			r.collectAudioPlayoutStats(collector, nowTime, remoteTrack)
+		}
+	}
+}
+
+func (r *RTPReceiver) collectAudioPlayoutStats(
+	collector *statsReportCollector,
+	nowTime time.Time,
+	remoteTrack *TrackRemote,
+) {
+	playoutStats := remoteTrack.pullAudioPlayoutStats(nowTime)
+	for _, stats := range playoutStats {
+		collector.Collecting()
+		collector.Collect(stats.ID, stats)
 	}
 }
 

--- a/stats_go.go
+++ b/stats_go.go
@@ -6,6 +6,12 @@
 
 package webrtc
 
+import (
+	"context"
+	"sync"
+	"time"
+)
+
 // GetConnectionStats is a helper method to return the associated stats for a given PeerConnection.
 func (r StatsReport) GetConnectionStats(conn *PeerConnection) (PeerConnectionStats, bool) {
 	statsID := conn.getStatsID()
@@ -100,4 +106,138 @@ func (r StatsReport) GetCodecStats(c *RTPCodecParameters) (CodecStats, bool) {
 	}
 
 	return codecStats, true
+}
+
+// AudioPlayoutStatsProvider is an interface for getting audio playout metrics.
+type AudioPlayoutStatsProvider interface {
+	// AddTrack registers a track to report playout stats to this provider.
+	AddTrack(track *TrackRemote) error
+
+	// RemoveTrack unregisters a track from this provider.
+	RemoveTrack(track *TrackRemote)
+
+	// Snapshot returns the accumulated stats at the given time.
+	Snapshot(now time.Time) (AudioPlayoutStats, bool)
+}
+
+type trackContext struct {
+	cancel context.CancelFunc
+}
+
+// defaultAudioPlayoutStatsProvider accumulates audio playout stats on behalf of the application.
+type defaultAudioPlayoutStatsProvider struct {
+	mu sync.Mutex
+
+	stats           AudioPlayoutStats
+	lastSynthesized bool
+	tracks          map[*TrackRemote]*trackContext
+}
+
+// NewAudioPlayoutStatsProvider constructs a default provider with the supplied stats ID.
+func NewAudioPlayoutStatsProvider(id string) *defaultAudioPlayoutStatsProvider {
+	return &defaultAudioPlayoutStatsProvider{
+		stats: AudioPlayoutStats{
+			ID:   id,
+			Type: StatsTypeMediaPlayout,
+			Kind: string(MediaKindAudio),
+		},
+		tracks: make(map[*TrackRemote]*trackContext),
+	}
+}
+
+// Accumulate applies a new batch of played-out samples to the running totals.
+func (p *defaultAudioPlayoutStatsProvider) Accumulate(
+	samples int, sampleRate uint32, deviceDelay time.Duration, synthesized bool,
+) {
+	if samples <= 0 || sampleRate == 0 {
+		return
+	}
+
+	delaySeconds := deviceDelay.Seconds()
+	if delaySeconds < 0 {
+		delaySeconds = 0
+	}
+
+	duration := float64(samples) / float64(sampleRate)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.stats.TotalSamplesCount += uint64(samples)
+	p.stats.TotalSamplesDuration += duration
+	p.stats.TotalPlayoutDelay += delaySeconds * float64(samples)
+
+	if synthesized {
+		p.stats.SynthesizedSamplesDuration += duration
+		if !p.lastSynthesized {
+			p.stats.SynthesizedSamplesEvents++
+		}
+	}
+
+	p.lastSynthesized = synthesized
+}
+
+// Snapshot returns the accumulated stats at the given time.
+func (p *defaultAudioPlayoutStatsProvider) Snapshot(now time.Time) (AudioPlayoutStats, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.stats.TotalSamplesCount == 0 {
+		return AudioPlayoutStats{}, false
+	}
+
+	stats := p.stats
+	stats.Timestamp = statsTimestampFrom(now)
+
+	return stats, true
+}
+
+// AddTrack registers a track to report playout stats to this provider.
+func (p *defaultAudioPlayoutStatsProvider) AddTrack(track *TrackRemote) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, exists := p.tracks[track]; exists {
+		return nil
+	}
+
+	track.addProvider(p)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.tracks[track] = &trackContext{cancel: cancel}
+
+	go func() {
+		receiver := track.receiver
+		if receiver == nil {
+			cancel()
+
+			return
+		}
+
+		select {
+		case <-receiver.closed:
+			p.removeTrackInternal(track)
+		case <-ctx.Done():
+			return
+		}
+	}()
+
+	return nil
+}
+
+// RemoveTrack unregisters a track from this provider.
+func (p *defaultAudioPlayoutStatsProvider) RemoveTrack(track *TrackRemote) {
+	p.removeTrackInternal(track)
+}
+
+func (p *defaultAudioPlayoutStatsProvider) removeTrackInternal(track *TrackRemote) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if tc, exists := p.tracks[track]; exists {
+		tc.cancel()
+		delete(p.tracks, track)
+	}
+
+	track.removeProvider(p)
 }

--- a/track_remote_test.go
+++ b/track_remote_test.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2024 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+// +build !js
+
+package webrtc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTrackAudioPlayoutStatsProvider struct {
+	stats AudioPlayoutStats
+	ok    bool
+
+	calls   int
+	lastNow time.Time
+}
+
+func (f *fakeTrackAudioPlayoutStatsProvider) Snapshot(now time.Time) (AudioPlayoutStats, bool) {
+	f.calls++
+	f.lastNow = now
+
+	return f.stats, f.ok
+}
+
+func (f *fakeTrackAudioPlayoutStatsProvider) AddTrack(track *TrackRemote) error {
+	track.addProvider(f)
+
+	return nil
+}
+
+func (f *fakeTrackAudioPlayoutStatsProvider) RemoveTrack(track *TrackRemote) {
+	track.removeProvider(f)
+}
+
+func TestTrackRemotePullAudioPlayoutStats(t *testing.T) {
+	receiver := &RTPReceiver{}
+	track := newTrackRemote(RTPCodecTypeAudio, 4242, 0, "", receiver)
+
+	provider := &fakeTrackAudioPlayoutStatsProvider{
+		stats: AudioPlayoutStats{
+			ID:                "media-playout-4242",
+			Type:              StatsTypeMediaPlayout,
+			Kind:              string(MediaKindAudio),
+			TotalSamplesCount: 960,
+		},
+		ok: true,
+	}
+
+	err := provider.AddTrack(track)
+	require.NoError(t, err)
+
+	now := time.Unix(1710000000, 0)
+	allStats := track.pullAudioPlayoutStats(now)
+
+	require.Len(t, allStats, 1)
+	stats := allStats[0]
+	assert.Equal(t, provider.stats.TotalSamplesCount, stats.TotalSamplesCount)
+	assert.Equal(t, provider.stats.Type, stats.Type)
+	assert.Equal(t, provider.stats.ID, stats.ID)
+	assert.Equal(t, provider.stats.Kind, stats.Kind)
+	assert.Equal(t, statsTimestampFrom(now), stats.Timestamp)
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, now, provider.lastNow)
+}
+
+func TestTrackRemotePullAudioPlayoutStatsMissingProvider(t *testing.T) {
+	receiver := &RTPReceiver{}
+	track := newTrackRemote(RTPCodecTypeAudio, 1111, 0, "", receiver)
+
+	stats := track.pullAudioPlayoutStats(time.Now())
+	require.Empty(t, stats)
+}
+
+func TestTrackRemotePullAudioPlayoutStatsProviderFalse(t *testing.T) {
+	receiver := &RTPReceiver{}
+	track := newTrackRemote(RTPCodecTypeAudio, 1111, 0, "", receiver)
+
+	provider := &fakeTrackAudioPlayoutStatsProvider{ok: false}
+	err := provider.AddTrack(track)
+	require.NoError(t, err)
+
+	stats := track.pullAudioPlayoutStats(time.Now())
+	require.Empty(t, stats)
+	assert.Equal(t, 1, provider.calls)
+}
+
+func TestTrackRemotePullAudioPlayoutStatsNormalizesDefaults(t *testing.T) {
+	receiver := &RTPReceiver{}
+	track := newTrackRemote(RTPCodecTypeAudio, 2468, 0, "", receiver)
+
+	provider := &fakeTrackAudioPlayoutStatsProvider{
+		stats: AudioPlayoutStats{
+			TotalSamplesCount: 480,
+		},
+		ok: true,
+	}
+
+	err := provider.AddTrack(track)
+	require.NoError(t, err)
+
+	allStats := track.pullAudioPlayoutStats(time.Unix(10, 0))
+	require.Len(t, allStats, 1)
+	stats := allStats[0]
+
+	assert.Equal(t, "media-playout-2468", stats.ID)
+	assert.Equal(t, StatsTypeMediaPlayout, stats.Type)
+	assert.Equal(t, string(MediaKindAudio), stats.Kind)
+	assert.NotZero(t, stats.Timestamp)
+}


### PR DESCRIPTION
#### Description

- Refactored AudioPlayoutStatsProvider to provider-centric API with AddTrack/RemoveTrack methods, enabling multi-device and multi-track scenarios

- Provider represents a playout device (playout-id); tracks register to providers and stats are automatically collected via pc.GetStats()

#### Sample Usage

```go
// Create provider for a playback device
provider := webrtc.NewAudioPlayoutStatsProvider("speaker-device-1")

// Register tracks with the provider
provider.AddTrack(remoteTrack)

// Inside playback callback
provider.Accumulate(frames*channels, sampleRate, deviceDelay, synthesized)

// Switch devices 
provider.RemoveTrack(remoteTrack)
headphoneProvider.AddTrack(remoteTrack)

// Stats collection via GetStats
for id, stat := range pc.GetStats() {
    if playout, ok := stat.(webrtc.AudioPlayoutStats); ok {
        // consume playout stats
    }
}
```

#### Reference issue

Resolves https://github.com/pion/webrtc/issues/3134 (part 2/2)

Also related to resolving https://github.com/pion/webrtc/issues/3226