### PR TITLE
Add nohost gather policy

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -170,8 +170,13 @@ func (g *ICEGatherer) resolveCandidateTypes() []ice.CandidateType {
 	if g.api.settingEngine.candidates.ICELite {
 		return []ice.CandidateType{ice.CandidateTypeHost}
 	}
-	if g.gatherPolicy == ICETransportPolicyRelay {
+
+	switch g.gatherPolicy {
+	case ICETransportPolicyRelay:
 		return []ice.CandidateType{ice.CandidateTypeRelay}
+	case ICETransportPolicyNoHost:
+		return []ice.CandidateType{ice.CandidateTypeServerReflexive, ice.CandidateTypeRelay}
+	default:
 	}
 
 	return nil

--- a/icetransportpolicy.go
+++ b/icetransportpolicy.go
@@ -21,17 +21,23 @@ const (
 	// ICETransportPolicyRelay indicates only media relay candidates such
 	// as candidates passing through a TURN server are used.
 	ICETransportPolicyRelay
+
+	// ICETransportPolicyNoHost indicates only non-host candidates are used.
+	ICETransportPolicyNoHost
 )
 
 // This is done this way because of a linter.
 const (
-	iceTransportPolicyRelayStr = "relay"
-	iceTransportPolicyAllStr   = "all"
+	iceTransportPolicyRelayStr  = "relay"
+	iceTransportPolicyNoHostStr = "nohost"
+	iceTransportPolicyAllStr    = "all"
 )
 
 // NewICETransportPolicy takes a string and converts it to ICETransportPolicy.
 func NewICETransportPolicy(raw string) ICETransportPolicy {
 	switch raw {
+	case iceTransportPolicyNoHostStr:
+		return ICETransportPolicyNoHost
 	case iceTransportPolicyRelayStr:
 		return ICETransportPolicyRelay
 	default:
@@ -41,6 +47,8 @@ func NewICETransportPolicy(raw string) ICETransportPolicy {
 
 func (t ICETransportPolicy) String() string {
 	switch t {
+	case ICETransportPolicyNoHost:
+		return iceTransportPolicyNoHostStr
 	case ICETransportPolicyRelay:
 		return iceTransportPolicyRelayStr
 	case ICETransportPolicyAll:

--- a/icetransportpolicy_test.go
+++ b/icetransportpolicy_test.go
@@ -14,6 +14,7 @@ func TestNewICETransportPolicy(t *testing.T) {
 		policyString   string
 		expectedPolicy ICETransportPolicy
 	}{
+		{"nohost", ICETransportPolicyNoHost},
 		{"relay", ICETransportPolicyRelay},
 		{"all", ICETransportPolicyAll},
 	}
@@ -32,6 +33,7 @@ func TestICETransportPolicy_String(t *testing.T) {
 		policy         ICETransportPolicy
 		expectedString string
 	}{
+		{ICETransportPolicyNoHost, "nohost"},
 		{ICETransportPolicyRelay, "relay"},
 		{ICETransportPolicyAll, "all"},
 	}


### PR DESCRIPTION
#### Description
Currently, we don't have a way to limit which candidates we gather beyond lite-mode (host candidates only) and relay mode (relay only). As a result, users end up relying on hacky workarounds like https://github.com/pion/webrtc/issues/3176 to limit to srflx only, which aren't reliable due to how ICE actually works.
Added many tests to make sure that it actually works.
Edit: this pr was changed from SetCandidateTypes to just nohost gather policy which did exist in ORTC https://github.com/w3c/ortc/issues/742
this resolves https://github.com/pion/webrtc/issues/3176