### PR TITLE
Add continual gathering policy to SettingEngine

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -157,6 +157,7 @@ func (g *ICEGatherer) buildAgentOptions() ([]ice.AgentOption, error) {
 	options = append(options, g.timeoutOptions()...)
 	options = append(options, g.miscOptions()...)
 	options = append(options, g.renominationOptions()...)
+	options = append(options, g.continualGatheringOptions()...)
 
 	requestedNetworkTypes := g.api.settingEngine.candidates.ICENetworkTypes
 	if len(requestedNetworkTypes) == 0 {
@@ -332,6 +333,15 @@ func (g *ICEGatherer) renominationOptions() []ice.AgentOption {
 	}
 
 	return opts
+}
+
+func (g *ICEGatherer) continualGatheringOptions() []ice.AgentOption {
+	policy := g.api.settingEngine.iceContinualGatheringPolicy
+	if policy == 0 {
+		return nil
+	}
+
+	return []ice.AgentOption{ice.WithContinualGatheringPolicy(policy)}
 }
 
 func legacyNAT1To1AddressRewriteRules(ips []string, candidateType ice.CandidateType) []ice.AddressRewriteRule {

--- a/settingengine.go
+++ b/settingengine.go
@@ -105,6 +105,7 @@ type SettingEngine struct {
 	iceProxyDialer                            proxy.Dialer
 	iceDisableActiveTCP                       bool
 	iceBindingRequestHandler                  func(m *stun.Message, local, remote ice.Candidate, pair *ice.CandidatePair) bool //nolint:lll
+	iceContinualGatheringPolicy               ice.ContinualGatheringPolicy
 	disableMediaEngineCopy                    bool
 	disableMediaEngineMultipleCodecs          bool
 	srtpProtectionProfiles                    []dtls.SRTPProtectionProfile
@@ -660,6 +661,17 @@ func (e *SettingEngine) SetICEBindingRequestHandler(
 	bindingRequestHandler func(m *stun.Message, local, remote ice.Candidate, pair *ice.CandidatePair) bool,
 ) {
 	e.iceBindingRequestHandler = bindingRequestHandler
+}
+
+// SetICEContinualGatheringPolicy sets the policy for gathering ICE candidates.
+// When set to GatherContinually, the ICE agent monitors for network changes and
+// gathers new candidates when interfaces are added or removed. This changes the
+// observable ICE behavior:
+// - ICEGatheringState remains in "gathering" and never transitions to "complete".
+// - OnICECandidate(nil) is never called, as gathering never finishes.
+// Applications should use trickle ICE and not wait for gathering to complete.
+func (e *SettingEngine) SetICEContinualGatheringPolicy(policy ice.ContinualGatheringPolicy) {
+	e.iceContinualGatheringPolicy = policy
 }
 
 // SetFireOnTrackBeforeFirstRTP sets if firing the OnTrack event should happen

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -106,6 +106,19 @@ func TestICERenomination(t *testing.T) {
 	})
 }
 
+func TestICEContinualGatheringPolicy(t *testing.T) {
+	t.Run("DefaultIsZero", func(t *testing.T) {
+		s := SettingEngine{}
+		assert.Equal(t, ice.ContinualGatheringPolicy(0), s.iceContinualGatheringPolicy)
+	})
+
+	t.Run("SetPolicy", func(t *testing.T) {
+		s := SettingEngine{}
+		s.SetICEContinualGatheringPolicy(ice.GatherContinually)
+		assert.Equal(t, ice.GatherContinually, s.iceContinualGatheringPolicy)
+	})
+}
+
 func TestDetachDataChannels(t *testing.T) {
 	s := SettingEngine{}
 	assert.False(t, s.detach.DataChannels)


### PR DESCRIPTION
#### Description
Expose pion/ice's ContinualGatheringPolicy via the SettingEngine.

See #3321
I thought setting the gathering policy through the settings engine would be the best place for this as I am not aware of any w3c standard api.