### PR TITLE
Fix bundle-only data channel startup

### DIFF
--- a/datachannel_go_test.go
+++ b/datachannel_go_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDataChannel_EventHandlers(t *testing.T) {
@@ -531,6 +532,53 @@ func TestEOF(t *testing.T) { //nolint:cyclop
 		<-dcaClosedCh // (1)
 		<-dcbClosedCh // (2)
 	})
+}
+
+func TestDataChannel_BundleOnlyPortZero(t *testing.T) {
+	offerPC, err := NewPeerConnection(Configuration{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, offerPC.Close()) }()
+
+	answerPC, err := NewPeerConnection(Configuration{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, answerPC.Close()) }()
+
+	_, err = offerPC.AddTransceiverFromKind(RTPCodecTypeAudio)
+	require.NoError(t, err)
+
+	dataChannel, err := offerPC.CreateDataChannel(expectedLabel, nil)
+	require.NoError(t, err)
+	answerPC.OnDataChannel(func(*DataChannel) {})
+
+	offer, err := offerPC.CreateOffer(nil)
+	require.NoError(t, err)
+	offerGatheringComplete := GatheringCompletePromise(offerPC)
+	require.NoError(t, offerPC.SetLocalDescription(offer))
+	<-offerGatheringComplete
+
+	const applicationMLine = "m=application 9 UDP/DTLS/SCTP webrtc-datachannel"
+	require.Contains(t, offerPC.LocalDescription().SDP, applicationMLine)
+	bundleOnlyOfferSDP := strings.Replace(
+		offerPC.LocalDescription().SDP,
+		applicationMLine,
+		"m=application 0 UDP/DTLS/SCTP webrtc-datachannel\r\na=bundle-only",
+		1,
+	)
+	require.NoError(t, answerPC.SetRemoteDescription(SessionDescription{
+		Type: SDPTypeOffer,
+		SDP:  bundleOnlyOfferSDP,
+	}))
+
+	answer, err := answerPC.CreateAnswer(nil)
+	require.NoError(t, err)
+	answerGatheringComplete := GatheringCompletePromise(answerPC)
+	require.NoError(t, answerPC.SetLocalDescription(answer))
+	<-answerGatheringComplete
+	require.NoError(t, offerPC.SetRemoteDescription(*answerPC.LocalDescription()))
+
+	require.Eventually(t, func() bool {
+		return dataChannel.ReadyState() == DataChannelStateOpen
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 // Assert that a Session Description that doesn't follow

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // expectedLabel represents the label of the data channel we are trying to test.
@@ -275,6 +276,53 @@ func TestDataChannel_Open(t *testing.T) {
 		assert.Len(t, answerOpenCalls, 1)
 		assert.Len(t, offerOpenCalls, 1)
 	})
+}
+
+func TestDataChannel_BundleOnlyPortZero(t *testing.T) {
+	offerPC, err := NewPeerConnection(Configuration{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, offerPC.Close()) }()
+
+	answerPC, err := NewPeerConnection(Configuration{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, answerPC.Close()) }()
+
+	_, err = offerPC.AddTransceiverFromKind(RTPCodecTypeAudio)
+	require.NoError(t, err)
+
+	dataChannel, err := offerPC.CreateDataChannel(expectedLabel, nil)
+	require.NoError(t, err)
+	answerPC.OnDataChannel(func(*DataChannel) {})
+
+	offer, err := offerPC.CreateOffer(nil)
+	require.NoError(t, err)
+	offerGatheringComplete := GatheringCompletePromise(offerPC)
+	require.NoError(t, offerPC.SetLocalDescription(offer))
+	<-offerGatheringComplete
+
+	const applicationMLine = "m=application 9 UDP/DTLS/SCTP webrtc-datachannel"
+	require.Contains(t, offerPC.LocalDescription().SDP, applicationMLine)
+	bundleOnlyOfferSDP := strings.Replace(
+		offerPC.LocalDescription().SDP,
+		applicationMLine,
+		"m=application 0 UDP/DTLS/SCTP webrtc-datachannel\r\na=bundle-only",
+		1,
+	)
+	require.NoError(t, answerPC.SetRemoteDescription(SessionDescription{
+		Type: SDPTypeOffer,
+		SDP:  bundleOnlyOfferSDP,
+	}))
+
+	answer, err := answerPC.CreateAnswer(nil)
+	require.NoError(t, err)
+	answerGatheringComplete := GatheringCompletePromise(answerPC)
+	require.NoError(t, answerPC.SetLocalDescription(answer))
+	<-answerGatheringComplete
+	require.NoError(t, offerPC.SetRemoteDescription(*answerPC.LocalDescription()))
+
+	require.Eventually(t, func() bool {
+		return dataChannel.ReadyState() == DataChannelStateOpen
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestDataChannel_Send(t *testing.T) { //nolint:cyclop

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // expectedLabel represents the label of the data channel we are trying to test.
@@ -276,53 +275,6 @@ func TestDataChannel_Open(t *testing.T) {
 		assert.Len(t, answerOpenCalls, 1)
 		assert.Len(t, offerOpenCalls, 1)
 	})
-}
-
-func TestDataChannel_BundleOnlyPortZero(t *testing.T) {
-	offerPC, err := NewPeerConnection(Configuration{})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, offerPC.Close()) }()
-
-	answerPC, err := NewPeerConnection(Configuration{})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, answerPC.Close()) }()
-
-	_, err = offerPC.AddTransceiverFromKind(RTPCodecTypeAudio)
-	require.NoError(t, err)
-
-	dataChannel, err := offerPC.CreateDataChannel(expectedLabel, nil)
-	require.NoError(t, err)
-	answerPC.OnDataChannel(func(*DataChannel) {})
-
-	offer, err := offerPC.CreateOffer(nil)
-	require.NoError(t, err)
-	offerGatheringComplete := GatheringCompletePromise(offerPC)
-	require.NoError(t, offerPC.SetLocalDescription(offer))
-	<-offerGatheringComplete
-
-	const applicationMLine = "m=application 9 UDP/DTLS/SCTP webrtc-datachannel"
-	require.Contains(t, offerPC.LocalDescription().SDP, applicationMLine)
-	bundleOnlyOfferSDP := strings.Replace(
-		offerPC.LocalDescription().SDP,
-		applicationMLine,
-		"m=application 0 UDP/DTLS/SCTP webrtc-datachannel\r\na=bundle-only",
-		1,
-	)
-	require.NoError(t, answerPC.SetRemoteDescription(SessionDescription{
-		Type: SDPTypeOffer,
-		SDP:  bundleOnlyOfferSDP,
-	}))
-
-	answer, err := answerPC.CreateAnswer(nil)
-	require.NoError(t, err)
-	answerGatheringComplete := GatheringCompletePromise(answerPC)
-	require.NoError(t, answerPC.SetLocalDescription(answer))
-	<-answerGatheringComplete
-	require.NoError(t, offerPC.SetRemoteDescription(*answerPC.LocalDescription()))
-
-	require.Eventually(t, func() bool {
-		return dataChannel.ReadyState() == DataChannelStateOpen
-	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestDataChannel_Send(t *testing.T) { //nolint:cyclop

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2841,9 +2841,12 @@ func (pc *PeerConnection) startRTP(
 	}
 
 	pc.startRTPReceivers(remoteDesc, currentTransceivers)
-	if d := haveDataChannel(remoteDesc); d != nil && d.MediaName.Port.Value != 0 {
-		remoteSctpInit, _ := getSctpInit(d)
-		pc.startSCTP(getMaxMessageSize(d), remoteSctpInit)
+	if d := haveDataChannel(remoteDesc); d != nil {
+		// RFC 8843 Section 6 permits bundle-only media sections to use port zero.
+		if _, bundleOnly := d.Attribute("bundle-only"); d.MediaName.Port.Value != 0 || bundleOnly {
+			remoteSctpInit, _ := getSctpInit(d)
+			pc.startSCTP(getMaxMessageSize(d), remoteSctpInit)
+		}
 	}
 }
 


### PR DESCRIPTION
Pion currently treats every zero-port application `m=` section as rejected. This violates [RFC 8843, Section 6](https://www.rfc-editor.org/rfc/rfc8843.html#section-6), which permits a bundled `m=` section to use port zero with `a=bundle-only`.

Start SCTP when the application section has either a nonzero port or `a=bundle-only`. Zero-port sections without `a=bundle-only` remain rejected.
