### PR TITLE
Fix a rare race in peerconnection_go_test

### DIFF
--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -1775,9 +1775,11 @@ func TestPeerConnectionNoNULLCipherDefault(t *testing.T) {
 	assert.NoError(t, signalPair(offerPC, answerPC))
 
 	peerConnectionClosed := make(chan struct{})
+	var closeOnce sync.Once
+
 	answerPC.OnConnectionStateChange(func(s PeerConnectionState) {
 		if s == PeerConnectionStateClosed {
-			close(peerConnectionClosed)
+			closeOnce.Do(func() { close(peerConnectionClosed) })
 		}
 	})
 


### PR DESCRIPTION
#### Description
Fixes a rare race in `TestPeerConnectionNoNULLCipherDefault`.

This was being caused by `if s == PeerConnectionStateClosed {` sometimes being triggered twice which would cause a race.

#### Reference issue
Found from https://github.com/pion/webrtc/actions/runs/18957686422/job/54138154000?pr=3258#step:7:510