### PR TITLE
SetConfiguration now updates ICEGatherer's servers

### DIFF
--- a/icegatherer_test.go
+++ b/icegatherer_test.go
@@ -111,6 +111,26 @@ func TestICEGatherer_InvalidMDNSHostName(t *testing.T) {
 	assert.ErrorIs(t, err, ice.ErrInvalidMulticastDNSHostName)
 }
 
+func TestICEGatherer_updateServers(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	gatherer, err := NewAPI().NewICEGatherer(ICEGatherOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, gatherer.validatedServersCount())
+
+	newServers := []ICEServer{{URLs: []string{"stun:stun.l.google.com:19302"}}}
+	err = gatherer.updateServers(newServers, ICETransportPolicyAll)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, gatherer.validatedServersCount())
+
+	assert.NoError(t, gatherer.Close())
+}
+
 func TestLegacyNAT1To1AddressRewriteRules(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		assert.Empty(t, legacyNAT1To1AddressRewriteRules(nil, ice.CandidateTypeHost))


### PR DESCRIPTION
#### Description
After using `SetConfiguration` I found that the new ice servers have not been used. Turns out after creating a peer connection the ice gatherer is created with the current configuration, but it is never updated with new servers when the configuration changes

This pr should fix the issue and implement the spec properly. We just need to wait on https://github.com/pion/ice/pull/866 to land.