### PR TITLE
Expose ICE use-candidate priority setting

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -244,7 +244,7 @@ func (g *ICEGatherer) sanitizedMDNSMode() ice.MulticastDNSMode {
 }
 
 func (g *ICEGatherer) baseAgentOptions(mDNSMode ice.MulticastDNSMode) []ice.AgentOption {
-	return []ice.AgentOption{
+	options := []ice.AgentOption{
 		ice.WithICELite(g.api.settingEngine.candidates.ICELite),
 		ice.WithUrls(g.validatedServers),
 		ice.WithPortRange(g.api.settingEngine.ephemeralUDP.PortMin, g.api.settingEngine.ephemeralUDP.PortMax),
@@ -259,6 +259,12 @@ func (g *ICEGatherer) baseAgentOptions(mDNSMode ice.MulticastDNSMode) []ice.Agen
 		ice.WithProxyDialer(g.api.settingEngine.iceProxyDialer),
 		ice.WithBindingRequestHandler(g.api.settingEngine.iceBindingRequestHandler),
 	}
+
+	if g.api.settingEngine.iceUseCandidateCheckPriority {
+		options = append(options, ice.WithEnableUseCandidateCheckPriority())
+	}
+
+	return options
 }
 
 func (g *ICEGatherer) credentialOptions() []ice.AgentOption {

--- a/icegatherer.go
+++ b/icegatherer.go
@@ -244,7 +244,7 @@ func (g *ICEGatherer) sanitizedMDNSMode() ice.MulticastDNSMode {
 }
 
 func (g *ICEGatherer) baseAgentOptions(mDNSMode ice.MulticastDNSMode) []ice.AgentOption {
-	options := []ice.AgentOption{
+	return []ice.AgentOption{
 		ice.WithICELite(g.api.settingEngine.candidates.ICELite),
 		ice.WithUrls(g.validatedServers),
 		ice.WithPortRange(g.api.settingEngine.ephemeralUDP.PortMin, g.api.settingEngine.ephemeralUDP.PortMax),
@@ -259,12 +259,6 @@ func (g *ICEGatherer) baseAgentOptions(mDNSMode ice.MulticastDNSMode) []ice.Agen
 		ice.WithProxyDialer(g.api.settingEngine.iceProxyDialer),
 		ice.WithBindingRequestHandler(g.api.settingEngine.iceBindingRequestHandler),
 	}
-
-	if g.api.settingEngine.iceUseCandidateCheckPriority {
-		options = append(options, ice.WithEnableUseCandidateCheckPriority())
-	}
-
-	return options
 }
 
 func (g *ICEGatherer) credentialOptions() []ice.AgentOption {
@@ -336,7 +330,7 @@ func (g *ICEGatherer) timeoutOptions() []ice.AgentOption {
 }
 
 func (g *ICEGatherer) miscOptions() []ice.AgentOption {
-	opts := make([]ice.AgentOption, 0, 4)
+	opts := make([]ice.AgentOption, 0, 5)
 
 	if g.api.settingEngine.candidates.MulticastDNSHostName != "" {
 		opts = append(opts, ice.WithMulticastDNSHostName(g.api.settingEngine.candidates.MulticastDNSHostName))
@@ -352,6 +346,10 @@ func (g *ICEGatherer) miscOptions() []ice.AgentOption {
 
 	if g.api.settingEngine.iceMaxBindingRequests != nil {
 		opts = append(opts, ice.WithMaxBindingRequests(*g.api.settingEngine.iceMaxBindingRequests))
+	}
+
+	if g.api.settingEngine.iceUseCandidateCheckPriority {
+		opts = append(opts, ice.WithEnableUseCandidateCheckPriority())
 	}
 
 	return opts

--- a/icegatherer_test.go
+++ b/icegatherer_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1642,6 +1643,25 @@ func TestICEGatherer_DisableActiveTCP(t *testing.T) { //nolint:cyclop
 			}
 		})
 	}
+}
+
+func TestICEGatherer_UseCandidateCheckPriority(t *testing.T) {
+	se := SettingEngine{}
+	se.SetICEUseCandidateCheckPriority(true)
+
+	gatherer, err := NewAPI(WithSettingEngine(se)).NewICEGatherer(ICEGatherOptions{})
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, gatherer.Close())
+	}()
+
+	require.NoError(t, gatherer.createAgent())
+	agent := gatherer.getAgent()
+	require.NotNil(t, agent)
+
+	enabled := reflect.ValueOf(agent).Elem().FieldByName("enableUseCandidateCheckPriority")
+	require.True(t, enabled.IsValid())
+	assert.True(t, enabled.Bool())
 }
 
 func TestICEGatherer_HostAcceptanceMinWait(t *testing.T) {

--- a/settingengine.go
+++ b/settingengine.go
@@ -106,6 +106,7 @@ type SettingEngine struct {
 	iceUDPMux                                 ice.UDPMux
 	iceProxyDialer                            proxy.Dialer
 	iceDisableActiveTCP                       bool
+	iceUseCandidateCheckPriority              bool
 	iceBindingRequestHandler                  func(m *stun.Message, local, remote ice.Candidate, pair *ice.CandidatePair) bool //nolint:lll
 	disableMediaEngineCopy                    bool
 	disableMediaEngineMultipleCodecs          bool
@@ -506,6 +507,12 @@ func (e *SettingEngine) SetICEProxyDialer(d proxy.Dialer) {
 // that can be sent on a candidate before it is considered invalid.
 func (e *SettingEngine) SetICEMaxBindingRequests(d uint16) {
 	e.iceMaxBindingRequests = &d
+}
+
+// SetICEUseCandidateCheckPriority enables checking pair priority before switching
+// selected candidate pair when an ICE Lite agent receives USE-CANDIDATE.
+func (e *SettingEngine) SetICEUseCandidateCheckPriority(enabled bool) {
+	e.iceUseCandidateCheckPriority = enabled
 }
 
 // DisableActiveTCP disables using active TCP for ICE. Active TCP is enabled by default.

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -398,6 +398,17 @@ func TestSetSCTPRTOMax(t *testing.T) {
 	assert.Equal(t, expSize, s.sctp.rtoMax)
 }
 
+func TestSetICEUseCandidateCheckPriority(t *testing.T) {
+	settingEngine := SettingEngine{}
+	assert.False(t, settingEngine.iceUseCandidateCheckPriority)
+
+	settingEngine.SetICEUseCandidateCheckPriority(true)
+	assert.True(t, settingEngine.iceUseCandidateCheckPriority)
+
+	settingEngine.SetICEUseCandidateCheckPriority(false)
+	assert.False(t, settingEngine.iceUseCandidateCheckPriority)
+}
+
 func TestSetICEBindingRequestHandler(t *testing.T) {
 	seenICEControlled, seenICEControlledCancel := context.WithCancel(context.Background())
 	seenICEControlling, seenICEControllingCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
#### Description

Expose `SettingEngine.SetICEUseCandidateCheckPriority` so applications can enable ICE use-candidate check priority handling in the underlying ICE agent.

For ICE Lite deployments, enforcing candidate-pair priorities before honoring `USE-CANDIDATE` allows applications to work around Firefox selecting a lower-priority pair: https://bugzilla.mozilla.org/show_bug.cgi?id=1034964

#### Reference issue

N/A - external Firefox Bugzilla issue above.