### PR TITLE
Preferr RRID for retransmission over RTX

### DIFF
--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -101,6 +101,18 @@ func (t *RTPTransceiver) setCodecPreferencesFromRemoteDescription(media *sdp.Med
 		return
 	}
 
+	simulcast := false
+	if len(getRids(media)) > 0 {
+		extensions, err := rtpExtensionsFromMediaDescription(media)
+		if err == nil {
+			for extension := range extensions {
+				if extension == sdp.SDESRepairRTPStreamIDURI {
+					simulcast = true
+				}
+			}
+		}
+	}
+
 	// make a copy as this slice is modified
 	leftCodecs := append([]RTPCodecParameters{}, t.api.mediaEngine.getCodecsByKind(t.kind)...)
 
@@ -169,6 +181,10 @@ func (t *RTPTransceiver) setCodecPreferencesFromRemoteDescription(media *sdp.Med
 
 		mediaEngineRTX := findRTXPayloadType(mediaEnginePayloadType, leftCodecs)
 		if mediaEngineRTX == PayloadType(0) {
+			continue
+		}
+
+		if simulcast {
 			continue
 		}
 


### PR DESCRIPTION
#### Description

When receiving an offer with simulcast enabled from Chrome the offer contains RRID and RTX both offered to be used for retransmitting missing packets. Without this PR Pion's answer SDP would contain both mechanisms. That results in Chrome actually sending the retransmission twice, once over RRID and a second time over RTX.

This PR results in Pion preferring RRID and omitting RTX from the m-section payloads to avoid this double retransmission.
