### PR TITLE
fix: default audio channels to 1 when not specified in SDP

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,12 @@
+fix: default audio channels to 1 when not specified in SDP
+
+RFC 4556 Section 6 states that for audio streams, the encoding
+parameters indicate the number of channels, and this parameter
+is OPTIONAL and may be omitted if the number of channels is one.
+
+Previously, codecsFromMediaDescription defaulted channels to 0
+when not specified. This caused codec matching issues after PR #3021
+added channel count verification, breaking G722 and other audio
+codecs that omit the channel count from their rtpmap line.
+
+Fixes #3127

--- a/sdp.go
+++ b/sdp.go
@@ -1124,6 +1124,13 @@ func codecsFromMediaDescription(mediaDescr *sdp.MediaDescription) (out []RTPCode
 			channels = uint16(val)
 		}
 
+		// RFC 4556 Section 6: For audio streams, the encoding parameters
+		// indicate the number of channels. This parameter is OPTIONAL and
+		// may be omitted if the number of channels is one.
+		if channels == 0 && strings.EqualFold(mediaDescr.MediaName.Media, "audio") {
+			channels = 1
+		}
+
 		feedback := []RTCPFeedback{}
 		for _, raw := range codec.RTCPFeedback {
 			split := strings.Split(raw, " ")

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -1426,6 +1426,23 @@ func TestCodecsFromMediaDescription(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	})
+
+	t.Run("Audio codec without channel count defaults to 1", func(t *testing.T) {
+		codecs, err := codecsFromMediaDescription(&sdp.MediaDescription{
+			MediaName: sdp.MediaName{
+				Media:   "audio",
+				Formats: []string{"9"},
+			},
+			Attributes: []sdp.Attribute{
+				{Key: "rtpmap", Value: "9 G722/8000"},
+			},
+		})
+
+		assert.NoError(t, err)
+		require.Len(t, codecs, 1)
+		assert.Equal(t, uint16(1), codecs[0].Channels)
+		assert.Equal(t, MimeTypeG722, codecs[0].MimeType)
+	})
 }
 
 func TestRtpExtensionsFromMediaDescription(t *testing.T) {


### PR DESCRIPTION
## Problem

When an SDP  line omits the channel count (e.g., ), the  function defaults  to . Per RFC 4556 Section 6:

> For audio streams, \<encoding parameters\> indicates the number of audio channels. This parameter is OPTIONAL and may be omitted if the number of channels is one.

This means the default should be  for audio, not .

## Impact

After PR #3021 added channel count verification to codec matching, this causes G722 (and potentially other audio codecs that omit the channel count) to fail matching when the remote SDP uses a different payload type (e.g., Chrome's dynamic PT 9 for G722).

While  in  has a workaround that defaults 0 to 1 during comparison, the stored codec value is still incorrect and could affect other code paths that use  directly (e.g., stats reporting, interceptor configuration).

## Fix

In , after parsing the encoding parameters, default  to  for audio media types when the value is . This aligns the parsed value with the RFC specification.

Also adds a test case verifying G722 with no explicit channel count gets .

Fixes #3127