### PR TITLE
Ensure candidate gathering promise completes

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -485,6 +485,13 @@ func (g *ICEGatherer) close(shouldGracefullyClose bool) error {
 		}
 	}
 
+	// onGatheringCompleteHandler is used solely by the GatheringCompletePromise helper and the common usage
+	// for that helper is aided by ensuring that this completion is fired in case the PC/ICEGatherer are closed
+	// before gathering actually completes. If things have already completed then this should be a no-op
+	if handler, ok := g.onGatheringCompleteHandler.Load().(func()); ok && handler != nil {
+		handler()
+	}
+
 	g.agent = nil
 	g.setState(ICEGathererStateClosed)
 


### PR DESCRIPTION
#### Description
This ensures that even if ICE Candidate Gathering is interrupted that the helper wrapper we provide still completes.

We decided to take this fix over a fix within the ICE Agent so that the ICE Gathering State and OnCandidate handlers can continue matching behavior to the browser.

#### Reference issue
Fixes #2507 
