### PR TITLE
rm redundant lock

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -467,8 +467,6 @@ func (d *DataChannel) SendText(s string) error {
 }
 
 func (d *DataChannel) ensureOpen() error {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 	if d.ReadyState() != DataChannelStateOpen {
 		return io.ErrClosedPipe
 	}


### PR DESCRIPTION
rm redundant lock

#### Description

The d.ReadyState uses atomic, so the RLock is not necessary.

#### Reference issue
None