### PR TITLE
Expose stats ID for use in interceptor factories

### DIFF
--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -374,7 +374,7 @@ func TestStatsInterceptorIsAddedByDefault(t *testing.T) {
 
 	// Also assert that the getter stored during interceptor Build matches
 	// the one attached to this PeerConnection.
-	getter, ok := lookupStats(pc.statsID)
+	getter, ok := lookupStats(pc.id)
 	assert.True(t, ok, "lookupStats should return a getter for this statsID")
 	assert.NotNil(t, getter)
 	assert.Equal(t,
@@ -392,7 +392,7 @@ func TestStatsGetterCleanup(t *testing.T) {
 
 	assert.NotNil(t, pc.statsGetter, "statsGetter should be non-nil after creation")
 
-	statsID := pc.statsID
+	statsID := pc.id
 	getter, exists := lookupStats(statsID)
 	assert.True(t, exists, "global statsGetter map should contain entry for this PC")
 	assert.NotNil(t, getter, "looked up getter should not be nil")

--- a/stats_go.go
+++ b/stats_go.go
@@ -14,7 +14,7 @@ import (
 
 // GetConnectionStats is a helper method to return the associated stats for a given PeerConnection.
 func (r StatsReport) GetConnectionStats(conn *PeerConnection) (PeerConnectionStats, bool) {
-	statsID := conn.getStatsID()
+	statsID := conn.ID()
 	stats, ok := r[statsID]
 	if !ok {
 		return PeerConnectionStats{}, false

--- a/stats_go_test.go
+++ b/stats_go_test.go
@@ -2037,7 +2037,7 @@ func TestUnmarshalSCTPTransportStats_Error(t *testing.T) {
 
 func TestStatsReport_GetConnectionStats_MissingEntry(t *testing.T) {
 	conn := &PeerConnection{}
-	conn.getStatsID()
+	conn.ID()
 
 	r := StatsReport{}
 	got, ok := r.GetConnectionStats(conn)
@@ -2048,7 +2048,7 @@ func TestStatsReport_GetConnectionStats_MissingEntry(t *testing.T) {
 
 func TestStatsReport_GetConnectionStats_WrongType(t *testing.T) {
 	conn := &PeerConnection{}
-	id := conn.getStatsID()
+	id := conn.ID()
 
 	r := StatsReport{
 		id: DataChannelStats{ID: "not-a-pc-stats"},
@@ -2062,7 +2062,7 @@ func TestStatsReport_GetConnectionStats_WrongType(t *testing.T) {
 
 func TestStatsReport_GetConnectionStats_Success(t *testing.T) {
 	conn := &PeerConnection{}
-	id := conn.getStatsID()
+	id := conn.ID()
 
 	want := PeerConnectionStats{
 		ID:        id,


### PR DESCRIPTION
#### Description

We are already using the ID to access interceptors. If we expose it, we can store data per peerconnection in interceptor factories and give users an API to interceptors of a specific peerconnection.