### PR TITLE
ECN support

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -551,8 +551,9 @@ func (t *DTLSTransport) streamsForSSRC(
 
 				if a == nil {
 					a = interceptor.Attributes{}
-					a["ECN"] = attr.GetReadPacketAttributes().Buffer[0]
-					fmt.Println("Got packet with ECN at dtlstransport ", a["ECN"])
+					if len(attr.GetReadPacketAttributes().Buffer) > 0 {
+						a["ECN"] = attr.GetReadPacketAttributes().Buffer[0]
+					}
 				}
 				return n, a, err
 			},

--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -546,12 +546,13 @@ func (t *DTLSTransport) streamsForSSRC(
 		&streamInfo,
 		interceptor.RTPReaderFunc(
 			func(in []byte, a interceptor.Attributes) (n int, attributes interceptor.Attributes, err error) {
-				attr := transport.NewPacketAttributes()
+				attr := transport.NewPacketAttributesWithLen(10)
 				n, err = rtpReadStream.ReadWithAttributes(in, attr)
 
 				if a == nil {
 					a = interceptor.Attributes{}
-					a["ECN"] = rtcp.ECN(attr.GetECN())
+					a["ECN"] = attr.GetReadPacketAttributes().Buffer[0]
+					fmt.Println("Got packet with ECN at dtlstransport ", a["ECN"])
 				}
 				return n, a, err
 			},

--- a/internal/mux/endpoint.go
+++ b/internal/mux/endpoint.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pion/ice/v4"
+	"github.com/pion/transport/v3"
 	"github.com/pion/transport/v3/packetio"
 )
 
@@ -51,6 +52,16 @@ func (e *Endpoint) ReadFrom(p []byte) (int, net.Addr, error) {
 	i, err := e.Read(p)
 
 	return i, nil, err
+}
+
+func (e *Endpoint) ReadWithAttributes(b []byte, attr *transport.PacketAttributes) (int, error) {
+	return e.buffer.ReadWithAttributes(b, attr)
+}
+
+func (e *Endpoint) ReadFromWithAttributes(b []byte, attr *transport.PacketAttributes) (int, net.Addr, error) {
+	n, err := e.ReadWithAttributes(b, attr)
+
+	return n, nil, err
 }
 
 // Write writes len(p) bytes to the underlying conn.

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -123,7 +123,7 @@ func (m *Mux) readLoop() {
 	}()
 
 	buf := make([]byte, m.bufferSize)
-	attr := transport.NewPacketAttributes()
+	attr := transport.NewPacketAttributesWithLen(transport.MaxAttributesLen)
 	for {
 		n, err := m.nextConn.ReadWithAttributes(buf, attr)
 		switch {
@@ -139,7 +139,7 @@ func (m *Mux) readLoop() {
 			return
 		}
 
-		if err = m.dispatch(buf[:n], attr); err != nil {
+		if err = m.dispatch(buf[:n], attr.GetReadPacketAttributes()); err != nil {
 			if errors.Is(err, io.ErrClosedPipe) {
 				// if the buffer was closed, that's not an error we care to report
 				return

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -23,7 +23,7 @@ func TestNoEndpoints(t *testing.T) {
 	ca, cb := net.Pipe()
 	require.NoError(t, cb.Close())
 
-	attr := transport.NewPacketAttributes()
+	attr := transport.NewPacketAttributesWithLen(transport.MaxAttributesLen)
 	mux := NewMux(Config{
 		Conn:          transport.NewNetConnToNetConnSocket(ca),
 		BufferSize:    testPipeBufferSize,
@@ -148,7 +148,7 @@ func BenchmarkDispatch(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := mux.dispatch(buf, transport.NewPacketAttributes())
+		err := mux.dispatch(buf, transport.NewPacketAttributesWithLen(transport.MaxAttributesLen))
 		if err != nil {
 			b.Errorf("dispatch: %v", err)
 		}
@@ -167,7 +167,7 @@ func TestPendingQueue(t *testing.T) {
 		log:       factory.NewLogger("mux"),
 	}
 
-	attr := transport.NewPacketAttributes()
+	attr := transport.NewPacketAttributesWithLen(transport.MaxAttributesLen)
 
 	// Assert empty packets don't end up in queue
 	require.NoError(t, mux.dispatch([]byte{}, attr))

--- a/settingengine.go
+++ b/settingengine.go
@@ -94,7 +94,7 @@ type SettingEngine struct {
 	disableSRTPReplayProtection               bool
 	disableSRTCPReplayProtection              bool
 	net                                       transport.Net
-	BufferFactory                             func(packetType packetio.BufferPacketType, ssrc uint32) io.ReadWriteCloser
+	BufferFactory                             func(packetType packetio.BufferPacketType, ssrc uint32) *packetio.Buffer
 	LoggerFactory                             logging.LoggerFactory
 	iceTCPMux                                 ice.TCPMux
 	iceUDPMux                                 ice.UDPMux


### PR DESCRIPTION
`mux` and `endpoint` structs either implemented `net.Conn` or `net.PacketConn`. Now they implement either `transport.PacketConnSocket` or `transport.NetConnSocket` which include the ReadWithAttributes method. 
`srtp.NewSessionSRTPWithNewSocket` is used for creating SRTP session with the desired functionality.