### PR TITLE
Rename dtlsRoleFromRemoteSDP to dtlsRoleFromSDP

### DIFF
--- a/dtlsrole.go
+++ b/dtlsrole.go
@@ -58,10 +58,9 @@ func (r DTLSRole) String() string {
 	}
 }
 
-// Iterate a SessionDescription from a remote to determine if an explicit
-// role can been determined from it. The decision is made from the first role we we parse.
-// If no role can be found we return DTLSRoleAuto.
-func dtlsRoleFromRemoteSDP(sessionDescription *sdp.SessionDescription) DTLSRole {
+// Extract the dtls role from a session description. The decision is made from
+// the first role we we parse. If no role can be found we return DTLSRoleAuto.
+func dtlsRoleFromSDP(sessionDescription *sdp.SessionDescription) DTLSRole {
 	if sessionDescription == nil {
 		return DTLSRoleAuto
 	}

--- a/dtlsrole_test.go
+++ b/dtlsrole_test.go
@@ -31,7 +31,7 @@ func TestDTLSRole_String(t *testing.T) {
 	}
 }
 
-func TestDTLSRoleFromRemoteSDP(t *testing.T) {
+func TestDTLSRoleFromSDP(t *testing.T) {
 	parseSDP := func(raw string) *sdp.SessionDescription {
 		parsed := &sdp.SessionDescription{}
 		assert.NoError(t, parsed.Unmarshal([]byte(raw)))
@@ -77,7 +77,7 @@ a=setup:%s
 	for _, testCase := range testCases {
 		assert.Equal(t,
 			testCase.expectedRole,
-			dtlsRoleFromRemoteSDP(testCase.sessionDescription),
+			dtlsRoleFromSDP(testCase.sessionDescription),
 			"TestDTLSRoleFromSDP (%s)", testCase.test,
 		)
 	}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -869,7 +869,7 @@ func (pc *PeerConnection) CreateAnswer(options *AnswerOptions) (SessionDescripti
 
 	connectionRole := connectionRoleFromDtlsRole(pc.api.settingEngine.answeringDTLSRole)
 	if connectionRole == sdp.ConnectionRole(0) {
-		dtlsRole := dtlsRoleFromRemoteSDP(remoteDesc.parsed)
+		dtlsRole := dtlsRoleFromSDP(remoteDesc.parsed)
 		switch dtlsRole {
 		case DTLSRoleClient:
 			connectionRole = connectionRoleFromDtlsRole(DTLSRoleServer)
@@ -1311,7 +1311,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 	pc.ops.Enqueue(func() {
 		pc.startTransports(
 			iceRole,
-			dtlsRoleFromRemoteSDP(desc.parsed),
+			dtlsRoleFromSDP(desc.parsed),
 			iceDetails.Ufrag,
 			iceDetails.Password,
 			fingerprint,

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -2369,7 +2369,7 @@ func TestCreateAnswerActiveOfferPassiveAnswer(t *testing.T) {
 	assert.NoError(t, pc.SetRemoteDescription(activeDesc))
 	answer, err := pc.CreateAnswer(nil)
 	assert.NoError(t, err)
-	answerRole := dtlsRoleFromRemoteSDP(answer.parsed)
+	answerRole := dtlsRoleFromSDP(answer.parsed)
 	assert.Equal(t, answerRole, DTLSRoleServer)
 	assert.NoError(t, pc.Close())
 }
@@ -2382,7 +2382,7 @@ func TestCreateAnswerPassiveOfferActiveAnswer(t *testing.T) {
 	assert.NoError(t, pc.SetRemoteDescription(passiveDesc))
 	answer, err := pc.CreateAnswer(nil)
 	assert.NoError(t, err)
-	answerRole := dtlsRoleFromRemoteSDP(answer.parsed)
+	answerRole := dtlsRoleFromSDP(answer.parsed)
 	assert.Equal(t, answerRole, DTLSRoleClient)
 	assert.NoError(t, pc.Close())
 }


### PR DESCRIPTION
since nothing in the method utilizies that this is from a remote SDP (e.g. to reverse the client/server roles).

F'up from #3325