### PR TITLE
Add a setting to toggle interleaving

### DIFF
--- a/examples/sctp-interleaving-inspect/main.go
+++ b/examples/sctp-interleaving-inspect/main.go
@@ -271,6 +271,7 @@ func runStack(
 		sctp.WithMTU(outboundMTU),
 		sctp.WithMaxMessageSize(maxMessageSize),
 		sctp.WithLoggerFactory(logging.NewDefaultLoggerFactory()),
+		sctp.WithEnableInterleaving(true),
 	)
 	if err != nil {
 		return err

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -169,7 +169,7 @@ func (r *SCTPTransport) sctpClientOptions(netConn net.Conn, maxMessageSize uint3
 }
 
 func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
-	opts := make([]sctp.ClientOption, 0, 7)
+	opts := make([]sctp.ClientOption, 0, 8)
 
 	if r.api.settingEngine.sctp.maxReceiveBufferSize != 0 {
 		opts = append(opts, sctp.WithMaxReceiveBufferSize(r.api.settingEngine.sctp.maxReceiveBufferSize))
@@ -200,6 +200,10 @@ func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
 
 	if r.api.settingEngine.sctp.cwndCAStep != 0 {
 		opts = append(opts, sctp.WithCwndCAStep(r.api.settingEngine.sctp.cwndCAStep))
+	}
+
+	if r.api.settingEngine.sctp.enableInterleaving != nil {
+		opts = append(opts, sctp.WithEnableInterleaving(*r.api.settingEngine.sctp.enableInterleaving))
 	}
 
 	return opts
@@ -515,14 +519,30 @@ func (r *SCTPTransport) BufferedAmount() int {
 func (r *SCTPTransport) GetSctpInit() []byte {
 	if len(r.localSctpInit) == 0 {
 		var err error
-		r.localSctpInit, err = sctp.GenerateOutOfBandToken(sctp.Config{
-			MaxReceiveBufferSize: r.api.settingEngine.sctp.maxReceiveBufferSize,
-			EnableZeroChecksum:   r.api.settingEngine.sctp.enableZeroChecksum,
-		})
+		opts := r.optionalSCTPTokenOptions()
+		r.localSctpInit, err = sctp.GenerateOutOfBandToken(opts...)
 		if err != nil {
 			r.log.Warnf("Failed to create sctp-init: %v", err)
 		}
 	}
 
 	return r.localSctpInit
+}
+
+func (r *SCTPTransport) optionalSCTPTokenOptions() []sctp.ClientOption {
+	opts := make([]sctp.ClientOption, 0, 3)
+
+	if r.api.settingEngine.sctp.maxReceiveBufferSize != 0 {
+		opts = append(opts, sctp.WithMaxReceiveBufferSize(r.api.settingEngine.sctp.maxReceiveBufferSize))
+	}
+
+	if r.api.settingEngine.sctp.enableZeroChecksum {
+		opts = append(opts, sctp.WithEnableZeroChecksum(true))
+	}
+
+	if r.api.settingEngine.sctp.enableInterleaving != nil {
+		opts = append(opts, sctp.WithEnableInterleaving(*r.api.settingEngine.sctp.enableInterleaving))
+	}
+
+	return opts
 }

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -129,6 +129,20 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 			wantExtra: 1,
 		},
 		{
+			name: "EnableInterleavingTrue",
+			configure: func(se *SettingEngine) {
+				se.EnableSCTPInterleaving(true)
+			},
+			wantExtra: 1,
+		},
+		{
+			name: "EnableInterleavingFalse",
+			configure: func(se *SettingEngine) {
+				se.EnableSCTPInterleaving(false)
+			},
+			wantExtra: 1,
+		},
+		{
 			name: "AllOptional",
 			configure: func(se *SettingEngine) {
 				se.sctp.maxReceiveBufferSize = 1024
@@ -139,8 +153,9 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 				se.sctp.minCwnd = 11
 				se.sctp.fastRtxWnd = 22
 				se.sctp.cwndCAStep = 33
+				se.EnableSCTPInterleaving(false)
 			},
-			wantExtra: 7,
+			wantExtra: 8,
 		},
 	}
 
@@ -153,6 +168,69 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 			opts := transport.sctpClientOptions(clientConn, defaultMaxSCTPMessageSize)
 
 			assert.Len(t, opts, baseCount+tc.wantExtra)
+		})
+	}
+}
+
+func TestSCTPTransport_optionalSCTPTokenOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*SettingEngine)
+		wantLen   int
+	}{
+		{
+			name:    "Default",
+			wantLen: 0,
+		},
+		{
+			name: "MaxReceiveBufferSize",
+			configure: func(se *SettingEngine) {
+				se.sctp.maxReceiveBufferSize = 1024
+			},
+			wantLen: 1,
+		},
+		{
+			name: "EnableZeroChecksum",
+			configure: func(se *SettingEngine) {
+				se.sctp.enableZeroChecksum = true
+			},
+			wantLen: 1,
+		},
+		{
+			name: "EnableInterleavingTrue",
+			configure: func(se *SettingEngine) {
+				se.EnableSCTPInterleaving(true)
+			},
+			wantLen: 1,
+		},
+		{
+			name: "EnableInterleavingFalse",
+			configure: func(se *SettingEngine) {
+				se.EnableSCTPInterleaving(false)
+			},
+			wantLen: 1,
+		},
+		{
+			name: "AllOptional",
+			configure: func(se *SettingEngine) {
+				se.sctp.maxReceiveBufferSize = 1024
+				se.sctp.enableZeroChecksum = true
+				se.EnableSCTPInterleaving(false)
+			},
+			wantLen: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			api := NewAPI()
+			if tc.configure != nil {
+				tc.configure(api.settingEngine)
+			}
+
+			transport := &SCTPTransport{api: api}
+
+			assert.Len(t, transport.optionalSCTPTokenOptions(), tc.wantLen)
 		})
 	}
 }

