### PR TITLE
Simplify interface to handleUnknownRTPPacket

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1827,19 +1827,16 @@ func (pc *PeerConnection) handleIncomingSSRC(rtpStream *srtp.ReadStreamSRTP, ssr
 	rtcpInterceptor := result.rtcpInterceptor
 
 	// try to read simulcast IDs from the packet we already have
-	var mid, rid, rsid string
-	if _, err = handleUnknownRTPPacket(
+	mid, rid, rsid, _, err := handleUnknownRTPPacket(
 		b[:i], uint8(midExtensionID), //nolint:gosec // G115
 		uint8(streamIDExtensionID),       //nolint:gosec // G115
 		uint8(repairStreamIDExtensionID), //nolint:gosec // G115
-		&mid,
-		&rid,
-		&rsid,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
 
-	peekedPackets := []*peekedPacket{}
+	peekedPackets := []*peekedPacket(nil)
 
 	// if the first packet didn't contain simuilcast IDs, then probe more packets
 	var paddingOnly bool
@@ -1860,14 +1857,12 @@ func (pc *PeerConnection) handleIncomingSSRC(rtpStream *srtp.ReadStreamSRTP, ssr
 				attributes: attributes,
 			})
 
-			if paddingOnly, err = handleUnknownRTPPacket(
+			mid, rid, rsid, paddingOnly, err = handleUnknownRTPPacket(
 				b[:i], uint8(midExtensionID), //nolint:gosec // G115
 				uint8(streamIDExtensionID),       //nolint:gosec // G115
 				uint8(repairStreamIDExtensionID), //nolint:gosec // G115
-				&mid,
-				&rid,
-				&rsid,
-			); err != nil {
+			)
+			if err != nil {
 				return err
 			}
 

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -427,32 +427,31 @@ func handleUnknownRTPPacket(
 	midExtensionID,
 	streamIDExtensionID,
 	repairStreamIDExtensionID uint8,
-	mid, rid, rsid *string,
-) (paddingOnly bool, err error) {
+) (mid, rid, rsid string, paddingOnly bool, err error) {
 	rp := &rtp.Packet{}
 	if err = rp.Unmarshal(buf); err != nil {
-		return false, err
+		return mid, rid, rsid, false, err
 	}
 
 	if rp.Padding && len(rp.Payload) == 0 {
-		paddingOnly = true
+		return mid, rid, rsid, true, nil
 	}
 
 	if !rp.Header.Extension {
-		return paddingOnly, nil
+		return mid, rid, rsid, false, nil
 	}
 
 	if payload := rp.GetExtension(midExtensionID); payload != nil {
-		*mid = string(payload)
+		mid = string(payload)
 	}
 
 	if payload := rp.GetExtension(streamIDExtensionID); payload != nil {
-		*rid = string(payload)
+		rid = string(payload)
 	}
 
 	if payload := rp.GetExtension(repairStreamIDExtensionID); payload != nil {
-		*rsid = string(payload)
+		rsid = string(payload)
 	}
 
-	return paddingOnly, nil
+	return mid, rid, rsid, false, nil
 }


### PR DESCRIPTION
Use multiple return values instead of returning values through
pointers.
