### PR TITLE
Support simulcast from "SIM" ssrc-group

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -38,6 +38,8 @@ const (
 
 	sdpAttributeSimulcast = "simulcast"
 
+	ssrcGroupSimulcast = "SIM"
+
 	outboundMTU = 1200
 
 	rtpPayloadTypeBitmask = 0x7F

--- a/constants.go
+++ b/constants.go
@@ -46,7 +46,7 @@ const (
 
 	incomingUnhandledRTPSsrc = "Incoming unhandled RTP ssrc(%d), OnTrack will not be fired. %v"
 
-	useReadSimulcast = "Use ReadSimulcast(rid) instead of Read() when multiple tracks are present"
+	useReadSimulcast = "Use ReadSimulcast(rid)/ReadSimulcastSSRC(ssrc) instead of Read() when multiple tracks are present"
 
 	generatedCertificateOrigin = "WebRTC"
 

--- a/errors.go
+++ b/errors.go
@@ -244,6 +244,7 @@ var (
 	errRTPReceiverReceiveAlreadyCalled        = errors.New("Receive has already been called")
 	errRTPReceiverWithSSRCTrackStreamNotFound = errors.New("unable to find stream for Track with SSRC")
 	errRTPReceiverForRIDTrackStreamNotFound   = errors.New("no trackStreams found for RID")
+	errRTPReceiverForSSRCTrackStreamNotFound  = errors.New("no trackStreams found for SSRC")
 
 	errRTPSenderTrackNil             = errors.New("Track must not be nil")
 	errRTPSenderDTLSTransportNil     = errors.New("DTLSTransport must not be nil")

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1784,10 +1784,14 @@ func (pc *PeerConnection) handleIncomingSSRC(rtpStream *srtp.ReadStreamSRTP, ssr
 
 	// If a SSRC already exists in the RemoteDescription don't perform heuristics upon it
 	for _, track := range trackDetailsFromSDP(pc.log, remoteDescription.parsed) {
-		if track.rtxSsrc != nil && ssrc == *track.rtxSsrc {
+		if slices.ContainsFunc(track.rtxSsrc, func(s *SSRC) bool {
+			return s != nil && ssrc == *s
+		}) {
 			return nil
 		}
-		if track.fecSsrc != nil && ssrc == *track.fecSsrc {
+		if slices.ContainsFunc(track.fecSsrc, func(s *SSRC) bool {
+			return s != nil && ssrc == *s
+		}) {
 			return nil
 		}
 		if slices.Contains(track.ssrcs, ssrc) {

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -326,6 +326,33 @@ func (r *RTPReceiver) ReadSimulcast(b []byte, rid string) (n int, a interceptor.
 	}
 }
 
+// ReadSimulcastSSRC reads incoming RTCP for this RTPReceiver for given SSRC.
+func (r *RTPReceiver) ReadSimulcastSSRC(b []byte, ssrc SSRC) (n int, a interceptor.Attributes, err error) {
+	select {
+	case <-r.received:
+		var rtcpInterceptor interceptor.RTCPReader
+
+		r.mu.Lock()
+		for _, t := range r.tracks {
+			if t.track != nil && t.track.ssrc == ssrc {
+				rtcpInterceptor = t.rtcpInterceptor
+
+				break
+			}
+		}
+		r.mu.Unlock()
+
+		if rtcpInterceptor == nil {
+			return 0, nil, fmt.Errorf("%w: %d", errRTPReceiverForSSRCTrackStreamNotFound, ssrc)
+		}
+
+		return rtcpInterceptor.Read(b, a)
+
+	case <-r.closedChan:
+		return 0, nil, io.ErrClosedPipe
+	}
+}
+
 // ReadRTCP is a convenience method that wraps Read and unmarshal for you.
 // It also runs any configured interceptors.
 func (r *RTPReceiver) ReadRTCP() ([]rtcp.Packet, interceptor.Attributes, error) {
@@ -347,6 +374,19 @@ func (r *RTPReceiver) ReadRTCP() ([]rtcp.Packet, interceptor.Attributes, error) 
 func (r *RTPReceiver) ReadSimulcastRTCP(rid string) ([]rtcp.Packet, interceptor.Attributes, error) {
 	b := make([]byte, r.api.settingEngine.getReceiveMTU())
 	i, attributes, err := r.ReadSimulcast(b, rid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkts, err := rtcp.Unmarshal(b[:i])
+
+	return pkts, attributes, err
+}
+
+// ReadSimulcastSSRCRTCP is a convenience method that wraps ReadSimulcastSSRC and unmarshal for you.
+func (r *RTPReceiver) ReadSimulcastSSRCRTCP(ssrc SSRC) ([]rtcp.Packet, interceptor.Attributes, error) {
+	b := make([]byte, r.api.settingEngine.getReceiveMTU())
+	i, attributes, err := r.ReadSimulcastSSRC(b, ssrc)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sdp.go
+++ b/sdp.go
@@ -29,8 +29,8 @@ type trackDetails struct {
 	streamID string
 	id       string
 	ssrcs    []SSRC
-	rtxSsrc  *SSRC
-	fecSsrc  *SSRC
+	rtxSsrc  []*SSRC
+	fecSsrc  []*SSRC
 	rids     []string
 }
 
@@ -136,7 +136,7 @@ func trackDetailsFromSDP(
 						for i := range tracksInMediaSection {
 							if tracksInMediaSection[i].ssrcs[0] == SSRC(baseSsrc) {
 								repairSsrc := SSRC(rtxRepairFlow)
-								tracksInMediaSection[i].rtxSsrc = &repairSsrc
+								tracksInMediaSection[i].rtxSsrc = []*SSRC{&repairSsrc}
 							}
 						}
 					}
@@ -164,7 +164,7 @@ func trackDetailsFromSDP(
 						for i := range tracksInMediaSection {
 							if tracksInMediaSection[i].ssrcs[0] == SSRC(baseSsrc) {
 								repairSsrc := SSRC(fecRepairFlow)
-								tracksInMediaSection[i].fecSsrc = &repairSsrc
+								tracksInMediaSection[i].fecSsrc = []*SSRC{&repairSsrc}
 							}
 						}
 					}
@@ -221,13 +221,13 @@ func trackDetailsFromSDP(
 				for r, baseSsrc := range rtxRepairFlows {
 					if baseSsrc == ssrc {
 						repairSsrc := SSRC(r) //nolint:gosec // G115
-						trackDetails.rtxSsrc = &repairSsrc
+						trackDetails.rtxSsrc = []*SSRC{&repairSsrc}
 					}
 				}
 				for r, baseSsrc := range fecRepairFlows {
 					if baseSsrc == ssrc {
 						fecSsrc := SSRC(r) //nolint:gosec // G115
-						trackDetails.fecSsrc = &fecSsrc
+						trackDetails.fecSsrc = []*SSRC{&fecSsrc}
 					}
 				}
 
@@ -258,6 +258,26 @@ func trackDetailsFromSDP(
 				id:       trackID,
 				ssrcs:    ssrcs,
 			}
+			if len(rtxRepairFlows) > 0 {
+				simulcastTrack.rtxSsrc = make([]*SSRC, len(ssrcs))
+				for rtx, base := range rtxRepairFlows {
+					baseSsrc := SSRC(base) //nolint:gosec // G115
+					if pos := slices.Index(ssrcs, baseSsrc); pos != -1 {
+						repairSsrc := SSRC(rtx) //nolint:gosec // G115
+						simulcastTrack.rtxSsrc[pos] = &repairSsrc
+					}
+				}
+			}
+			if len(fecRepairFlows) > 0 {
+				simulcastTrack.fecSsrc = make([]*SSRC, len(ssrcs))
+				for fec, base := range fecRepairFlows {
+					baseSsrc := SSRC(base) //nolint:gosec // G115
+					if pos := slices.Index(ssrcs, baseSsrc); pos != -1 {
+						fecSsrc := SSRC(fec) //nolint:gosec // G115
+						simulcastTrack.fecSsrc[pos] = &fecSsrc
+					}
+				}
+			}
 
 			tracksInMediaSection = []trackDetails{simulcastTrack}
 		}
@@ -280,12 +300,12 @@ func trackDetailsToRTPReceiveParameters(trackDetails *trackDetails) RTPReceivePa
 			encodings[i].SSRC = trackDetails.ssrcs[i]
 		}
 
-		if trackDetails.rtxSsrc != nil {
-			encodings[i].RTX.SSRC = *trackDetails.rtxSsrc
+		if len(trackDetails.rtxSsrc) > i && trackDetails.rtxSsrc[i] != nil {
+			encodings[i].RTX.SSRC = *trackDetails.rtxSsrc[i]
 		}
 
-		if trackDetails.fecSsrc != nil {
-			encodings[i].FEC.SSRC = *trackDetails.fecSsrc
+		if len(trackDetails.fecSsrc) > i && trackDetails.fecSsrc[i] != nil {
+			encodings[i].FEC.SSRC = *trackDetails.fecSsrc[i]
 		}
 	}
 

--- a/sdp.go
+++ b/sdp.go
@@ -250,6 +250,16 @@ func trackDetailsFromSDP(
 			}
 
 			tracksInMediaSection = []trackDetails{simulcastTrack}
+		} else if ssrcs := getSimulcastSSRCs(log, media); len(ssrcs) != 0 && trackID != "" && streamID != "" {
+			simulcastTrack := trackDetails{
+				mid:      midValue,
+				kind:     codecType,
+				streamID: streamID,
+				id:       trackID,
+				ssrcs:    ssrcs,
+			}
+
+			tracksInMediaSection = []trackDetails{simulcastTrack}
 		}
 
 		incomingTracks = append(incomingTracks, tracksInMediaSection...)
@@ -314,6 +324,29 @@ func getRids(media *sdp.MediaDescription) []*simulcastRid {
 	}
 
 	return rids
+}
+
+func getSimulcastSSRCs(log logging.LeveledLogger, media *sdp.MediaDescription) []SSRC {
+	var ssrcs []SSRC
+	for _, attr := range media.Attributes {
+		if attr.Key == sdp.AttrKeySSRCGroup {
+			split := strings.Split(attr.Value, " ")
+			if split[0] == ssrcGroupSimulcast {
+				for _, v := range split[1:] {
+					ssrc, err := strconv.ParseUint(v, 10, 32)
+					if err != nil {
+						log.Warnf("Failed to parse SSRC: %v", err)
+
+						continue
+					}
+
+					ssrcs = append(ssrcs, SSRC(ssrc))
+				}
+			}
+		}
+	}
+
+	return ssrcs
 }
 
 func addCandidatesToMediaDescriptions(

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -591,10 +591,12 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 		assert.Equal(t, RTPCodecTypeVideo, track.kind)
 		assert.Equal(t, SSRC(3000), track.ssrcs[0])
 		assert.Equal(t, "video_trk_label", track.streamID)
-		require.NotNil(t, track.rtxSsrc, "missing RTX ssrc for video track")
-		assert.Equal(t, SSRC(4000), *track.rtxSsrc)
-		require.NotNil(t, track.fecSsrc, "missing FEC ssrc for video track")
-		assert.Equal(t, SSRC(5000), *track.fecSsrc)
+		require.Len(t, track.rtxSsrc, 1)
+		require.NotNil(t, track.rtxSsrc[0], "missing RTX ssrc for video track")
+		assert.Equal(t, SSRC(4000), *track.rtxSsrc[0])
+		require.Len(t, track.fecSsrc, 1)
+		require.NotNil(t, track.fecSsrc[0], "missing FEC ssrc for video track")
+		assert.Equal(t, SSRC(5000), *track.fecSsrc[0])
 	})
 
 	t.Run("inactive and recvonly tracks ignored", func(t *testing.T) {
@@ -655,8 +657,10 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 
 		tracks := trackDetailsFromSDP(nil, descr)
 		assert.Equal(t, 2, len(tracks))
-		assert.Equal(t, SSRC(4000), *tracks[0].rtxSsrc)
-		assert.Equal(t, SSRC(6000), *tracks[1].rtxSsrc)
+		require.Len(t, tracks[0].rtxSsrc, 1)
+		assert.Equal(t, SSRC(4000), *tracks[0].rtxSsrc[0])
+		require.Len(t, tracks[1].rtxSsrc, 1)
+		assert.Equal(t, SSRC(6000), *tracks[1].rtxSsrc[0])
 	})
 
 	t.Run("simulcast ssrc-group", func(t *testing.T) {
@@ -689,13 +693,62 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 						{Key: "ssrc-group", Value: "SIM 3000 invalid 5000"},
 					},
 				},
+				{
+					MediaName: sdp.MediaName{
+						Media: "video",
+					},
+					Attributes: []sdp.Attribute{
+						{Key: "mid", Value: "0"},
+						{Key: "sendrecv"},
+						{Key: "ssrc", Value: "3000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "3100 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "4000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "4100 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "5000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "5100 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc-group", Value: "SIM 3000 4000 5000"},
+						{Key: "ssrc-group", Value: "FID 3000 3100"},
+						{Key: "ssrc-group", Value: "FID 4000 4100"},
+						{Key: "ssrc-group", Value: "FID 5000 5100"},
+					},
+				},
+				{
+					MediaName: sdp.MediaName{
+						Media: "video",
+					},
+					Attributes: []sdp.Attribute{
+						{Key: "mid", Value: "0"},
+						{Key: "sendrecv"},
+						{Key: "ssrc", Value: "3000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "3100 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "4000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "4100 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "5000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "5100 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc-group", Value: "SIM 3000 4000 5000"},
+						{Key: "ssrc-group", Value: "FEC-FR 3000 3100"},
+						{Key: "ssrc-group", Value: "FEC-FR 4000 4100"},
+						{Key: "ssrc-group", Value: "FEC-FR 5000 5100"},
+					},
+				},
 			},
 		}
 
 		tracks := trackDetailsFromSDP(log, descr)
-		assert.Equal(t, 2, len(tracks))
+		assert.Equal(t, 4, len(tracks))
 		assert.Equal(t, []SSRC{3000, 4000, 5000}, tracks[0].ssrcs)
 		assert.Equal(t, []SSRC{3000, 5000}, tracks[1].ssrcs)
+		assert.Equal(t, []SSRC{3000, 4000, 5000}, tracks[2].ssrcs)
+		if assert.Len(t, tracks[2].rtxSsrc, 3) {
+			assert.Equal(t, SSRC(3100), *tracks[2].rtxSsrc[0])
+			assert.Equal(t, SSRC(4100), *tracks[2].rtxSsrc[1])
+			assert.Equal(t, SSRC(5100), *tracks[2].rtxSsrc[2])
+		}
+		if assert.Len(t, tracks[3].fecSsrc, 3) {
+			assert.Equal(t, SSRC(3100), *tracks[3].fecSsrc[0])
+			assert.Equal(t, SSRC(4100), *tracks[3].fecSsrc[1])
+			assert.Equal(t, SSRC(5100), *tracks[3].fecSsrc[2])
+		}
 	})
 }
 

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pion/logging"
 	"github.com/pion/sdp/v3"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
@@ -656,6 +657,45 @@ func TestTrackDetailsFromSDP(t *testing.T) {
 		assert.Equal(t, 2, len(tracks))
 		assert.Equal(t, SSRC(4000), *tracks[0].rtxSsrc)
 		assert.Equal(t, SSRC(6000), *tracks[1].rtxSsrc)
+	})
+
+	t.Run("simulcast ssrc-group", func(t *testing.T) {
+		log := logging.NewDefaultLoggerFactory().NewLogger("test")
+		descr := &sdp.SessionDescription{
+			MediaDescriptions: []*sdp.MediaDescription{
+				{
+					MediaName: sdp.MediaName{
+						Media: "video",
+					},
+					Attributes: []sdp.Attribute{
+						{Key: "mid", Value: "0"},
+						{Key: "sendrecv"},
+						{Key: "ssrc", Value: "3000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "4000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "5000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc-group", Value: "SIM 3000 4000 5000"},
+					},
+				},
+				{
+					MediaName: sdp.MediaName{
+						Media: "video",
+					},
+					Attributes: []sdp.Attribute{
+						{Key: "mid", Value: "0"},
+						{Key: "sendrecv"},
+						{Key: "ssrc", Value: "3000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "4000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc", Value: "5000 msid:video_trk_label video_trk_guid"},
+						{Key: "ssrc-group", Value: "SIM 3000 invalid 5000"},
+					},
+				},
+			},
+		}
+
+		tracks := trackDetailsFromSDP(log, descr)
+		assert.Equal(t, 2, len(tracks))
+		assert.Equal(t, []SSRC{3000, 4000, 5000}, tracks[0].ssrcs)
+		assert.Equal(t, []SSRC{3000, 5000}, tracks[1].ssrcs)
 	})
 }
 


### PR DESCRIPTION
Required to correctly handle offer SDPs like this (taken from Nextcloud Talk with Chrome):
```
v=0
o=- 3304229686190011165 2 IN IP4 127.0.0.1
s=-
t=0 0
a=group:BUNDLE 0 1 2
a=extmap-allow-mixed
a=msid-semantic: WMS 3b43bf3b-262d-45df-a91d-c6f4dcf00b4e
m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126
c=IN IP4 0.0.0.0
a=rtcp:9 IN IP4 0.0.0.0
a=ice-ufrag:Ezq+
a=ice-pwd:3lSMQj0krWe/iGb7ex4U+/2d
a=ice-options:trickle
a=fingerprint:sha-256 B1:4D:7F:6B:5A:88:67:5D:D1:9E:D2:1C:FB:22:71:21:9B:09:B4:8D:C0:52:DC:6F:C9:A7:2D:D2:08:44:B8:70
a=setup:actpass
a=mid:0
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
a=sendonly
a=msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e cac04ecb-ee49-46c0-a5b9-189a33774647
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:111 opus/48000/2
a=rtcp-fb:111 transport-cc
a=fmtp:111 minptime=10;useinbandfec=1
a=rtpmap:63 red/48000/2
a=fmtp:63 111/111
a=rtpmap:9 G722/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:13 CN/8000
a=rtpmap:110 telephone-event/48000
a=rtpmap:126 telephone-event/8000
a=ssrc:1575337190 cname:4Cqdy6kA30DYfwYF
a=ssrc:1575337190 msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e cac04ecb-ee49-46c0-a5b9-189a33774647
m=video 9 UDP/TLS/RTP/SAVPF 96 97 103 104 107 108 109 114 115 116 117 118 39 40 45 46 98 99 100 101 119 120 121
c=IN IP4 0.0.0.0
a=rtcp:9 IN IP4 0.0.0.0
a=ice-ufrag:Ezq+
a=ice-pwd:3lSMQj0krWe/iGb7ex4U+/2d
a=ice-options:trickle
a=fingerprint:sha-256 B1:4D:7F:6B:5A:88:67:5D:D1:9E:D2:1C:FB:22:71:21:9B:09:B4:8D:C0:52:DC:6F:C9:A7:2D:D2:08:44:B8:70
a=setup:actpass
a=mid:1
a=extmap:14 urn:ietf:params:rtp-hdrext:toffset
a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:13 urn:3gpp:video-orientation
a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing
a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
a=sendonly
a=msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e a1c1d396-6eda-4d34-984a-f5f2eb70ece7
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:96 VP8/90000
a=rtcp-fb:96 goog-remb
a=rtcp-fb:96 transport-cc
a=rtcp-fb:96 ccm fir
a=rtcp-fb:96 nack
a=rtcp-fb:96 nack pli
a=rtpmap:97 rtx/90000
a=fmtp:97 apt=96
a=rtpmap:103 H264/90000
a=rtcp-fb:103 goog-remb
a=rtcp-fb:103 transport-cc
a=rtcp-fb:103 ccm fir
a=rtcp-fb:103 nack
a=rtcp-fb:103 nack pli
a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
a=rtpmap:104 rtx/90000
a=fmtp:104 apt=103
a=rtpmap:107 H264/90000
a=rtcp-fb:107 goog-remb
a=rtcp-fb:107 transport-cc
a=rtcp-fb:107 ccm fir
a=rtcp-fb:107 nack
a=rtcp-fb:107 nack pli
a=fmtp:107 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f
a=rtpmap:108 rtx/90000
a=fmtp:108 apt=107
a=rtpmap:109 H264/90000
a=rtcp-fb:109 goog-remb
a=rtcp-fb:109 transport-cc
a=rtcp-fb:109 ccm fir
a=rtcp-fb:109 nack
a=rtcp-fb:109 nack pli
a=fmtp:109 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
a=rtpmap:114 rtx/90000
a=fmtp:114 apt=109
a=rtpmap:115 H264/90000
a=rtcp-fb:115 goog-remb
a=rtcp-fb:115 transport-cc
a=rtcp-fb:115 ccm fir
a=rtcp-fb:115 nack
a=rtcp-fb:115 nack pli
a=fmtp:115 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f
a=rtpmap:116 rtx/90000
a=fmtp:116 apt=115
a=rtpmap:117 H264/90000
a=rtcp-fb:117 goog-remb
a=rtcp-fb:117 transport-cc
a=rtcp-fb:117 ccm fir
a=rtcp-fb:117 nack
a=rtcp-fb:117 nack pli
a=fmtp:117 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f
a=rtpmap:118 rtx/90000
a=fmtp:118 apt=117
a=rtpmap:39 H264/90000
a=rtcp-fb:39 goog-remb
a=rtcp-fb:39 transport-cc
a=rtcp-fb:39 ccm fir
a=rtcp-fb:39 nack
a=rtcp-fb:39 nack pli
a=fmtp:39 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f
a=rtpmap:40 rtx/90000
a=fmtp:40 apt=39
a=rtpmap:45 AV1/90000
a=rtcp-fb:45 goog-remb
a=rtcp-fb:45 transport-cc
a=rtcp-fb:45 ccm fir
a=rtcp-fb:45 nack
a=rtcp-fb:45 nack pli
a=fmtp:45 level-idx=5;profile=0;tier=0
a=rtpmap:46 rtx/90000
a=fmtp:46 apt=45
a=rtpmap:98 VP9/90000
a=rtcp-fb:98 goog-remb
a=rtcp-fb:98 transport-cc
a=rtcp-fb:98 ccm fir
a=rtcp-fb:98 nack
a=rtcp-fb:98 nack pli
a=fmtp:98 profile-id=0
a=rtpmap:99 rtx/90000
a=fmtp:99 apt=98
a=rtpmap:100 VP9/90000
a=rtcp-fb:100 goog-remb
a=rtcp-fb:100 transport-cc
a=rtcp-fb:100 ccm fir
a=rtcp-fb:100 nack
a=rtcp-fb:100 nack pli
a=fmtp:100 profile-id=2
a=rtpmap:101 rtx/90000
a=fmtp:101 apt=100
a=rtpmap:119 red/90000
a=rtpmap:120 rtx/90000
a=fmtp:120 apt=119
a=rtpmap:121 ulpfec/90000
a=ssrc:1109168805 cname:4Cqdy6kA30DYfwYF
a=ssrc:1109168805 msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e a1c1d396-6eda-4d34-984a-f5f2eb70ece7
a=ssrc:3192552408 cname:4Cqdy6kA30DYfwYF
a=ssrc:3192552408 msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e a1c1d396-6eda-4d34-984a-f5f2eb70ece7
a=ssrc:3046756662 cname:4Cqdy6kA30DYfwYF
a=ssrc:3046756662 msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e a1c1d396-6eda-4d34-984a-f5f2eb70ece7
a=ssrc:1315488727 cname:4Cqdy6kA30DYfwYF
a=ssrc:1315488727 msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e a1c1d396-6eda-4d34-984a-f5f2eb70ece7
a=ssrc:274207894 cname:4Cqdy6kA30DYfwYF
a=ssrc:274207894 msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e a1c1d396-6eda-4d34-984a-f5f2eb70ece7
a=ssrc:547186941 cname:4Cqdy6kA30DYfwYF
a=ssrc:547186941 msid:3b43bf3b-262d-45df-a91d-c6f4dcf00b4e a1c1d396-6eda-4d34-984a-f5f2eb70ece7
a=ssrc-group:SIM 1109168805 3046756662 274207894
a=ssrc-group:FID 1109168805 3192552408
a=ssrc-group:FID 3046756662 1315488727
a=ssrc-group:FID 274207894 547186941
m=application 9 UDP/DTLS/SCTP webrtc-datachannel
c=IN IP4 0.0.0.0
a=ice-ufrag:Ezq+
a=ice-pwd:3lSMQj0krWe/iGb7ex4U+/2d
a=ice-options:trickle
a=fingerprint:sha-256 B1:4D:7F:6B:5A:88:67:5D:D1:9E:D2:1C:FB:22:71:21:9B:09:B4:8D:C0:52:DC:6F:C9:A7:2D:D2:08:44:B8:70
a=setup:actpass
a=mid:2
a=sctp-port:5000
a=max-message-size:262144
```

Without this change, only a single track with the first SSRC is signaled from `PeerConnection.OnTrack`.