### PR TITLE
Extract a `DTLSConn` interface to wrap `dtls.Conn`

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -62,14 +62,14 @@ type DTLSTransport struct {
 	log logging.LeveledLogger
 }
 
-// DTLSConn exposes the portion of the DTLS connection used by DTLSTransport.
-// It can be implemented to allow replacement at runtime.
+// DTLSConn wraps the DTLS connection used by DTLSTransport.
+// It can be injected via SettingEngine to allow replacement at runtime.
 type DTLSConn interface {
 	net.Conn
 	ConnectionState() (dtls.State, bool)
-	SelectedSRTPProtectionProfile() (dtls.SRTPProtectionProfile, bool)
-	HandshakeContext(ctx context.Context) error
 	Handshake() error
+	HandshakeContext(ctx context.Context) error
+	SelectedSRTPProtectionProfile() (dtls.SRTPProtectionProfile, bool)
 }
 
 type dtlsConnFactory func(role DTLSRole, conn net.PacketConn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error)

--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -73,7 +73,7 @@ type DTLSConn interface {
 	Handshake() error
 }
 
-type dtlsConnFactory func(role DTLSRole, conn net.Conn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error)
+type dtlsConnFactory func(role DTLSRole, conn net.PacketConn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error)
 
 type simulcastStreamPair struct {
 	srtp  *srtp.ReadStreamSRTP
@@ -330,7 +330,7 @@ func (t *DTLSTransport) role() DTLSRole {
 
 func (t *DTLSTransport) createDTLSConn(
 	role DTLSRole,
-	conn net.Conn,
+	conn net.PacketConn,
 	remoteAddr net.Addr,
 	config *dtls.Config,
 ) (DTLSConn, error) {
@@ -343,7 +343,7 @@ func (t *DTLSTransport) createDTLSConn(
 
 func defaultDTLSConnFactory(
 	role DTLSRole,
-	conn net.Conn,
+	conn net.PacketConn,
 	remoteAddr net.Addr,
 	config *dtls.Config,
 ) (DTLSConn, error) {

--- a/dtlstransport_js.go
+++ b/dtlstransport_js.go
@@ -63,9 +63,3 @@ func (t *DTLSTransport) GetRemoteCertificate() []byte {
 
 	return cert
 }
-
-// GetRemoteSRTPMasterKeyIdentifier returns the identifier negotiated by DTLS for SRTP.
-// It returns false when the identifier is unavailable in the JS runtime.
-func (t *DTLSTransport) GetRemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
-	return nil, false
-}

--- a/dtlstransport_js.go
+++ b/dtlstransport_js.go
@@ -63,3 +63,9 @@ func (t *DTLSTransport) GetRemoteCertificate() []byte {
 
 	return cert
 }
+
+// GetRemoteSRTPMasterKeyIdentifier returns the identifier negotiated by DTLS for SRTP.
+// It returns false when the identifier is unavailable in the JS runtime.
+func (t *DTLSTransport) GetRemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
+	return nil, false
+}

--- a/settingengine.go
+++ b/settingengine.go
@@ -72,7 +72,7 @@ type SettingEngine struct {
 		retransmissionInterval        time.Duration
 		ellipticCurves                []dtlsElliptic.Curve
 		connectContextMaker           func() (context.Context, func())
-		connFactory                   func(role DTLSRole, conn net.Conn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error)
+		connFactory                   func(role DTLSRole, conn net.PacketConn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error)
 		extendedMasterSecret          dtls.ExtendedMasterSecretType
 		clientAuth                    *dtls.ClientAuthType
 		clientCAs                     *x509.CertPool
@@ -555,7 +555,7 @@ func (e *SettingEngine) SetDTLSConnectContextMaker(connectContextMaker func() (c
 // SetDTLSConnFactory overrides the DTLS connection creation for DTLSTransport.
 // If nil, the default pion/dtls Client/Server constructors are used.
 func (e *SettingEngine) SetDTLSConnFactory(
-	factory func(role DTLSRole, conn net.Conn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error),
+	factory func(role DTLSRole, conn net.PacketConn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error),
 ) {
 	e.dtls.connFactory = factory
 }

--- a/settingengine.go
+++ b/settingengine.go
@@ -72,6 +72,7 @@ type SettingEngine struct {
 		retransmissionInterval        time.Duration
 		ellipticCurves                []dtlsElliptic.Curve
 		connectContextMaker           func() (context.Context, func())
+		connFactory                   func(role DTLSRole, conn net.Conn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error)
 		extendedMasterSecret          dtls.ExtendedMasterSecretType
 		clientAuth                    *dtls.ClientAuthType
 		clientCAs                     *x509.CertPool
@@ -549,6 +550,14 @@ func (e *SettingEngine) SetDTLSEllipticCurves(ellipticCurves ...dtlsElliptic.Cur
 //	}
 func (e *SettingEngine) SetDTLSConnectContextMaker(connectContextMaker func() (context.Context, func())) {
 	e.dtls.connectContextMaker = connectContextMaker
+}
+
+// SetDTLSConnFactory overrides the DTLS connection creation for DTLSTransport.
+// If nil, the default pion/dtls Client/Server constructors are used.
+func (e *SettingEngine) SetDTLSConnFactory(
+	factory func(role DTLSRole, conn net.Conn, remoteAddr net.Addr, config *dtls.Config) (DTLSConn, error),
+) {
+	e.dtls.connFactory = factory
 }
 
 // SetDTLSExtendedMasterSecret sets the extended master secret type for DTLS.


### PR DESCRIPTION
#### Description
This PR allows for runtime replacement of the `dtls.Conn` implementation from pion/dtls with a test or injected implementation. It defines a new `DTLSConn` interface, along with a factory function for creating a `DTLSConn` which can be specified in `SettingEngine`.

By default, a `DTLSConn` based on `dtls.Conn` is created, and for the most part, the `DTLSConn` methods are straight thunks to `dtls.Conn`. The one exception is the key extractor method, which calls `ConnectionState()` and then returns a `KeyingMaterialExporter`, which is the only data that pion/webrtc needs from `ConnectionState()`.

lint passes, tests pass

