### PR TITLE
Implement write deadline

### DIFF
--- a/internal/mux/endpoint.go
+++ b/internal/mux/endpoint.go
@@ -80,21 +80,24 @@ func (e *Endpoint) RemoteAddr() net.Addr {
 	return e.mux.nextConn.RemoteAddr()
 }
 
-// SetDeadline sets the read deadline for this Endpoint.
-// Write deadlines are not supported because writes go directly to the shared
-// underlying connection and are non-blocking for this endpoint.
+// SetDeadline sets the read and write deadlines on the shared underlying
+// connection. Because the connection is shared, this applies to all endpoints
+// on the mux. Per-endpoint read deadlines can be set with SetReadDeadline.
 func (e *Endpoint) SetDeadline(t time.Time) error {
-	return e.buffer.SetReadDeadline(t)
+	return e.mux.nextConn.SetDeadline(t)
 }
 
-// SetReadDeadline sets the read deadline for this Endpoint.
+// SetReadDeadline sets the read deadline for this Endpoint's internal
+// packet buffer. This timeout applies only to reads from this Endpoint,
+// not to the shared underlying connection.
 func (e *Endpoint) SetReadDeadline(t time.Time) error {
 	return e.buffer.SetReadDeadline(t)
 }
 
-// SetWriteDeadline is a stub.
-func (e *Endpoint) SetWriteDeadline(time.Time) error {
-	return nil
+// SetWriteDeadline sets the write deadline on the shared underlying connection.
+// Because the connection is shared, this applies to all endpoints on the mux.
+func (e *Endpoint) SetWriteDeadline(t time.Time) error {
+	return e.mux.nextConn.SetWriteDeadline(t)
 }
 
 // SetOnClose is a user set callback that


### PR DESCRIPTION
#### Description
Make write deadline actually work.
Endpoint.SetDeadline(t):
1. Now directly calls e.mux.nextConn.SetDeadline(t).
2. This is a connection-wide operation. it affects every endpoint attached to the mux.
3. This makes SetDeadline the API you call when you want to control the underlying transport's read/write deadlines.

Endpoint.SetReadDeadline(t):
1. Still calls e.buffer.SetReadDeadline(t).
2. The new comment explicitly documents that this sets the read deadline on the internal packet buffer, not on the shared net.Conn.
3. Only reads from that specific Endpoint are affected. other endpoints and the mux's Read loop are unaffected.