### PR TITLE
Add an error for sdp unmarshalling error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -175,6 +175,9 @@ var (
 	// and the requested SSRC was ignored.
 	ErrSimulcastProbeOverflow = errors.New("simulcast probe limit has been reached, new SSRC has been discarded")
 
+	// ErrSDPUnmarshalling indicates that the SDP could not be unmarshalled.
+	ErrSDPUnmarshalling = errors.New("failed to unmarshal SDP")
+
 	errDetachNotEnabled                 = errors.New("enable detaching by calling webrtc.DetachDataChannels()")
 	errDetachBeforeOpened               = errors.New("datachannel not opened yet, try calling Detach from OnOpen")
 	errDtlsTransportNotStarted          = errors.New("the DTLS transport has not started yet")

--- a/sessiondescription.go
+++ b/sessiondescription.go
@@ -4,6 +4,8 @@
 package webrtc
 
 import (
+	"fmt"
+
 	"github.com/pion/sdp/v3"
 )
 
@@ -20,6 +22,9 @@ type SessionDescription struct {
 func (sd *SessionDescription) Unmarshal() (*sdp.SessionDescription, error) {
 	sd.parsed = &sdp.SessionDescription{}
 	err := sd.parsed.UnmarshalString(sd.SDP)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSDPUnmarshalling, err)
+	}
 
-	return sd.parsed, err
+	return sd.parsed, nil
 }

--- a/sessiondescription_test.go
+++ b/sessiondescription_test.go
@@ -85,3 +85,13 @@ func TestSessionDescription_Unmarshal(t *testing.T) {
 	// check if the two parsed results _really_ match, could be affected by internal caching
 	assert.True(t, reflect.DeepEqual(parsed1, parsed2))
 }
+
+func TestSessionDescription_UnmarshalError(t *testing.T) {
+	desc := SessionDescription{
+		Type: SDPTypeOffer,
+		SDP:  "invalid sdp",
+	}
+	assert.Nil(t, desc.parsed)
+	_, err := desc.Unmarshal()
+	assert.ErrorIs(t, err, ErrSDPUnmarshalling)
+}


### PR DESCRIPTION
When we receive an error from the SetLocal/RemoteDescription methods, we cannot distinguish the server error from the input error, i.e. invalid SDP.

This PR adds a public SDP parsing error, which can be relied upon when choosing further error handling actions.