### PR TITLE
Fix wasm null JS event handlers before release

### DIFF
--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -181,18 +181,22 @@ func (d *DataChannel) Close() (err error) {
 
 	// Release any handlers as required by the syscall/js API.
 	if d.onOpenHandler != nil {
+		d.underlying.Set("onopen", js.Null())
 		d.onOpenHandler.Release()
 	}
 	if d.onCloseHandler != nil {
 		d.onCloseHandler.Release()
 	}
 	if d.onClosingHandler != nil {
+		d.underlying.Set("onclosing", js.Null())
 		d.onClosingHandler.Release()
 	}
 	if d.onMessageHandler != nil {
+		d.underlying.Set("onmessage", js.Null())
 		d.onMessageHandler.Release()
 	}
 	if d.onBufferedAmountLow != nil {
+		d.underlying.Set("onbufferedamountlow", js.Null())
 		d.onBufferedAmountLow.Release()
 	}
 	if d.onErrorHandler != nil {

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -180,32 +180,22 @@ func (d *DataChannel) Close() (err error) {
 	d.underlying.Call("close")
 
 	// Release any handlers as required by the syscall/js API.
-	// Null out each JS property before Release() to prevent "call to released
-	// function": close() queues browser events (e.g. close, closing) that fire
-	// asynchronously; if Release() runs first, those callbacks call a Go FuncOf
-	// that is no longer in funcs[].
 	if d.onOpenHandler != nil {
-		d.underlying.Set("onopen", js.Null())
 		d.onOpenHandler.Release()
 	}
 	if d.onCloseHandler != nil {
-		d.underlying.Set("onclose", js.Null())
 		d.onCloseHandler.Release()
 	}
 	if d.onClosingHandler != nil {
-		d.underlying.Set("onclosing", js.Null())
 		d.onClosingHandler.Release()
 	}
 	if d.onMessageHandler != nil {
-		d.underlying.Set("onmessage", js.Null())
 		d.onMessageHandler.Release()
 	}
 	if d.onBufferedAmountLow != nil {
-		d.underlying.Set("onbufferedamountlow", js.Null())
 		d.onBufferedAmountLow.Release()
 	}
 	if d.onErrorHandler != nil {
-		d.underlying.Set("onerror", js.Null())
 		d.onErrorHandler.Release()
 	}
 

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -36,6 +36,10 @@ type DataChannel struct {
 	// invoked from a self-releasing wrapper installed by Close().
 	onCloseFunc func()
 
+	// closeWrapperInstalled guards the self-releasing onclose wrapper in Close()
+	// so repeated Close calls don't override the first wrapper before it fires.
+	closeWrapperInstalled bool
+
 	// A reference to the associated api object used by this datachannel
 	api *API
 }
@@ -207,28 +211,32 @@ func (d *DataChannel) Close() (err error) {
 	// Defer nullifying onclose and onerror until the channel has fully closed.
 	// An error event may still fire during the close handshake (between calling
 	// close() and the onclose event), and the user-provided OnClose callback
-	// must still be invoked. The wrapper installed below fires the user's
-	// OnClose callback (if any) and then nullifies/releases both onclose and
-	// onerror on the underlying JS object.
-	oldCloseHandler := d.onCloseHandler
-	oldErrorHandler := d.onErrorHandler
-	closeFunc := d.onCloseFunc
-	var wrapperHandler js.Func
-	wrapperHandler = js.FuncOf(func(this js.Value, args []js.Value) any {
-		if closeFunc != nil {
-			go closeFunc()
+	// must still be invoked. Install the wrapper only once so repeated Close()
+	// calls don't override the original wrapper before it fires.
+	if !d.closeWrapperInstalled {
+		oldCloseHandler := d.onCloseHandler
+		oldErrorHandler := d.onErrorHandler
+		closeFunc := d.onCloseFunc
+
+		var wrapperHandler js.Func
+		wrapperHandler = js.FuncOf(func(this js.Value, args []js.Value) any {
+			if closeFunc != nil {
+				go closeFunc()
+			}
+			d.underlying.Set("onclose", js.Null())
+			wrapperHandler.Release()
+			if oldErrorHandler != nil {
+				d.underlying.Set("onerror", js.Null())
+				oldErrorHandler.Release()
+			}
+			d.closeWrapperInstalled = false
+			return js.Undefined()
+		})
+		d.underlying.Set("onclose", wrapperHandler)
+		d.closeWrapperInstalled = true
+		if oldCloseHandler != nil {
+			oldCloseHandler.Release()
 		}
-		d.underlying.Set("onclose", js.Null())
-		wrapperHandler.Release()
-		if oldErrorHandler != nil {
-			d.underlying.Set("onerror", js.Null())
-			oldErrorHandler.Release()
-		}
-		return js.Undefined()
-	})
-	d.underlying.Set("onclose", wrapperHandler)
-	if oldCloseHandler != nil {
-		oldCloseHandler.Release()
 	}
 	d.onCloseHandler = nil
 	d.onCloseFunc = nil

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -32,6 +32,10 @@ type DataChannel struct {
 	onBufferedAmountLow *js.Func
 	onErrorHandler      *js.Func
 
+	// onCloseFunc retains the user-provided OnClose callback so it can still be
+	// invoked from a self-releasing wrapper installed by Close().
+	onCloseFunc func()
+
 	// A reference to the associated api object used by this datachannel
 	api *API
 }
@@ -63,6 +67,7 @@ func (d *DataChannel) OnClose(f func()) {
 		oldHandler := d.onCloseHandler
 		defer oldHandler.Release()
 	}
+	d.onCloseFunc = f
 	onCloseHandler := js.FuncOf(func(this js.Value, args []js.Value) any {
 		go f()
 		return js.Undefined()
@@ -177,31 +182,59 @@ func (d *DataChannel) Close() (err error) {
 		}
 	}()
 
-	d.underlying.Call("close")
-
-	// Release any handlers as required by the syscall/js API.
+	// Nullify and release handlers that should not fire after Close is called.
 	if d.onOpenHandler != nil {
 		d.underlying.Set("onopen", js.Null())
 		d.onOpenHandler.Release()
-	}
-	if d.onCloseHandler != nil {
-		d.onCloseHandler.Release()
+		d.onOpenHandler = nil
 	}
 	if d.onClosingHandler != nil {
 		d.underlying.Set("onclosing", js.Null())
 		d.onClosingHandler.Release()
+		d.onClosingHandler = nil
 	}
 	if d.onMessageHandler != nil {
 		d.underlying.Set("onmessage", js.Null())
 		d.onMessageHandler.Release()
+		d.onMessageHandler = nil
 	}
 	if d.onBufferedAmountLow != nil {
 		d.underlying.Set("onbufferedamountlow", js.Null())
 		d.onBufferedAmountLow.Release()
+		d.onBufferedAmountLow = nil
 	}
-	if d.onErrorHandler != nil {
-		d.onErrorHandler.Release()
+
+	// Defer nullifying onclose and onerror until the channel has fully closed.
+	// An error event may still fire during the close handshake (between calling
+	// close() and the onclose event), and the user-provided OnClose callback
+	// must still be invoked. The wrapper installed below fires the user's
+	// OnClose callback (if any) and then nullifies/releases both onclose and
+	// onerror on the underlying JS object.
+	oldCloseHandler := d.onCloseHandler
+	oldErrorHandler := d.onErrorHandler
+	closeFunc := d.onCloseFunc
+	var wrapperHandler js.Func
+	wrapperHandler = js.FuncOf(func(this js.Value, args []js.Value) any {
+		if closeFunc != nil {
+			go closeFunc()
+		}
+		d.underlying.Set("onclose", js.Null())
+		wrapperHandler.Release()
+		if oldErrorHandler != nil {
+			d.underlying.Set("onerror", js.Null())
+			oldErrorHandler.Release()
+		}
+		return js.Undefined()
+	})
+	d.underlying.Set("onclose", wrapperHandler)
+	if oldCloseHandler != nil {
+		oldCloseHandler.Release()
 	}
+	d.onCloseHandler = nil
+	d.onCloseFunc = nil
+	d.onErrorHandler = nil
+
+	d.underlying.Call("close")
 
 	return nil
 }

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -181,14 +181,20 @@ func (d *DataChannel) Close() (err error) {
 
 	// Release any handlers as required by the syscall/js API.
 	// Null out each JS property before Release() to prevent "call to released
-	// function" panics.
-	//
-	// Keep terminal handlers (onclosing/onclose/onerror) installed here because
-	// close() completes asynchronously and applications may still expect those
-	// events after Close() returns.
+	// function": close() queues browser events (e.g. close, closing) that fire
+	// asynchronously; if Release() runs first, those callbacks call a Go FuncOf
+	// that is no longer in funcs[].
 	if d.onOpenHandler != nil {
 		d.underlying.Set("onopen", js.Null())
 		d.onOpenHandler.Release()
+	}
+	if d.onCloseHandler != nil {
+		d.underlying.Set("onclose", js.Null())
+		d.onCloseHandler.Release()
+	}
+	if d.onClosingHandler != nil {
+		d.underlying.Set("onclosing", js.Null())
+		d.onClosingHandler.Release()
 	}
 	if d.onMessageHandler != nil {
 		d.underlying.Set("onmessage", js.Null())
@@ -197,6 +203,10 @@ func (d *DataChannel) Close() (err error) {
 	if d.onBufferedAmountLow != nil {
 		d.underlying.Set("onbufferedamountlow", js.Null())
 		d.onBufferedAmountLow.Release()
+	}
+	if d.onErrorHandler != nil {
+		d.underlying.Set("onerror", js.Null())
+		d.onErrorHandler.Release()
 	}
 
 	return nil

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -180,22 +180,32 @@ func (d *DataChannel) Close() (err error) {
 	d.underlying.Call("close")
 
 	// Release any handlers as required by the syscall/js API.
+	// Null out each JS property before Release() to prevent "call to released
+	// function": close() queues browser events (e.g. close, closing) that fire
+	// asynchronously; if Release() runs first, those callbacks call a Go FuncOf
+	// that is no longer in funcs[].
 	if d.onOpenHandler != nil {
+		d.underlying.Set("onopen", js.Null())
 		d.onOpenHandler.Release()
 	}
 	if d.onCloseHandler != nil {
+		d.underlying.Set("onclose", js.Null())
 		d.onCloseHandler.Release()
 	}
 	if d.onClosingHandler != nil {
+		d.underlying.Set("onclosing", js.Null())
 		d.onClosingHandler.Release()
 	}
 	if d.onMessageHandler != nil {
+		d.underlying.Set("onmessage", js.Null())
 		d.onMessageHandler.Release()
 	}
 	if d.onBufferedAmountLow != nil {
+		d.underlying.Set("onbufferedamountlow", js.Null())
 		d.onBufferedAmountLow.Release()
 	}
 	if d.onErrorHandler != nil {
+		d.underlying.Set("onerror", js.Null())
 		d.onErrorHandler.Release()
 	}
 

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -181,20 +181,14 @@ func (d *DataChannel) Close() (err error) {
 
 	// Release any handlers as required by the syscall/js API.
 	// Null out each JS property before Release() to prevent "call to released
-	// function": close() queues browser events (e.g. close, closing) that fire
-	// asynchronously; if Release() runs first, those callbacks call a Go FuncOf
-	// that is no longer in funcs[].
+	// function" panics.
+	//
+	// Keep terminal handlers (onclosing/onclose/onerror) installed here because
+	// close() completes asynchronously and applications may still expect those
+	// events after Close() returns.
 	if d.onOpenHandler != nil {
 		d.underlying.Set("onopen", js.Null())
 		d.onOpenHandler.Release()
-	}
-	if d.onCloseHandler != nil {
-		d.underlying.Set("onclose", js.Null())
-		d.onCloseHandler.Release()
-	}
-	if d.onClosingHandler != nil {
-		d.underlying.Set("onclosing", js.Null())
-		d.onClosingHandler.Release()
 	}
 	if d.onMessageHandler != nil {
 		d.underlying.Set("onmessage", js.Null())
@@ -203,10 +197,6 @@ func (d *DataChannel) Close() (err error) {
 	if d.onBufferedAmountLow != nil {
 		d.underlying.Set("onbufferedamountlow", js.Null())
 		d.onBufferedAmountLow.Release()
-	}
-	if d.onErrorHandler != nil {
-		d.underlying.Set("onerror", js.Null())
-		d.onErrorHandler.Release()
 	}
 
 	return nil

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -401,36 +401,25 @@ func (pc *PeerConnection) Close() (err error) {
 	pc.underlying.Call("close")
 
 	// Release any handlers as required by the syscall/js API.
-	// Null out each JS property before Release() to prevent "call to released
-	// function": close() queues browser events (e.g. iceconnectionstatechange)
-	// that fire asynchronously; if Release() runs first, those callbacks call a
-	// Go FuncOf that is no longer in funcs[].
 	if pc.onSignalingStateChangeHandler != nil {
-		pc.underlying.Set("onsignalingstatechange", js.Null())
 		pc.onSignalingStateChangeHandler.Release()
 	}
 	if pc.onDataChannelHandler != nil {
-		pc.underlying.Set("ondatachannel", js.Null())
 		pc.onDataChannelHandler.Release()
 	}
 	if pc.onNegotiationNeededHandler != nil {
-		pc.underlying.Set("onnegotiationneeded", js.Null())
 		pc.onNegotiationNeededHandler.Release()
 	}
 	if pc.onConnectionStateChangeHandler != nil {
-		pc.underlying.Set("onconnectionstatechange", js.Null())
 		pc.onConnectionStateChangeHandler.Release()
 	}
 	if pc.onICEConnectionStateChangeHandler != nil {
-		pc.underlying.Set("oniceconnectionstatechange", js.Null())
 		pc.onICEConnectionStateChangeHandler.Release()
 	}
 	if pc.onICECandidateHandler != nil {
-		pc.underlying.Set("onicecandidate", js.Null())
 		pc.onICECandidateHandler.Release()
 	}
 	if pc.onICEGatheringStateChangeHandler != nil {
-		pc.underlying.Set("onicegatheringstatechange", js.Null())
 		pc.onICEGatheringStateChangeHandler.Release()
 	}
 

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -401,25 +401,36 @@ func (pc *PeerConnection) Close() (err error) {
 	pc.underlying.Call("close")
 
 	// Release any handlers as required by the syscall/js API.
+	// Null out each JS property before Release() to prevent "call to released
+	// function": close() queues browser events (e.g. iceconnectionstatechange)
+	// that fire asynchronously; if Release() runs first, those callbacks call a
+	// Go FuncOf that is no longer in funcs[].
 	if pc.onSignalingStateChangeHandler != nil {
+		pc.underlying.Set("onsignalingstatechange", js.Null())
 		pc.onSignalingStateChangeHandler.Release()
 	}
 	if pc.onDataChannelHandler != nil {
+		pc.underlying.Set("ondatachannel", js.Null())
 		pc.onDataChannelHandler.Release()
 	}
 	if pc.onNegotiationNeededHandler != nil {
+		pc.underlying.Set("onnegotiationneeded", js.Null())
 		pc.onNegotiationNeededHandler.Release()
 	}
 	if pc.onConnectionStateChangeHandler != nil {
+		pc.underlying.Set("onconnectionstatechange", js.Null())
 		pc.onConnectionStateChangeHandler.Release()
 	}
 	if pc.onICEConnectionStateChangeHandler != nil {
+		pc.underlying.Set("oniceconnectionstatechange", js.Null())
 		pc.onICEConnectionStateChangeHandler.Release()
 	}
 	if pc.onICECandidateHandler != nil {
+		pc.underlying.Set("onicecandidate", js.Null())
 		pc.onICECandidateHandler.Release()
 	}
 	if pc.onICEGatheringStateChangeHandler != nil {
+		pc.underlying.Set("onicegatheringstatechange", js.Null())
 		pc.onICEGatheringStateChangeHandler.Release()
 	}
 

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -402,11 +402,13 @@ func (pc *PeerConnection) Close() (err error) {
 
 	// Release any handlers as required by the syscall/js API.
 	// Null out each JS property before Release() to prevent "call to released
-	// function" panics.
-	//
-	// Keep terminal state handlers installed here because close() transitions
-	// happen asynchronously and applications may still expect final state-change
-	// notifications after Close() returns.
+	// function": close() queues browser events (e.g. iceconnectionstatechange)
+	// that fire asynchronously; if Release() runs first, those callbacks call a
+	// Go FuncOf that is no longer in funcs[].
+	if pc.onSignalingStateChangeHandler != nil {
+		pc.underlying.Set("onsignalingstatechange", js.Null())
+		pc.onSignalingStateChangeHandler.Release()
+	}
 	if pc.onDataChannelHandler != nil {
 		pc.underlying.Set("ondatachannel", js.Null())
 		pc.onDataChannelHandler.Release()
@@ -414,6 +416,14 @@ func (pc *PeerConnection) Close() (err error) {
 	if pc.onNegotiationNeededHandler != nil {
 		pc.underlying.Set("onnegotiationneeded", js.Null())
 		pc.onNegotiationNeededHandler.Release()
+	}
+	if pc.onConnectionStateChangeHandler != nil {
+		pc.underlying.Set("onconnectionstatechange", js.Null())
+		pc.onConnectionStateChangeHandler.Release()
+	}
+	if pc.onICEConnectionStateChangeHandler != nil {
+		pc.underlying.Set("oniceconnectionstatechange", js.Null())
+		pc.onICEConnectionStateChangeHandler.Release()
 	}
 	if pc.onICECandidateHandler != nil {
 		pc.underlying.Set("onicecandidate", js.Null())

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -402,24 +402,31 @@ func (pc *PeerConnection) Close() (err error) {
 
 	// Release any handlers as required by the syscall/js API.
 	if pc.onSignalingStateChangeHandler != nil {
+		pc.underlying.Set("onsignalingstatechange", js.Null())
 		pc.onSignalingStateChangeHandler.Release()
 	}
 	if pc.onDataChannelHandler != nil {
+		pc.underlying.Set("ondatachannel", js.Null())
 		pc.onDataChannelHandler.Release()
 	}
 	if pc.onNegotiationNeededHandler != nil {
+		pc.underlying.Set("onnegotiationneeded", js.Null())
 		pc.onNegotiationNeededHandler.Release()
 	}
 	if pc.onConnectionStateChangeHandler != nil {
+		pc.underlying.Set("onconnectionstatechange", js.Null())
 		pc.onConnectionStateChangeHandler.Release()
 	}
 	if pc.onICEConnectionStateChangeHandler != nil {
+		pc.underlying.Set("oniceconnectionstatechange", js.Null())
 		pc.onICEConnectionStateChangeHandler.Release()
 	}
 	if pc.onICECandidateHandler != nil {
+		pc.underlying.Set("onicecandidate", js.Null())
 		pc.onICECandidateHandler.Release()
 	}
 	if pc.onICEGatheringStateChangeHandler != nil {
+		pc.underlying.Set("onicegatheringstatechange", js.Null())
 		pc.onICEGatheringStateChangeHandler.Release()
 	}
 

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -402,13 +402,11 @@ func (pc *PeerConnection) Close() (err error) {
 
 	// Release any handlers as required by the syscall/js API.
 	// Null out each JS property before Release() to prevent "call to released
-	// function": close() queues browser events (e.g. iceconnectionstatechange)
-	// that fire asynchronously; if Release() runs first, those callbacks call a
-	// Go FuncOf that is no longer in funcs[].
-	if pc.onSignalingStateChangeHandler != nil {
-		pc.underlying.Set("onsignalingstatechange", js.Null())
-		pc.onSignalingStateChangeHandler.Release()
-	}
+	// function" panics.
+	//
+	// Keep terminal state handlers installed here because close() transitions
+	// happen asynchronously and applications may still expect final state-change
+	// notifications after Close() returns.
 	if pc.onDataChannelHandler != nil {
 		pc.underlying.Set("ondatachannel", js.Null())
 		pc.onDataChannelHandler.Release()
@@ -416,14 +414,6 @@ func (pc *PeerConnection) Close() (err error) {
 	if pc.onNegotiationNeededHandler != nil {
 		pc.underlying.Set("onnegotiationneeded", js.Null())
 		pc.onNegotiationNeededHandler.Release()
-	}
-	if pc.onConnectionStateChangeHandler != nil {
-		pc.underlying.Set("onconnectionstatechange", js.Null())
-		pc.onConnectionStateChangeHandler.Release()
-	}
-	if pc.onICEConnectionStateChangeHandler != nil {
-		pc.underlying.Set("oniceconnectionstatechange", js.Null())
-		pc.onICEConnectionStateChangeHandler.Release()
 	}
 	if pc.onICECandidateHandler != nil {
 		pc.underlying.Set("onicecandidate", js.Null())


### PR DESCRIPTION
I ran into a frustrating bug when using pion/webrtc in a WASM app:
after closing a peer connection, every subsequent operation would
blow up with syscall/js: call to released function in the browser
console. Took a while to track down.