### PR TITLE
Add ICE UDPMuxSrflx option

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -256,6 +256,7 @@ func (g *ICEGatherer) baseAgentOptions(mDNSMode ice.MulticastDNSMode) []ice.Agen
 		ice.WithMulticastDNSMode(mDNSMode),
 		ice.WithTCPMux(g.api.settingEngine.iceTCPMux),
 		ice.WithUDPMux(g.api.settingEngine.iceUDPMux),
+		ice.WithUDPMuxSrflx(g.api.settingEngine.iceUDPMuxSrflx),
 		ice.WithProxyDialer(g.api.settingEngine.iceProxyDialer),
 		ice.WithBindingRequestHandler(g.api.settingEngine.iceBindingRequestHandler),
 	}

--- a/icemux.go
+++ b/icemux.go
@@ -5,6 +5,7 @@ package webrtc
 
 import (
 	"net"
+	"time"
 
 	"github.com/pion/ice/v4"
 	"github.com/pion/logging"
@@ -26,5 +27,24 @@ func NewICEUDPMux(logger logging.LeveledLogger, udpConn net.PacketConn) ice.UDPM
 	return ice.NewUDPMuxDefault(ice.UDPMuxParams{
 		UDPConn: udpConn,
 		Logger:  logger,
+	})
+}
+
+// NewICEUniversalUDPMux creates a new instance of ice.UniversalUDPMux. It allows many PeerConnections
+// with host, server reflexive and relayed candidates to be served by a single UDP port. Pass the
+// returned mux to both SettingEngine.SetICEUDPMux and SettingEngine.SetICEUDPMuxSrflx to also
+// multiplex the STUN traffic used for server reflexive candidate gathering.
+//
+// xorMappedAddrCacheTTL controls how long a discovered server reflexive (XOR-mapped) address is
+// cached before another STUN binding request is issued.
+func NewICEUniversalUDPMux(
+	logger logging.LeveledLogger,
+	udpConn net.PacketConn,
+	xorMappedAddrCacheTTL time.Duration,
+) ice.UniversalUDPMux {
+	return ice.NewUniversalUDPMuxDefault(ice.UniversalUDPMuxParams{
+		Logger:                logger,
+		UDPConn:               udpConn,
+		XORMappedAddrCacheTTL: xorMappedAddrCacheTTL,
 	})
 }

--- a/icemux_test.go
+++ b/icemux_test.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package webrtc
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/ice/v4"
+	"github.com/pion/transport/v4/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewICEUniversalUDPMux(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	assert.NoError(t, err)
+
+	udpMux := NewICEUniversalUDPMux(nil, udpConn, 30*time.Second)
+	assert.NotNil(t, udpMux)
+
+	// The universal mux embeds ice.UDPMuxDefault, so it also satisfies the plain
+	// ice.UDPMux interface. This allows a single mux to be passed to both
+	// SetICEUDPMux and SetICEUDPMuxSrflx.
+	var _ ice.UDPMux = udpMux
+
+	settingEngine := SettingEngine{}
+	settingEngine.SetICEUDPMux(udpMux)
+	settingEngine.SetICEUDPMuxSrflx(udpMux)
+	assert.Equal(t, ice.UDPMux(udpMux), settingEngine.iceUDPMux)
+	assert.Equal(t, udpMux, settingEngine.iceUDPMuxSrflx)
+
+	assert.NoError(t, udpMux.Close())
+}

--- a/settingengine.go
+++ b/settingengine.go
@@ -104,6 +104,7 @@ type SettingEngine struct {
 	LoggerFactory                             logging.LoggerFactory
 	iceTCPMux                                 ice.TCPMux
 	iceUDPMux                                 ice.UDPMux
+	iceUDPMuxSrflx                            ice.UniversalUDPMux
 	iceProxyDialer                            proxy.Dialer
 	iceDisableActiveTCP                       bool
 	iceUseCandidateCheckPriority              bool
@@ -496,6 +497,15 @@ func (e *SettingEngine) SetICETCPMux(tcpMux ice.TCPMux) {
 // UDPMux should be started prior to creating PeerConnections.
 func (e *SettingEngine) SetICEUDPMux(udpMux ice.UDPMux) {
 	e.iceUDPMux = udpMux
+}
+
+// SetICEUDPMuxSrflx allows ICE traffic from server reflexive candidates to be
+// multiplexed onto a single UDP port. This enables STUN binding requests, used
+// to gather server reflexive candidates, to share the same port as host
+// candidates instead of allocating an additional port per PeerConnection.
+// The mux should be started prior to creating PeerConnections.
+func (e *SettingEngine) SetICEUDPMuxSrflx(udpMuxSrflx ice.UniversalUDPMux) {
+	e.iceUDPMuxSrflx = udpMuxSrflx
 }
 
 // SetICEProxyDialer sets the proxy dialer interface based on golang.org/x/net/proxy.

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -272,6 +272,25 @@ func TestSettingEngine_SetICETCP(t *testing.T) {
 	assert.Equal(t, tcpMux, settingEngine.iceTCPMux)
 }
 
+func TestSettingEngine_SetICEUDPMuxSrflx(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	assert.NoError(t, err)
+
+	udpMux := NewICEUniversalUDPMux(nil, udpConn, 0)
+
+	defer func() {
+		_ = udpMux.Close()
+	}()
+
+	settingEngine := SettingEngine{}
+	settingEngine.SetICEUDPMuxSrflx(udpMux)
+
+	assert.Equal(t, udpMux, settingEngine.iceUDPMuxSrflx)
+}
+
 func TestSettingEngine_SetDisableMediaEngineCopy(t *testing.T) {
 	t.Run("Copy", func(t *testing.T) {
 		mediaEngine := &MediaEngine{}


### PR DESCRIPTION
Expose pion/ice's server reflexive UDP mux (UniversalUDPMux) through the SettingEngine so that STUN binding requests for server reflexive candidates can share a single UDP port instead of allocating an extra port per PeerConnection.

This revives #2298, addressing the commit message and test coverage feedback left on that PR.

### Description
This PR exposes pion/ice's existing server reflexive UDP mux (`ice.UniversalUDPMux`) through the `SettingEngine`. This lets STUN binding requests used to gather server reflexive candidates be multiplexed onto the same UDP port as host candidates, rather than allocating an additional port per `PeerConnection`.

`pion/ice` already supports this via `WithUDPMuxSrflx`; `pion/webrtc` just didn't expose it. This is useful for deployments that need a small, fixed number of UDP ports (restrictive NAT/firewall environments).

#### Changes

- `SettingEngine.SetICEUDPMuxSrflx(ice.UniversalUDPMux)`: sets the mux used for server reflexive candidates.
- `NewICEUniversalUDPMux(logger, udpConn, xorMappedAddrCacheTTL)`: constructs an `ice.UniversalUDPMux` (host + srflx + relay over one port). Since `*ice.UniversalUDPMuxDefault` also implements `ice.UDPMux`, the same mux can be passed to both `SetICEUDPMux` and `SetICEUDPMuxSrflx`.
- Wires the mux into the ICE agent via `ice.WithUDPMuxSrflx`.

#### Testing

- `TestSettingEngine_SetICEUDPMuxSrflx`: the setter stores the mux.
- `TestNewICEUniversalUDPMux`: the constructor returns a working mux that satisfies both `ice.UDPMux` and `ice.UniversalUDPMux`, and is accepted by both setters.

Both run under `test.CheckRoutines` and pass with `-race`.

#### Backward compatibility

This patch is purely additive, thus no existing API changes. When `SetICEUDPMuxSrflx` is not called, behavior is unchanged.
