### PR TITLE
Advertise ICE renomination option in SDP

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -724,6 +724,9 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 		if options != nil && options.ICETricklingSupported {
 			descr.WithICETrickleAdvertised()
 		}
+		if pc.api.settingEngine.renomination.enabled {
+			descr.WithICERenomination()
+		}
 
 		updateSDPOrigin(&pc.sdpOrigin, descr)
 		sdpBytes, err := descr.Marshal()
@@ -891,6 +894,9 @@ func (pc *PeerConnection) CreateAnswer(options *AnswerOptions) (SessionDescripti
 
 	if options != nil && options.ICETricklingSupported {
 		descr.WithICETrickleAdvertised()
+	}
+	if pc.api.settingEngine.renomination.enabled {
+		descr.WithICERenomination()
 	}
 
 	updateSDPOrigin(&pc.sdpOrigin, descr)

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -1903,6 +1903,62 @@ func TestICETricklingSupported(t *testing.T) {
 	assert.NoError(t, pcAnswer.Close())
 }
 
+func TestICERenominationAdvertised(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
+	offerSE := SettingEngine{}
+	assert.NoError(t, offerSE.SetICERenomination())
+
+	api := NewAPI(WithSettingEngine(offerSE))
+	pc, err := api.NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	offer, err := pc.CreateOffer(nil)
+	assert.NoError(t, err)
+	assert.Contains(t, offer.SDP, "a=ice-options:renomination")
+	assert.NoError(t, pc.Close())
+
+	answerSE := SettingEngine{}
+	assert.NoError(t, answerSE.SetICERenomination())
+
+	apiAnswer := NewAPI(WithSettingEngine(answerSE))
+	pcAnswer, err := apiAnswer.NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	offerSDP := strings.Join([]string{
+		"v=0",
+		"o=- 0 0 IN IP4 127.0.0.1",
+		"s=-",
+		"t=0 0",
+		"a=group:BUNDLE 0",
+		"a=ice-ufrag:someufrag",
+		"a=ice-pwd:somepwd",
+		"a=fingerprint:sha-256 " +
+			"F7:BF:B4:42:5B:44:C0:B9:49:70:6D:26:D7:3E:E6:08:B1:5B:25:2E:32:88:50:B6:3C:BE:4E:18:A7:2C:85:7C",
+		"a=msid-semantic: WMS *",
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111",
+		"c=IN IP4 0.0.0.0",
+		"a=rtcp:9 IN IP4 0.0.0.0",
+		"a=mid:0",
+		"a=rtcp-mux",
+		"a=setup:actpass",
+		"a=rtpmap:111 opus/48000/2",
+		"",
+	}, "\r\n")
+
+	assert.NoError(t, pcAnswer.SetRemoteDescription(SessionDescription{
+		Type: SDPTypeOffer,
+		SDP:  offerSDP,
+	}))
+
+	answer, err := pcAnswer.CreateAnswer(nil)
+	assert.NoError(t, err)
+	assert.Contains(t, answer.SDP, "a=ice-options:renomination")
+
+	assert.NoError(t, pcAnswer.Close())
+}
+
 // https://github.com/pion/webrtc/issues/2690
 func TestPeerConnectionTrickleMediaStreamIdentification(t *testing.T) {
 	const remoteSdp = `v=0


### PR DESCRIPTION
#### Description
Advertise renomination ice-option when it's enabled. https://datatracker.ietf.org/doc/html/draft-thatcher-ice-renomination-01#section-3


 continues  https://github.com/pion/sdp/pull/237 and https://github.com/pion/webrtc/pull/3306