### PR TITLE
Add CanTrickleICECandidates

### DIFF
--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -463,6 +463,21 @@ func (pc *PeerConnection) PendingRemoteDescription() *SessionDescription {
 	return valueToSessionDescription(desc)
 }
 
+// CanTrickleICECandidates reports whether the remote endpoint indicated
+// support for receiving trickled ICE candidates.
+func (pc *PeerConnection) CanTrickleICECandidates() ICETrickleCapability {
+	val := pc.underlying.Get("canTrickleIceCandidates")
+	if val.IsNull() || val.IsUndefined() {
+		return ICETrickleCapabilityUnknown
+	}
+
+	if val.Bool() {
+		return ICETrickleCapabilitySupported
+	}
+
+	return ICETrickleCapabilityUnsupported
+}
+
 // SignalingState returns the signaling state of the PeerConnection instance.
 func (pc *PeerConnection) SignalingState() SignalingState {
 	rawState := pc.underlying.Get("signalingState").String()
@@ -714,6 +729,7 @@ func valueToSessionDescription(descValue js.Value) *SessionDescription {
 	if descValue.IsNull() || descValue.IsUndefined() {
 		return nil
 	}
+
 	return &SessionDescription{
 		Type: NewSDPType(descValue.Get("type").String()),
 		SDP:  descValue.Get("sdp").String(),

--- a/peerconnection_js_test.go
+++ b/peerconnection_js_test.go
@@ -104,3 +104,20 @@ func TestValueToICEServer(t *testing.T) {
 		assert.Equal(t, testCase, s)
 	}
 }
+
+func TestPeerConnectionCanTrickleICECandidatesJS(t *testing.T) {
+	pc := &PeerConnection{
+		underlying: js.ValueOf(map[string]any{
+			"canTrickleIceCandidates": true,
+		}),
+	}
+	assert.Equal(t, ICETrickleCapabilitySupported, pc.CanTrickleICECandidates())
+
+	pc.underlying = js.ValueOf(map[string]any{
+		"canTrickleIceCandidates": false,
+	})
+	assert.Equal(t, ICETrickleCapabilityUnsupported, pc.CanTrickleICECandidates())
+
+	pc.underlying = js.ValueOf(map[string]any{})
+	assert.Equal(t, ICETrickleCapabilityUnknown, pc.CanTrickleICECandidates())
+}

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -806,3 +806,18 @@ func TestPeerConnection_SessionID(t *testing.T) {
 	}
 	closePairNow(t, pcOffer, pcAnswer)
 }
+
+func TestICETrickleCapabilityString(t *testing.T) {
+	tests := []struct {
+		value    ICETrickleCapability
+		expected string
+	}{
+		{ICETrickleCapabilityUnknown, "unknown"},
+		{ICETrickleCapabilitySupported, "supported"},
+		{ICETrickleCapabilityUnsupported, "unsupported"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.value.String())
+	}
+}

--- a/sessiondescription.go
+++ b/sessiondescription.go
@@ -5,9 +5,36 @@ package webrtc
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/pion/sdp/v3"
 )
+
+// ICETrickleCapability represents whether the remote endpoint accepts
+// trickled ICE candidates.
+type ICETrickleCapability int
+
+const (
+	// ICETrickleCapabilityUnknown no remote peer has been established.
+	ICETrickleCapabilityUnknown ICETrickleCapability = iota
+	// ICETrickleCapabilitySupported remote peer can accept trickled ICE candidates.
+	ICETrickleCapabilitySupported
+	// ICETrickleCapabilitySupported remote peer didn't state that it can accept trickle ICE candidates.
+	ICETrickleCapabilityUnsupported
+)
+
+// String returns the string representation of ICETrickleCapability.
+func (t ICETrickleCapability) String() string {
+	switch t {
+	case ICETrickleCapabilitySupported:
+		return "supported"
+	case ICETrickleCapabilityUnsupported:
+		return "unsupported"
+	default:
+		return "unknown"
+	}
+}
 
 // SessionDescription is used to expose local and remote session descriptions.
 type SessionDescription struct {
@@ -27,4 +54,22 @@ func (sd *SessionDescription) Unmarshal() (*sdp.SessionDescription, error) {
 	}
 
 	return sd.parsed, nil
+}
+
+func hasICETrickleOption(desc *sdp.SessionDescription) bool {
+	if value, ok := desc.Attribute(sdp.AttrKeyICEOptions); ok && hasTrickleOptionValue(value) {
+		return true
+	}
+
+	for _, media := range desc.MediaDescriptions {
+		if value, ok := media.Attribute(sdp.AttrKeyICEOptions); ok && hasTrickleOptionValue(value) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasTrickleOptionValue(value string) bool {
+	return slices.Contains(strings.Fields(value), "trickle")
 }


### PR DESCRIPTION
#### Description

https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-cantrickleicecandidates

We diverged from the W3C specification for null/true/false because exposing `*bool` in a public Go API isn't a good idea IMO. Instead, we use an "enum" to represent these states explicitly.

@ValorZard started this feature in https://github.com/pion/webrtc/pull/3097 and i finished the first PR for sending and this to get sending and receiving tricke-ice-candidates flag into 4.2. 

not 100% sure about the enum name,

Added wasm bindings.

#### Reference issue
Fixes #2898
