### PR TITLE
ivfwriter: Add WithTimebase option for precise RTP timestamp handling

### DIFF
--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -382,23 +382,18 @@ func WithFrameRate(numerator, denominator uint32) Option {
 	}
 }
 
-// WithTimebase sets the IVF timebase (numerator/denominator) and enables
-// direct use of RTP timestamps as PTS values.
+// WithDirectPTS enables direct use of RTP timestamps as PTS values
+// without millisecond conversion.
 //
-// The timebase defines the time unit for PTS values in the IVF container.
-// For example, WithTimebase(1, 90000) means each PTS unit represents 1/90000 seconds.
-//
-// When this option is used, RTP timestamps are written directly as PTS values
-// without millisecond conversion, preserving full timestamp precision.
-// This is ideal for accurate timing when converting RTP streams to IVF.
+// When this option is used, RTP timestamps are written directly as PTS values,
+// preserving full timestamp precision. Use WithFrameRate to set the appropriate
+// timebase (e.g., WithFrameRate(1, 90000) for standard 90kHz RTP clock).
 //
 // Example usage for standard RTP video (90kHz clock rate):
 //
-//	WithTimebase(1, 90000)
-func WithTimebase(numerator, denominator uint32) Option {
+//	NewWith(file, WithFrameRate(1, 90000), WithDirectPTS())
+func WithDirectPTS() Option {
 	return func(i *IVFWriter) error {
-		i.timebaseNumerator = numerator
-		i.timebaseDenominator = denominator
 		i.directPTS = true
 
 		return nil

--- a/pkg/media/ivfwriter/ivfwriter_test.go
+++ b/pkg/media/ivfwriter/ivfwriter_test.go
@@ -417,10 +417,10 @@ func TestIVFWriter_WithFrameRate(t *testing.T) {
 	}, buffer.Bytes())
 }
 
-func TestIVFWriter_WithTimebase(t *testing.T) {
+func TestIVFWriter_WithDirectPTS(t *testing.T) {
 	buffer := &bytes.Buffer{}
 
-	writer, err := NewWith(buffer, WithTimebase(1, 90000))
+	writer, err := NewWith(buffer, WithFrameRate(1, 90000), WithDirectPTS())
 	assert.NoError(t, err)
 	assert.True(t, writer.directPTS)
 	assert.Equal(t, uint32(1), writer.timebaseNumerator)
@@ -429,10 +429,10 @@ func TestIVFWriter_WithTimebase(t *testing.T) {
 	assert.NoError(t, writer.Close())
 }
 
-func TestIVFWriter_Timebase_VP8(t *testing.T) {
+func TestIVFWriter_DirectPTS_VP8(t *testing.T) {
 	buffer := &bytes.Buffer{}
 
-	writer, err := NewWith(buffer, WithCodec(mimeTypeVP8), WithTimebase(1, 90000))
+	writer, err := NewWith(buffer, WithCodec(mimeTypeVP8), WithFrameRate(1, 90000), WithDirectPTS())
 	assert.NoError(t, err)
 
 	// Write keyframe with timestamp 0.
@@ -498,10 +498,10 @@ func TestIVFWriter_Timebase_VP8(t *testing.T) {
 	assert.Equal(t, uint64(6000), pts2, "Second frame PTS should be 6000")
 }
 
-func TestIVFWriter_Timebase_Precision(t *testing.T) {
+func TestIVFWriter_DirectPTS_Precision(t *testing.T) {
 	buffer := &bytes.Buffer{}
 
-	writer, err := NewWith(buffer, WithCodec(mimeTypeVP8), WithTimebase(1, 90000))
+	writer, err := NewWith(buffer, WithCodec(mimeTypeVP8), WithFrameRate(1, 90000), WithDirectPTS())
 	assert.NoError(t, err)
 
 	// Simulate 15fps video (6000 RTP ticks per frame at 90kHz).
@@ -551,7 +551,7 @@ func TestIVFWriter_Timebase_Precision(t *testing.T) {
 }
 
 func TestIVFWriter_BackwardCompatibility(t *testing.T) {
-	// Test that default behavior (without WithTimebase) remains unchanged.
+	// Test that default behavior (without WithDirectPTS) remains unchanged.
 	buffer := &bytes.Buffer{}
 
 	writer, err := NewWith(buffer, WithCodec(mimeTypeVP8))


### PR DESCRIPTION
  #### Description
  Add `WithTimebase(numerator, denominator)` option that enables direct use of RTP timestamps as PTS values, preserving full
  timestamp precision.

  The current implementation converts RTP timestamps to milliseconds before calculating PTS, which causes precision loss. For a
  15fps video, this results in ~16 seconds duration instead of the expected 15 seconds.

  With `WithTimebase(1, 90000)`, RTP timestamps are written directly as PTS values without millisecond conversion.

  #### Reference issue
  Fixes #3286
