### PR TITLE
Optimize SampleBuilder and reset cross-sample state on Flush

### DIFF
--- a/pkg/media/samplebuilder/samplebuilder.go
+++ b/pkg/media/samplebuilder/samplebuilder.go
@@ -318,9 +318,16 @@ func (s *SampleBuilder) buildSample(purgingBuffers bool) *media.Sample {
 	}
 	samples := afterTimestamp - sampleTimestamp
 
+	var duration time.Duration
+	if s.sampleRate == 0 {
+		duration = 0
+	} else {
+		duration = time.Duration(samples) * time.Second / time.Duration(s.sampleRate)
+	}
+
 	sample := &media.Sample{
 		Data:               data,
-		Duration:           time.Duration(samples) * time.Second / time.Duration(s.sampleRate),
+		Duration:           duration,
 		PacketTimestamp:    sampleTimestamp,
 		PrevDroppedPackets: s.droppedPackets,
 		Metadata:           metadata,

--- a/pkg/media/samplebuilder/samplebuilder.go
+++ b/pkg/media/samplebuilder/samplebuilder.go
@@ -38,7 +38,8 @@ type SampleBuilder struct {
 	// prepared contains the samples that have been processed to date
 	prepared sampleSequenceLocation
 
-	lastSampleTimestamp *uint32
+	lastSampleTimestamp    uint32
+	hasLastSampleTimestamp bool
 
 	// number of packets forced to be dropped
 	droppedPackets uint16
@@ -199,12 +200,17 @@ func (s *SampleBuilder) Push(packet *rtp.Packet) {
 	s.purgeBuffers(false)
 }
 
-// Flush marks all samples in the buffer to be popped.
+// Flush marks all samples in the buffer to be popped and resets cross-sample
+// state so a subsequent RTP stream is not affected by packets processed before
+// the flush.
 func (s *SampleBuilder) Flush() {
 	s.purgeBuffers(true)
-}
 
-const secondToNanoseconds = 1000000000
+	s.hasLastSampleTimestamp = false
+	s.lastSampleTimestamp = 0
+	s.droppedPackets = 0
+	s.paddingPackets = 0
+}
 
 // buildSample creates a sample from a valid collection of RTP Packets by
 // walking forwards building a sample if everything looks good clear and
@@ -273,7 +279,7 @@ func (s *SampleBuilder) buildSample(purgingBuffers bool) *media.Sample {
 	if !s.depacketizer.IsPartitionHead(s.buffer[consume.head].Payload) {
 		isPadding := false
 		for i := consume.head; i != consume.tail; i++ {
-			if s.lastSampleTimestamp != nil && *s.lastSampleTimestamp == s.buffer[i].Timestamp && len(s.buffer[i].Payload) == 0 {
+			if s.hasLastSampleTimestamp && s.lastSampleTimestamp == s.buffer[i].Timestamp && len(s.buffer[i].Payload) == 0 {
 				isPadding = true
 			}
 		}
@@ -288,7 +294,11 @@ func (s *SampleBuilder) buildSample(purgingBuffers bool) *media.Sample {
 	}
 
 	// merge all the buffers into a sample
-	data := []byte{}
+	var dataLen int
+	for i := consume.head; i != consume.tail; i++ {
+		dataLen += len(s.buffer[i].Payload)
+	}
+	data := make([]byte, 0, dataLen)
 	var metadata any
 	var rtpHeaders []*rtp.Header
 	for i := consume.head; i != consume.tail; i++ {
@@ -310,7 +320,7 @@ func (s *SampleBuilder) buildSample(purgingBuffers bool) *media.Sample {
 
 	sample := &media.Sample{
 		Data:               data,
-		Duration:           time.Duration((float64(samples)/float64(s.sampleRate))*secondToNanoseconds) * time.Nanosecond,
+		Duration:           time.Duration(samples) * time.Second / time.Duration(s.sampleRate),
 		PacketTimestamp:    sampleTimestamp,
 		PrevDroppedPackets: s.droppedPackets,
 		Metadata:           metadata,
@@ -319,8 +329,8 @@ func (s *SampleBuilder) buildSample(purgingBuffers bool) *media.Sample {
 
 	s.droppedPackets = 0
 	s.paddingPackets = 0
-	s.lastSampleTimestamp = new(uint32)
-	*s.lastSampleTimestamp = sampleTimestamp
+	s.lastSampleTimestamp = sampleTimestamp
+	s.hasLastSampleTimestamp = true
 
 	s.preparedSamples[s.prepared.tail] = sample
 	s.prepared.tail++

--- a/pkg/media/samplebuilder/samplebuilder_test.go
+++ b/pkg/media/samplebuilder/samplebuilder_test.go
@@ -826,6 +826,11 @@ func BenchmarkSampleBuilderFragmented(b *testing.B) {
 	}
 }
 
+func TestNewZeroSampleRate(t *testing.T) {
+	sb := New(50, &fakeDepacketizer{}, 0)
+	assert.NotNil(t, sb)
+}
+
 func BenchmarkSampleBuilderFragmentedLoss(b *testing.B) {
 	fd := New(100, &fakeDepacketizer{}, 1)
 	b.ResetTimer()

--- a/pkg/media/samplebuilder/samplebuilder_test.go
+++ b/pkg/media/samplebuilder/samplebuilder_test.go
@@ -666,7 +666,7 @@ func TestSampleBuilder_FlushResetsState(t *testing.T) {
 	})
 
 	samples := []*media.Sample{}
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		if sample := fd.Pop(); sample != nil {
 			samples = append(samples, sample)
 		}

--- a/pkg/media/samplebuilder/samplebuilder_test.go
+++ b/pkg/media/samplebuilder/samplebuilder_test.go
@@ -620,6 +620,105 @@ func TestSampleBuilder_Flush(t *testing.T) {
 	assert.Equal(t, expected, samples)
 }
 
+func TestSampleBuilder_FlushResetsState(t *testing.T) {
+	assert := assert.New(t)
+	fd := New(50, &fakeDepacketizer{
+		headChecker: true,
+		headBytes:   []byte{0x01},
+	}, 1)
+
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5000, Timestamp: 1}, Payload: []byte{0x01},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5001, Timestamp: 1}, Payload: []byte{0x02},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5002, Timestamp: 1, Marker: true}, Payload: []byte{0x03},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5003, Timestamp: 1}, Payload: []byte{},
+	})
+
+	first := fd.Pop()
+	assert.NotNil(first, "precondition: first sample should be built")
+	assert.Equal([]byte{0x01, 0x02, 0x03}, first.Data)
+	assert.Equal(uint32(1), first.PacketTimestamp)
+
+	fd.Flush()
+
+	// After Flush, lastSampleTimestamp is cleared so empty packets matching the
+	// pre-flush timestamp are not treated as late padding from the old stream.
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5004, Timestamp: 1}, Payload: []byte{},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5005, Timestamp: 1}, Payload: []byte{},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5006, Timestamp: 3}, Payload: []byte{0x01},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5007, Timestamp: 3, Marker: true}, Payload: []byte{0x04},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5008, Timestamp: 4}, Payload: []byte{0x01},
+	})
+
+	samples := []*media.Sample{}
+	for i := 0; i < 5; i++ {
+		if sample := fd.Pop(); sample != nil {
+			samples = append(samples, sample)
+		}
+	}
+
+	assert.Equal([]*media.Sample{
+		{Data: []byte{0x01, 0x04}, Duration: time.Second, PacketTimestamp: 3, PrevDroppedPackets: 2},
+	}, samples)
+}
+
+func TestSampleBuilder_ValidSampleSameTimestampAfterFlush(t *testing.T) {
+	assert := assert.New(t)
+	fd := New(50, &fakeDepacketizer{
+		headChecker: true,
+		headBytes:   []byte{0x01},
+	}, 1)
+
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5000, Timestamp: 100}, Payload: []byte{0x01},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5001, Timestamp: 100, Marker: true}, Payload: []byte{0x02},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 5002, Timestamp: 100}, Payload: []byte{},
+	})
+
+	first := fd.Pop()
+	assert.NotNil(first, "precondition: first sample should be built")
+	assert.Equal([]byte{0x01, 0x02}, first.Data)
+	assert.Equal(uint32(100), first.PacketTimestamp)
+
+	fd.Flush()
+
+	// Valid partition head at the same timestamp must not be misclassified as padding.
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 6000, Timestamp: 100}, Payload: []byte{0x01},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 6001, Timestamp: 100, Marker: true}, Payload: []byte{0x02},
+	})
+	fd.Push(&rtp.Packet{
+		Header: rtp.Header{SequenceNumber: 6002, Timestamp: 100}, Payload: []byte{},
+	})
+
+	sample := fd.Pop()
+	assert.NotNil(sample, "valid frame must not be misclassified as padding after flush")
+	assert.Equal([]byte{0x01, 0x02}, sample.Data)
+	assert.Equal(uint32(100), sample.PacketTimestamp)
+	assert.Nil(fd.Pop(), "no extra samples should be emitted")
+}
+
 func BenchmarkSampleBuilderSequential(b *testing.B) {
 	fd := New(100, &fakeDepacketizer{}, 1)
 	b.ResetTimer()


### PR DESCRIPTION
#### Description
Improve SampleBuilder performance and make Flush() a clean boundary for a new RTP stream.
Performance:
- Replace lastSampleTimestamp *uint32 with uint32 + hasLastSampleTimestamp to avoid a heap allocation on every emitted sample
- Pre-size sample payload buffers from the total RTP payload length
- Compute Sample.Duration with integer arithmetic instead of float64 Flush semantics:
- After purging buffered packets, Flush() now clears lastSampleTimestamp, droppedPackets, and paddingPackets
- Prevents post-flush packets from being misclassified as padding from a prior stream when timestamps collide
- Prevents PrevDroppedPackets on the next sample from including drops that occurred during the flush of leftover buffer data Samples built during Flush() still capture PrevDroppedPackets at build time; only state for packets received after Flush() is reset. Tests:
- Add TestSampleBuilder_FlushResetsState
- Add TestSampleBuilder_ValidSampleSameTimestampAfterFlush

#### Reference issue
None
