### PR TITLE
Fix DC OnClose race, add default DC open handler

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -53,6 +53,7 @@ type DataChannel struct {
 	onOpenHandler       func()
 	dialHandlerOnce     sync.Once
 	onDialHandler       func()
+	closeHandlerOnce    sync.Once
 	onCloseHandler      func()
 	onBufferedAmountLow func()
 	onErrorHandler      func(error)
@@ -284,8 +285,14 @@ func (d *DataChannel) onDial() {
 // prior to GracefulClose.
 func (d *DataChannel) OnClose(f func()) {
 	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.closeHandlerOnce = sync.Once{}
 	d.onCloseHandler = f
+	d.mu.Unlock()
+
+	if d.ReadyState() == DataChannelStateClosed {
+		// If the data channel is already closed, call the handler immediately.
+		go d.closeHandlerOnce.Do(f)
+	}
 }
 
 func (d *DataChannel) onClose() {
@@ -294,7 +301,7 @@ func (d *DataChannel) onClose() {
 	d.mu.RUnlock()
 
 	if handler != nil {
-		go handler()
+		go d.closeHandlerOnce.Do(handler)
 	}
 }
 

--- a/datachannel_go_test.go
+++ b/datachannel_go_test.go
@@ -64,6 +64,31 @@ func TestDataChannel_EventHandlers(t *testing.T) {
 	<-onMessageCalled
 }
 
+func TestDataChannel_OnCloseImmediateAfterClosed(t *testing.T) {
+	dc := &DataChannel{}
+	dc.setReadyState(DataChannelStateClosed)
+
+	called := atomic.Int32{}
+	done := make(chan struct{})
+
+	dc.OnClose(func() {
+		if called.Add(1) == 1 {
+			close(done)
+		}
+	})
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		assert.Fail(t, "OnClose did not fire immediately for closed DataChannel")
+	}
+
+	// Simulate additional close signaling and verify nonce prevents duplicate calls.
+	dc.onClose()
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(1), called.Load())
+}
+
 func TestDataChannel_MessagesAreOrdered(t *testing.T) {
 	report := test.CheckRoutines(t)
 	defer report()
@@ -612,6 +637,10 @@ func TestDataChannel_Dial(t *testing.T) {
 
 		offerPC, answerPC, err := newPair()
 		assert.NoError(t, err)
+
+		// Accept incoming data channels without closing them; without this the
+		// default handler would close the channel before the offer side opens it.
+		answerPC.OnDataChannel(func(_ *DataChannel) {})
 
 		d, err := offerPC.CreateDataChannel(expectedLabel, nil)
 		assert.NoError(t, err)

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -140,6 +140,7 @@ func (api *API) NewPeerConnection(configuration Configuration) (*PeerConnection,
 		api: api,
 		log: api.settingEngine.LoggerFactory.NewLogger("pc"),
 	}
+	pc.onDataChannelHandler = pc.defaultOnDataChannelHandler
 	pc.ops = newOperations(pc.updateNegotiationNeededFlagOnEmptyChain, pc.onNegotiationNeeded)
 
 	pc.iceConnectionState.Store(ICEConnectionStateNew)
@@ -296,10 +297,27 @@ func (pc *PeerConnection) onSignalingStateChange(newState SignalingState) {
 
 // OnDataChannel sets an event handler which is invoked when a data
 // channel message arrives from a remote peer.
+// When handler is nil, the default handler will be used which closes
+// the incoming data channel immediately.
 func (pc *PeerConnection) OnDataChannel(f func(*DataChannel)) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
+	if f == nil {
+		pc.onDataChannelHandler = pc.defaultOnDataChannelHandler
+
+		return
+	}
 	pc.onDataChannelHandler = f
+}
+
+func (pc *PeerConnection) defaultOnDataChannelHandler(d *DataChannel) {
+	if d == nil {
+		return
+	}
+
+	if err := d.Close(); err != nil {
+		pc.log.Warnf("Failed to close undeclared DataChannel: %v", err)
+	}
 }
 
 // OnNegotiationNeeded sets an event handler which is invoked when

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -361,6 +361,27 @@ func TestPeerConnection_EventHandlers_Go(t *testing.T) {
 	assert.NoError(t, pc.Close())
 }
 
+func TestPeerConnection_OnDataChannel_DefaultHandlerClosesChannel(t *testing.T) {
+	api := NewAPI()
+	pc, err := api.NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+
+	dc := &DataChannel{api: api}
+	dc.setReadyState(DataChannelStateOpen)
+
+	assert.NotPanics(t, func() { pc.onDataChannelHandler(dc) })
+	assert.Equal(t, DataChannelStateClosing, dc.ReadyState())
+
+	pc.OnDataChannel(nil)
+	dc2 := &DataChannel{api: api}
+	dc2.setReadyState(DataChannelStateOpen)
+
+	assert.NotPanics(t, func() { pc.onDataChannelHandler(dc2) })
+	assert.Equal(t, DataChannelStateClosing, dc2.ReadyState())
+
+	assert.NoError(t, pc.Close())
+}
+
 // This test asserts that nothing deadlocks we try to shutdown when DTLS is in flight
 // We ensure that DTLS is in flight by removing the mux func for it, so all inbound DTLS is lost.
 func TestPeerConnection_ShutdownNoDTLS(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR addresses two related reliability issues with `DataChannel` close handling and unhandled incoming data channels.

---

## Changes

### `DataChannel`: fire `OnClose` immediately if already closed + prevent duplicate calls

**Problem:** If `OnClose` was registered after the channel had already transitioned to `DataChannelStateClosed`, the handler would never be called.

The late-registration race for `OnClose` is rarely observed in production or even in localhost-based unit tests, due to network and scheduling latency. However, when it does occur in tests it causes flaky failures — the `OnClose` handler silently never fires — which was the direct motivation for this fix. The scenario where a remote peer closes a data channel immediately after opening it should be handled reliably regardless of timing.

**Fix:**

- Added a `closeHandlerOnce sync.Once` field to `DataChannel`.
- `OnClose()` now resets the once-guard when a new handler is registered. If the channel is already closed at registration time, the handler is fired immediately in a goroutine.
- `onClose()` now wraps the handler call in `closeHandlerOnce.Do(...)`, ensuring the handler is called at most once per registration.

### `PeerConnection`: default `OnDataChannel` handler closes undeclared channels

**Problem:** Some applications are designed so that only one side opens data channels and the other side only accepts them. Such an app typically registers `OnDataChannel` to handle expected channels, but may not consider the case where the remote peer opens an unexpected channel. Before this change, any application that never called `OnDataChannel` (or reset it to `nil`) would silently accept every incoming channel and leave it open — leaking resources.

**Fix:**

- `NewPeerConnection` now initialises `onDataChannelHandler` to a new `defaultOnDataChannelHandler`.
- `defaultOnDataChannelHandler` calls `d.Close()` on any incoming channel, logging a warning on error.
- `OnDataChannel(nil)` restores the default handler instead of setting the field to `nil`.