--- a/settingengine.go
+++ b/settingengine.go
@@ -93,6 +93,7 @@ type SettingEngine struct {
 		fastRtxWnd           uint32
 		cwndCAStep           uint32
 		enableSnap           bool
+		enableInterleaving   *bool
 	}
 	sdpMediaLevelFingerprints                 bool
 	answeringDTLSRole                         DTLSRole
@@ -613,6 +614,12 @@ func (e *SettingEngine) EnableSCTPZeroChecksum(isEnabled bool) {
 // EnableSctpSnap enables the use of the SCTP SNAP connect optimization.
 func (e *SettingEngine) EnableSctpSnap(isEnabled bool) {
 	e.sctp.enableSnap = isEnabled
+}
+
+// EnableSCTPInterleaving controls whether SCTP negotiates RFC 8260 user message interleaving.
+// If this setting is not called, the underlying SCTP default is used.
+func (e *SettingEngine) EnableSCTPInterleaving(isEnabled bool) {
+	e.sctp.enableInterleaving = &isEnabled
 }
 
 // SetSCTPMaxMessageSize sets the largest message we are willing to accept.

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -125,6 +125,19 @@ func TestICERenomination(t *testing.T) {
 	})
 }
 
+func TestEnableSCTPInterleaving(t *testing.T) {
+	settings := SettingEngine{}
+	assert.Nil(t, settings.sctp.enableInterleaving)
+
+	settings.EnableSCTPInterleaving(true)
+	assert.NotNil(t, settings.sctp.enableInterleaving)
+	assert.True(t, *settings.sctp.enableInterleaving)
+
+	settings.EnableSCTPInterleaving(false)
+	assert.NotNil(t, settings.sctp.enableInterleaving)
+	assert.False(t, *settings.sctp.enableInterleaving)
+}
+
 func TestDetachDataChannels(t *testing.T) {
 	s := SettingEngine{}
 	assert.False(t, s.detach.DataChannels)


### PR DESCRIPTION
#### Description
A setting to switch if I-DATA is enabled in SCTP, we're going to enable it by default only after 4.3, and even after this some users might want to disable it for whatever reasons.

based on https://github.com/pion/sctp/pull/466 and requires https://github.com/pion/sctp/pull/443 to get merged