### PR TITLE
Do not block on SCTP accept if the transport is aborted

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -190,6 +190,17 @@ func (r *SCTPTransport) acceptDataChannels(
 	}
 ACCEPT:
 	for {
+		// check if the association has been stopped before calling accept.
+		r.lock.RLock()
+		currentAssoc := r.sctpAssociation
+		shouldStop := currentAssoc == nil || currentAssoc != assoc
+		r.lock.RUnlock()
+		if shouldStop {
+			r.onClose(nil)
+
+			return
+		}
+
 		dc, err := datachannel.Accept(assoc, &datachannel.Config{
 			LoggerFactory: r.api.settingEngine.LoggerFactory,
 		}, dataChannels...)


### PR DESCRIPTION
#### Description

Do not wait on data channel Accept  when SCTP association is aborted. 
Found this while was bench-marking different data for @philipch07's SCTP changes for the blog post.
