### PR TITLE
Wire address rewrite API

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -199,6 +199,7 @@ var (
 	errICERoleUnknown              = errors.New("unknown ICE Role")
 	errICEProtocolUnknown          = errors.New("unknown protocol")
 	errICEGathererNotStarted       = errors.New("gatherer not started")
+	errAddressRewriteWithNAT1To1   = errors.New("address rewrite rules cannot be combined with NAT1To1IPs")
 
 	errNetworkTypeUnknown = errors.New("unknown network type")
 

--- a/icecandidatetype.go
+++ b/icecandidatetype.go
@@ -101,7 +101,7 @@ func getCandidateType(candidateType ice.CandidateType) (ICECandidateType, error)
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.
-func (t ICECandidateType) MarshalText() ([]byte, error) {
+func (t ICECandidateType) MarshalText() ([]byte, error) { //nolint:staticcheck
 	return []byte(t.String()), nil
 }
 
@@ -111,4 +111,8 @@ func (t *ICECandidateType) UnmarshalText(b []byte) error {
 	*t, err = NewICECandidateType(string(b))
 
 	return err
+}
+
+func (r ICECandidateType) toICE() ice.CandidateType {
+	return ice.CandidateType(r)
 }

--- a/networktype.go
+++ b/networktype.go
@@ -62,7 +62,7 @@ func (t NetworkType) String() string {
 }
 
 // Protocol returns udp or tcp.
-func (t NetworkType) Protocol() string {
+func (t NetworkType) Protocol() string { //nolint:staticcheck
 	switch t {
 	case NetworkTypeUDP4:
 		return "udp"
@@ -107,4 +107,21 @@ func getNetworkType(iceNetworkType ice.NetworkType) (NetworkType, error) {
 	default:
 		return NetworkTypeUnknown, fmt.Errorf("%w: %s", errNetworkTypeUnknown, iceNetworkType.String())
 	}
+}
+
+func toICENetworkTypes(networkTypes []NetworkType) []ice.NetworkType {
+	if len(networkTypes) == 0 {
+		return nil
+	}
+
+	converted := make([]ice.NetworkType, 0, len(networkTypes))
+	for _, networkType := range networkTypes {
+		converted = append(converted, networkType.toICE())
+	}
+
+	return converted
+}
+
+func (networkType NetworkType) toICE() ice.NetworkType {
+	return ice.NetworkType(networkType)
 }


### PR DESCRIPTION
#### Description
based on https://github.com/pion/webrtc/pull/3303 
Adds the new AddressRewrite API which replaces NAT1To1.
Added many vnet tests.
