### PR TITLE
Avoid unused RTX repair readers

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -66,10 +66,21 @@ type simulcastStreamPair struct {
 }
 
 type streamsForSSRCResult struct {
-	rtpReadStream   *srtp.ReadStreamSRTP
-	rtpInterceptor  interceptor.RTPReader
-	rtcpReadStream  *srtp.ReadStreamSRTCP
-	rtcpInterceptor interceptor.RTCPReader
+	rtpReadStream             *srtp.ReadStreamSRTP
+	rtpInterceptor            interceptor.RTPReader
+	startRTPReaderImmediately bool
+	rtcpReadStream            *srtp.ReadStreamSRTCP
+	rtcpInterceptor           interceptor.RTCPReader
+}
+
+type srtpRTPReader struct {
+	readStream *srtp.ReadStreamSRTP
+}
+
+func (r *srtpRTPReader) Read(in []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+	n, err := r.readStream.Read(in)
+
+	return n, a, err
 }
 
 // NewDTLSTransport creates a new DTLSTransport.
@@ -693,16 +704,8 @@ func (t *DTLSTransport) streamsForSSRC(
 		return nil, err
 	}
 
-	rtpInterceptor := t.api.interceptor.BindRemoteStream(
-		&streamInfo,
-		interceptor.RTPReaderFunc(
-			func(in []byte, a interceptor.Attributes) (n int, attributes interceptor.Attributes, err error) {
-				n, err = rtpReadStream.Read(in)
-
-				return n, a, err
-			},
-		),
-	)
+	rtpReader := &srtpRTPReader{readStream: rtpReadStream}
+	rtpInterceptor := t.api.interceptor.BindRemoteStream(&streamInfo, rtpReader)
 
 	srtcpSession, err := t.getSRTCPSession()
 	if err != nil {
@@ -723,9 +726,10 @@ func (t *DTLSTransport) streamsForSSRC(
 	)
 
 	return &streamsForSSRCResult{
-		rtpReadStream:   rtpReadStream,
-		rtpInterceptor:  rtpInterceptor,
-		rtcpReadStream:  rtcpReadStream,
-		rtcpInterceptor: rtcpInterceptor,
+		rtpReadStream:             rtpReadStream,
+		rtpInterceptor:            rtpInterceptor,
+		startRTPReaderImmediately: rtpInterceptor != rtpReader && t.api.settingEngine.BufferFactory == nil,
+		rtcpReadStream:            rtcpReadStream,
+		rtcpInterceptor:           rtcpInterceptor,
 	}, nil
 }

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1417,7 +1417,7 @@ func (pc *PeerConnection) startReceiver(incoming trackDetails, receiver *RTPRece
 		}
 		go func(track *TrackRemote) {
 			b := make([]byte, pc.api.settingEngine.getReceiveMTU())
-			n, _, err := track.peek(b)
+			n, err := track.peek(b)
 			if err != nil {
 				pc.log.Warnf("Could not determine PayloadType for SSRC %d (%s)", track.SSRC(), err)
 
@@ -1945,7 +1945,16 @@ func (pc *PeerConnection) handleIncomingSSRC(rtpStream *srtp.ReadStreamSRTP, ssr
 			}
 
 			if rsid != "" {
-				return receiver.receiveForRtx(SSRC(0), rsid, streamInfo, readStream, interceptor, rtcpReadStream, rtcpInterceptor)
+				return receiver.receiveForRtx(
+					SSRC(0),
+					rsid,
+					streamInfo,
+					readStream,
+					interceptor,
+					result.startRTPReaderImmediately,
+					rtcpReadStream,
+					rtcpInterceptor,
+				)
 			}
 
 			track, err := receiver.receiveForRid(
@@ -1954,6 +1963,7 @@ func (pc *PeerConnection) handleIncomingSSRC(rtpStream *srtp.ReadStreamSRTP, ssr
 				streamInfo,
 				readStream,
 				interceptor,
+				result.startRTPReaderImmediately,
 				rtcpReadStream,
 				rtcpInterceptor,
 				peekedPackets,

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -1967,6 +1967,189 @@ func (s *simulcastTestTrackLocal) WriteRTP(pkt *rtp.Packet) error {
 	return util.FlattenErrs(writeErrs)
 }
 
+func TestPeerConnection_RIDRepairReaderStartsForPrimaryWrapper(t *testing.T) { //nolint:cyclop
+	for _, primaryFirst := range []bool{true, false} {
+		name := "RTX first"
+		if primaryFirst {
+			name = "primary first"
+		}
+		t.Run(name, func(t *testing.T) {
+			lim := test.TimeOut(time.Second * 30)
+			defer lim.Stop()
+
+			report := test.CheckRoutines(t)
+			defer report()
+
+			mediaEngine := &MediaEngine{}
+			require.NoError(t, mediaEngine.RegisterDefaultCodecs())
+			require.NoError(t, ConfigureSimulcastExtensionHeaders(mediaEngine))
+			ir := &interceptor.Registry{}
+			require.NoError(t, ConfigureNack(mediaEngine, ir))
+			api := NewAPI(WithMediaEngine(mediaEngine), WithInterceptorRegistry(ir))
+			pcOffer, pcAnswer, err := api.newPair(Configuration{})
+			require.NoError(t, err)
+			defer closePairNow(t, pcOffer, pcAnswer)
+
+			const rid = "a"
+			primaryTrack, err := NewTrackLocalStaticRTP(
+				RTPCodecCapability{MimeType: MimeTypeVP8},
+				"video",
+				"pion",
+				WithRTPStreamID(rid),
+			)
+			require.NoError(t, err)
+			secondTrack, err := NewTrackLocalStaticRTP(
+				RTPCodecCapability{MimeType: MimeTypeVP8},
+				"video",
+				"pion",
+				WithRTPStreamID("b"),
+			)
+			require.NoError(t, err)
+			writer := &simulcastTestTrackLocal{primaryTrack}
+			sender, err := pcOffer.AddTrack(writer)
+			require.NoError(t, err)
+			require.NoError(t, sender.AddEncoding(&simulcastTestTrackLocal{secondTrack}))
+
+			// Do not read the TrackRemote: eager startup must come only from the interceptor wrapper.
+			pcAnswer.OnTrack(func(*TrackRemote, *RTPReceiver) {})
+
+			connected := untilConnectionState(PeerConnectionStateConnected, pcOffer, pcAnswer)
+			require.NoError(t, signalPairWithModification(pcOffer, pcAnswer, func(raw string) string {
+				lines := strings.Split(raw, "\r\n")
+				filtered := lines[:0]
+				for _, line := range lines {
+					if strings.HasPrefix(line, "a=ssrc") || strings.HasPrefix(line, "a=rtcp-fb:97") {
+						continue
+					}
+					filtered = append(filtered, line)
+				}
+
+				return strings.Join(filtered, "\r\n")
+			}))
+			connected.Wait()
+
+			parameters := sender.GetParameters()
+			var midID, ridID, rsidID uint8
+			for _, extension := range parameters.HeaderExtensions {
+				switch extension.URI {
+				case sdp.SDESMidURI:
+					midID = uint8(extension.ID) //nolint:gosec // G115
+				case sdp.SDESRTPStreamIDURI:
+					ridID = uint8(extension.ID) //nolint:gosec // G115
+				case sdp.SDESRepairRTPStreamIDURI:
+					rsidID = uint8(extension.ID) //nolint:gosec // G115
+				}
+			}
+			require.NotZero(t, midID)
+			require.NotZero(t, ridID)
+			require.NotZero(t, rsidID)
+			mid := sender.rtpTransceiver.Mid()
+			require.NotEmpty(t, mid)
+
+			receivers := pcAnswer.GetReceivers()
+			require.Len(t, receivers, 1)
+			receiver := receivers[0]
+			type repairState struct {
+				found, primaryBound, repairBound bool
+				startImmediately, readerStarted  bool
+				readRequested                    bool
+			}
+			snapshot := func() repairState {
+				receiver.mu.RLock()
+				defer receiver.mu.RUnlock()
+				for i := range receiver.tracks {
+					if receiver.tracks[i].track.RID() != rid {
+						continue
+					}
+
+					return repairState{
+						found:            true,
+						primaryBound:     receiver.tracks[i].streamInfo != nil,
+						repairBound:      receiver.tracks[i].repairStreamInfo != nil,
+						startImmediately: receiver.tracks[i].startRepairReaderImmediately,
+						readerStarted:    receiver.tracks[i].repairReaderStarted,
+						readRequested:    receiver.tracks[i].track.repairReadRequested.Load(),
+					}
+				}
+
+				return repairState{}
+			}
+
+			var sequenceNumber uint16
+			send := func(repair bool) error {
+				sequenceNumber++
+				header := rtp.Header{
+					Version:        2,
+					SequenceNumber: sequenceNumber,
+					PayloadType:    96,
+					SSRC:           1111,
+				}
+				payload := []byte{0xAA}
+				if repair {
+					header.PayloadType = 97
+					header.SSRC = 2222
+					payload = []byte{0, 1, 0xAA}
+				}
+				if err := header.SetExtension(midID, []byte(mid)); err != nil {
+					return err
+				}
+				if repair {
+					if err := header.SetExtension(rsidID, []byte(rid)); err != nil {
+						return err
+					}
+				} else if err := header.SetExtension(ridID, []byte(rid)); err != nil {
+					return err
+				}
+
+				return writer.WriteRTP(&rtp.Packet{Header: header, Payload: payload})
+			}
+			sendUntil := func(repair bool, ready func(repairState) bool) {
+				t.Helper()
+				deadline := time.Now().Add(5 * time.Second)
+				for {
+					state := snapshot()
+					if ready(state) {
+						return
+					}
+					if time.Now().After(deadline) {
+						require.FailNow(t, "timed out waiting for RID/RSID binding", "%+v", state)
+					}
+					require.NoError(t, send(repair))
+					time.Sleep(20 * time.Millisecond)
+				}
+			}
+
+			firstIsRepair := !primaryFirst
+			sendUntil(firstIsRepair, func(state repairState) bool {
+				if primaryFirst {
+					return state.primaryBound
+				}
+
+				return state.repairBound
+			})
+			firstState := snapshot()
+			require.True(t, firstState.found)
+			assert.False(t, firstState.readerStarted)
+			assert.False(t, firstState.readRequested)
+			if primaryFirst {
+				assert.True(t, firstState.startImmediately)
+				assert.False(t, firstState.repairBound)
+			} else {
+				assert.False(t, firstState.startImmediately)
+				assert.False(t, firstState.primaryBound)
+			}
+
+			sendUntil(primaryFirst, func(state repairState) bool {
+				return state.primaryBound && state.repairBound && state.readerStarted
+			})
+			finalState := snapshot()
+			assert.True(t, finalState.startImmediately)
+			assert.True(t, finalState.readerStarted)
+			assert.False(t, finalState.readRequested)
+		})
+	}
+}
+
 func TestPeerConnection_Simulcast_RTX(t *testing.T) { //nolint:cyclop
 	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -35,9 +35,11 @@ type trackStreams struct {
 	rtcpReadStream  *srtp.ReadStreamSRTCP
 	rtcpInterceptor interceptor.RTCPReader
 
-	repairReadStream    *srtp.ReadStreamSRTP
-	repairInterceptor   interceptor.RTPReader
-	repairStreamChannel chan rtxPacketWithAttributes
+	repairReadStream             *srtp.ReadStreamSRTP
+	repairInterceptor            interceptor.RTPReader
+	repairStreamChannel          chan rtxPacketWithAttributes
+	repairReaderStarted          bool
+	startRepairReaderImmediately bool
 
 	repairRtcpReadStream  *srtp.ReadStreamSRTCP
 	repairRtcpInterceptor interceptor.RTCPReader
@@ -241,6 +243,8 @@ func (r *RTPReceiver) startReceive(parameters RTPReceiveParameters) error { //no
 		streams.rtpInterceptor = result.rtpInterceptor
 		streams.rtcpReadStream = result.rtcpReadStream
 		streams.rtcpInterceptor = result.rtcpInterceptor
+		streams.startRepairReaderImmediately = streams.startRepairReaderImmediately || result.startRTPReaderImmediately
+		r.maybeStartRepairStreamReader(streams)
 
 		if rtxSsrc := parameters.Encodings[i].RTX.SSRC; rtxSsrc != 0 {
 			// See RFC 4588 section 6.3,
@@ -267,6 +271,7 @@ func (r *RTPReceiver) startReceive(parameters RTPReceiveParameters) error { //no
 				streamInfo,
 				rtpReadStream,
 				rtpInterceptor,
+				result.startRTPReaderImmediately,
 				rtcpReadStream,
 				rtcpInterceptor,
 			); err != nil {
@@ -550,6 +555,7 @@ func (r *RTPReceiver) receiveForRid(
 	streamInfo *interceptor.StreamInfo,
 	rtpReadStream *srtp.ReadStreamSRTP,
 	rtpInterceptor interceptor.RTPReader,
+	startImmediately bool,
 	rtcpReadStream *srtp.ReadStreamSRTCP,
 	rtcpInterceptor interceptor.RTCPReader,
 	peekedPackets []*peekedPacket,
@@ -576,6 +582,8 @@ func (r *RTPReceiver) receiveForRid(
 			r.tracks[i].rtpInterceptor = rtpInterceptor
 			r.tracks[i].rtcpReadStream = rtcpReadStream
 			r.tracks[i].rtcpInterceptor = rtcpInterceptor
+			r.tracks[i].startRepairReaderImmediately = r.tracks[i].startRepairReaderImmediately || startImmediately
+			r.maybeStartRepairStreamReader(&r.tracks[i])
 
 			return r.tracks[i].track, nil
 		}
@@ -584,13 +592,14 @@ func (r *RTPReceiver) receiveForRid(
 	return nil, fmt.Errorf("%w: %s", errRTPReceiverForRIDTrackStreamNotFound, rid)
 }
 
-// receiveForRtx starts a routine that processes the repair stream.
+// receiveForRtx configures the repair stream and starts its reader when needed.
 func (r *RTPReceiver) receiveForRtx(
 	ssrc SSRC,
 	rsid string,
 	streamInfo *interceptor.StreamInfo,
 	rtpReadStream *srtp.ReadStreamSRTP,
 	rtpInterceptor interceptor.RTPReader,
+	startImmediately bool,
 	rtcpReadStream *srtp.ReadStreamSRTCP,
 	rtcpInterceptor interceptor.RTCPReader,
 ) error {
@@ -603,6 +612,7 @@ func (r *RTPReceiver) receiveForRtx(
 		streamInfo,
 		rtpReadStream,
 		rtpInterceptor,
+		startImmediately,
 		rtcpReadStream,
 		rtcpInterceptor,
 	)
@@ -615,6 +625,7 @@ func (r *RTPReceiver) receiveForRtxInternal(
 	streamInfo *interceptor.StreamInfo,
 	rtpReadStream *srtp.ReadStreamSRTP,
 	rtpInterceptor interceptor.RTPReader,
+	startImmediately bool,
 	rtcpReadStream *srtp.ReadStreamSRTCP,
 	rtcpInterceptor interceptor.RTCPReader,
 ) error {
@@ -648,9 +659,26 @@ func (r *RTPReceiver) receiveForRtxInternal(
 	track.repairRtcpReadStream = rtcpReadStream
 	track.repairRtcpInterceptor = rtcpInterceptor
 	track.repairStreamChannel = make(chan rtxPacketWithAttributes, 50)
+	track.repairReaderStarted = false
+	track.startRepairReaderImmediately = track.startRepairReaderImmediately || startImmediately
+	r.maybeStartRepairStreamReader(track)
+
+	return nil
+}
+
+// maybeStartRepairStreamReader starts repair processing when needed. The caller must hold r.mu.
+func (r *RTPReceiver) maybeStartRepairStreamReader(track *trackStreams) { //nolint:cyclop
+	if track.repairReaderStarted || track.repairInterceptor == nil {
+		return
+	}
+	if !track.startRepairReaderImmediately && !track.track.repairReadRequested.Load() {
+		return
+	}
+	track.repairReaderStarted = true
 
 	repairInterceptor := track.repairInterceptor
 	repairStreamChannel := track.repairStreamChannel
+	remoteTrack := track.track
 	go func() {
 		for {
 			b := r.rtxPool.Get().([]byte) // nolint:forcetypeassert
@@ -690,10 +718,10 @@ func (r *RTPReceiver) receiveForRtxInternal(
 			attributes.Set(AttributeRtxSequenceNumber, binary.BigEndian.Uint16(b[2:4]))
 			attributes.Set(AttributeRtxSsrc, binary.BigEndian.Uint32(b[8:12]))
 
-			b[1] = (b[1] & 0x80) | uint8(track.track.PayloadType())
+			b[1] = (b[1] & 0x80) | uint8(remoteTrack.PayloadType())
 			b[2] = b[headerLength]
 			b[3] = b[headerLength+1]
-			binary.BigEndian.PutUint32(b[8:12], uint32(track.track.SSRC()))
+			binary.BigEndian.PutUint32(b[8:12], uint32(remoteTrack.SSRC()))
 			copy(b[headerLength:i-2], b[headerLength+2:i])
 
 			select {
@@ -707,8 +735,6 @@ func (r *RTPReceiver) receiveForRtxInternal(
 			}
 		}
 	}()
-
-	return nil
 }
 
 // SetReadDeadline sets the max amount of time the RTCP stream will block before returning. 0 is forever.
@@ -745,6 +771,18 @@ func (r *RTPReceiver) setRTPReadDeadline(deadline time.Time, reader *TrackRemote
 	}
 
 	return fmt.Errorf("%w: %d", errRTPReceiverWithSSRCTrackStreamNotFound, reader.SSRC())
+}
+
+func (r *RTPReceiver) requestRepairStreamReader(reader *TrackRemote) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.haveClosed() {
+		return
+	}
+	if track := r.streamsForTrack(reader); track != nil {
+		r.maybeStartRepairStreamReader(track)
+	}
 }
 
 // readRTX returns an RTX packet if one is available on the RTX track, otherwise returns nil.

--- a/rtpreceiver_test.go
+++ b/rtpreceiver_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/pion/interceptor/pkg/stats"
 	"github.com/pion/logging"
 	"github.com/pion/rtp"
+	"github.com/pion/transport/v4/packetio"
 	"github.com/pion/transport/v4/test"
 	"github.com/pion/webrtc/v4/pkg/media"
 	"github.com/stretchr/testify/assert"
@@ -124,11 +126,11 @@ func TestRTPReceiver_ClosedReceiveForRIDAndRTX(t *testing.T) {
 	)
 
 	for range 50 {
-		track, err := receiver.receiveForRid("rid", params, ridStreamInfo, nil, nil, nil, nil, nil)
+		track, err := receiver.receiveForRid("rid", params, ridStreamInfo, nil, nil, false, nil, nil, nil)
 		assert.Nil(t, track)
 		assert.ErrorIs(t, err, io.EOF)
 
-		err = receiver.receiveForRtx(SSRC(0), "rid", rtxStreamInfo, nil, rtpInterceptor, nil, nil)
+		err = receiver.receiveForRtx(SSRC(0), "rid", rtxStreamInfo, nil, rtpInterceptor, false, nil, nil)
 		assert.ErrorIs(t, err, io.EOF)
 	}
 
@@ -137,6 +139,303 @@ func TestRTPReceiver_ClosedReceiveForRIDAndRTX(t *testing.T) {
 		assert.Fail(t, "repair reader invoked after Stop")
 	case <-time.After(100 * time.Millisecond):
 	}
+}
+
+func TestRTPReceiverRepairReaderPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		customBuffer bool
+		wrapped      bool
+	}{
+		{name: "default buffer passthrough"},
+		{name: "default buffer wrapped", wrapped: true},
+		{name: "custom buffer passthrough", customBuffer: true},
+		{name: "custom buffer wrapped", customBuffer: true, wrapped: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			startImmediately := tt.wrapped && !tt.customBuffer
+			receiver, track := newRepairReaderPolicyTestReceiver(t, tt.customBuffer, 2222, nil)
+			var calls atomic.Int32
+			releaseReader := make(chan struct{})
+			t.Cleanup(func() { close(releaseReader) })
+			repairReader := interceptor.RTPReaderFunc(
+				func(_ []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+					calls.Add(1)
+					<-releaseReader
+
+					return 0, a, io.EOF
+				},
+			)
+			require.NoError(t, receiver.receiveForRtx(
+				2222, "", &interceptor.StreamInfo{SSRC: 2222}, nil, repairReader, startImmediately, nil, nil,
+			))
+
+			repairReaderStarted := func() bool {
+				receiver.mu.RLock()
+				defer receiver.mu.RUnlock()
+
+				return receiver.tracks[0].repairReaderStarted
+			}
+			assert.Equal(t, startImmediately, repairReaderStarted())
+			if startImmediately {
+				require.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+			} else {
+				assert.Zero(t, calls.Load())
+			}
+
+			b := make([]byte, receiveMTU)
+			_, err := track.peek(b)
+			require.NoError(t, err)
+			if !startImmediately {
+				assert.False(t, repairReaderStarted())
+				assert.Zero(t, calls.Load())
+			}
+
+			_, _, err = track.Read(b)
+			require.NoError(t, err)
+			assert.True(t, repairReaderStarted())
+			require.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+
+			_, _, err = track.Read(b)
+			require.NoError(t, err)
+			assert.Never(t, func() bool { return calls.Load() > 1 }, 25*time.Millisecond, time.Millisecond)
+		})
+	}
+}
+
+func TestTrackRemoteReadUsesEagerRepairChannel(t *testing.T) {
+	var primaryCalls atomic.Int32
+	primaryReader := interceptor.RTPReaderFunc(
+		func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+			primaryCalls.Add(1)
+
+			return copy(b, []byte{
+				0x80, 96, 0, 1, 0, 0, 0, 0, 0, 0, 0x04, 0x57, 0xAA,
+			}), a, nil
+		},
+	)
+	receiver, track := newRepairReaderPolicyTestReceiver(t, false, 2222, primaryReader)
+	var repairCalls atomic.Int32
+	repairReader := interceptor.RTPReaderFunc(
+		func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+			if repairCalls.Add(1) != 1 {
+				return 0, a, io.EOF
+			}
+
+			return copy(b, []byte{
+				0x80, 97, 0x13, 0x88, 0, 0, 0, 0, 0, 0, 0x08, 0xAE,
+				0x04, 0xD2, 0xA1,
+			}), a, nil
+		},
+	)
+	require.NoError(t, receiver.receiveForRtx(
+		2222, "", &interceptor.StreamInfo{SSRC: 2222}, nil, repairReader, true, nil, nil,
+	))
+	require.Eventually(t, func() bool {
+		receiver.mu.RLock()
+		defer receiver.mu.RUnlock()
+
+		return len(receiver.tracks[0].repairStreamChannel) == 1
+	}, time.Second, time.Millisecond)
+
+	packet, _, err := track.ReadRTP()
+	require.NoError(t, err)
+	require.NotNil(t, packet)
+	assert.Equal(t, uint16(1234), packet.SequenceNumber)
+	assert.Equal(t, []byte{0xA1}, packet.Payload)
+	assert.Zero(t, primaryCalls.Load())
+}
+
+func TestRTPReceiverLateRepairBindAfterTrackRead(t *testing.T) {
+	receiver, track := newRepairReaderPolicyTestReceiver(t, true, 0, nil)
+	_, _, err := track.Read(make([]byte, receiveMTU))
+	require.NoError(t, err)
+
+	var calls atomic.Int32
+	releaseReader := make(chan struct{})
+	t.Cleanup(func() { close(releaseReader) })
+	repairReader := interceptor.RTPReaderFunc(
+		func(_ []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+			calls.Add(1)
+			<-releaseReader
+
+			return 0, a, io.EOF
+		},
+	)
+	require.NoError(t, receiver.receiveForRtx(
+		0, "rid", &interceptor.StreamInfo{SSRC: 2222}, nil, repairReader, false, nil, nil,
+	))
+
+	receiver.mu.RLock()
+	started := receiver.tracks[0].repairReaderStarted
+	receiver.mu.RUnlock()
+	assert.True(t, started)
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+}
+
+func TestRTPReceiverRIDRepairReaderStartsForPrimaryWrapper(t *testing.T) {
+	for _, primaryFirst := range []bool{true, false} {
+		name := "RTX first"
+		if primaryFirst {
+			name = "primary first"
+		}
+		t.Run(name, func(t *testing.T) {
+			api := NewAPI()
+			receiver, err := api.NewRTPReceiver(RTPCodecTypeVideo, &DTLSTransport{api: api})
+			require.NoError(t, err)
+			receiver.configureReceive(RTPReceiveParameters{Encodings: []RTPDecodingParameters{{
+				RTPCodingParameters: RTPCodingParameters{RID: "rid"},
+			}}})
+			close(receiver.received)
+			t.Cleanup(func() {
+				assert.NoError(t, receiver.Stop())
+			})
+
+			var repairCalls atomic.Int32
+			releaseReader := make(chan struct{})
+			t.Cleanup(func() { close(releaseReader) })
+			repairReader := interceptor.RTPReaderFunc(
+				func(_ []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+					repairCalls.Add(1)
+					<-releaseReader
+
+					return 0, a, io.EOF
+				},
+			)
+			params := RTPParameters{Codecs: []RTPCodecParameters{{
+				RTPCodecCapability: RTPCodecCapability{MimeType: MimeTypeVP8},
+				PayloadType:        96,
+			}}}
+			bindPrimary := func() error {
+				_, bindErr := receiver.receiveForRid(
+					"rid",
+					params,
+					&interceptor.StreamInfo{SSRC: 1111},
+					nil,
+					interceptor.RTPReaderFunc(nil),
+					true,
+					nil,
+					nil,
+					nil,
+				)
+
+				return bindErr
+			}
+			bindRTX := func() error {
+				return receiver.receiveForRtx(
+					0,
+					"rid",
+					&interceptor.StreamInfo{SSRC: 2222},
+					nil,
+					repairReader,
+					false,
+					nil,
+					nil,
+				)
+			}
+
+			first, second := bindRTX, bindPrimary
+			if primaryFirst {
+				first, second = bindPrimary, bindRTX
+			}
+			require.NoError(t, first())
+			receiver.mu.RLock()
+			startedAfterFirstBind := receiver.tracks[0].repairReaderStarted
+			receiver.mu.RUnlock()
+			assert.False(t, startedAfterFirstBind)
+			assert.Zero(t, repairCalls.Load())
+
+			require.NoError(t, second())
+			track := receiver.Track()
+			require.NotNil(t, track)
+			assert.False(t, track.repairReadRequested.Load())
+			receiver.mu.RLock()
+			started := receiver.tracks[0].repairReaderStarted
+			startImmediately := receiver.tracks[0].startRepairReaderImmediately
+			receiver.mu.RUnlock()
+			assert.True(t, startImmediately)
+			assert.True(t, started)
+			require.Eventually(t, func() bool { return repairCalls.Load() == 1 }, time.Second, time.Millisecond)
+		})
+	}
+}
+
+func TestRTPReceiverReadAfterStopDoesNotStartRepairReader(t *testing.T) {
+	receiver, track := newRepairReaderPolicyTestReceiver(t, true, 2222, nil)
+	var calls atomic.Int32
+	repairReader := interceptor.RTPReaderFunc(
+		func(_ []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+			calls.Add(1)
+
+			return 0, a, io.EOF
+		},
+	)
+	require.NoError(t, receiver.receiveForRtx(
+		2222, "", &interceptor.StreamInfo{SSRC: 2222}, nil, repairReader, false, nil, nil,
+	))
+	require.NoError(t, receiver.Stop())
+
+	_, _, err := track.Read(make([]byte, receiveMTU))
+	require.ErrorIs(t, err, io.EOF)
+	receiver.mu.RLock()
+	started := receiver.tracks[0].repairReaderStarted
+	receiver.mu.RUnlock()
+	assert.False(t, started)
+	assert.Zero(t, calls.Load())
+}
+
+func newRepairReaderPolicyTestReceiver(
+	t *testing.T,
+	customBuffer bool,
+	rtxSSRC SSRC,
+	primaryReader interceptor.RTPReader,
+) (*RTPReceiver, *TrackRemote) {
+	t.Helper()
+
+	transportSettings := SettingEngine{}
+	if customBuffer {
+		transportSettings.BufferFactory = func(packetio.BufferPacketType, uint32) io.ReadWriteCloser {
+			return nil
+		}
+	}
+	transportAPI := NewAPI(WithSettingEngine(transportSettings))
+	receiverAPI := NewAPI()
+	receiver, err := receiverAPI.NewRTPReceiver(
+		RTPCodecTypeVideo,
+		&DTLSTransport{api: transportAPI},
+	)
+	require.NoError(t, err)
+
+	receiver.configureReceive(RTPReceiveParameters{Encodings: []RTPDecodingParameters{{
+		RTPCodingParameters: RTPCodingParameters{
+			RID:  "rid",
+			SSRC: 1111,
+			RTX:  RTPRtxParameters{SSRC: rtxSSRC},
+		},
+	}}})
+	if primaryReader == nil {
+		primaryReader = interceptor.RTPReaderFunc(
+			func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+				return copy(b, []byte{
+					0x80, 96, 0, 1, 0, 0, 0, 0, 0, 0, 0x04, 0x57, 0xAA,
+				}), a, nil
+			},
+		)
+	}
+	params := RTPParameters{Codecs: []RTPCodecParameters{{
+		RTPCodecCapability: RTPCodecCapability{MimeType: MimeTypeVP8},
+		PayloadType:        96,
+	}}}
+	track, err := receiver.receiveForRid(
+		"rid", params, &interceptor.StreamInfo{SSRC: 1111}, nil, primaryReader, false, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	close(receiver.received)
+	t.Cleanup(func() {
+		assert.NoError(t, receiver.Stop())
+	})
+
+	return receiver, track
 }
 
 func TestRTPReceiver_readRTX_ChannelAccessSafe(t *testing.T) {
@@ -172,7 +471,7 @@ func TestRTPReceiver_readRTX_ChannelAccessSafe(t *testing.T) {
 		},
 	}
 	ridStreamInfo := &interceptor.StreamInfo{SSRC: 1111}
-	track, err := receiver.receiveForRid("rid", params, ridStreamInfo, nil, nil, nil, nil, nil)
+	track, err := receiver.receiveForRid("rid", params, ridStreamInfo, nil, nil, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	close(receiver.received)
@@ -199,7 +498,9 @@ func TestRTPReceiver_readRTX_ChannelAccessSafe(t *testing.T) {
 	)
 
 	for range 50 {
-		require.NoError(t, receiver.receiveForRtx(SSRC(2222), "", repairStreamInfo, nil, rtpInterceptor, nil, nil))
+		require.NoError(t, receiver.receiveForRtx(
+			SSRC(2222), "", repairStreamInfo, nil, rtpInterceptor, false, nil, nil,
+		))
 	}
 
 	close(stop)
@@ -258,7 +559,7 @@ func TestRTPReceiver_ReadRTP_SimulcastNoRace(t *testing.T) {
 		},
 	)
 	lowTrack, err := receiver.receiveForRid(
-		"low", params, &interceptor.StreamInfo{SSRC: 1111}, nil, lowInterceptor, nil, nil, nil,
+		"low", params, &interceptor.StreamInfo{SSRC: 1111}, nil, lowInterceptor, false, nil, nil, nil,
 	)
 	require.NoError(t, err)
 	lowTrack.mu.Lock()
@@ -286,7 +587,7 @@ func TestRTPReceiver_ReadRTP_SimulcastNoRace(t *testing.T) {
 		},
 	)
 	require.NoError(t, receiver.receiveForRtx(
-		SSRC(0), "low", repairStreamInfo, nil, repairInterceptor, nil, nil,
+		SSRC(0), "low", repairStreamInfo, nil, repairInterceptor, false, nil, nil,
 	))
 
 	highInterceptor := interceptor.RTPReaderFunc(
@@ -295,7 +596,7 @@ func TestRTPReceiver_ReadRTP_SimulcastNoRace(t *testing.T) {
 		},
 	)
 	_, err = receiver.receiveForRid(
-		"high", params, &interceptor.StreamInfo{SSRC: 2222}, nil, highInterceptor, nil, nil, nil,
+		"high", params, &interceptor.StreamInfo{SSRC: 2222}, nil, highInterceptor, false, nil, nil, nil,
 	)
 	require.NoError(t, err)
 	receiver.tracks[1].track.mu.Lock()
@@ -521,73 +822,109 @@ func (f *fakeAudioPlayoutStatsProvider) RemoveTrack(track *TrackRemote) {
 }
 
 func TestRTPReceiverRTXStreamInfoMimeType(t *testing.T) {
-	lim := test.TimeOut(time.Second * 30)
-	defer lim.Stop()
+	for _, tt := range []struct {
+		name          string
+		configureNack bool
+	}{
+		{name: "passthrough"},
+		{name: "ConfigureNack", configureNack: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			lim := test.TimeOut(time.Second * 30)
+			defer lim.Stop()
 
-	report := test.CheckRoutines(t)
-	defer report()
+			report := test.CheckRoutines(t)
+			defer report()
 
-	// Collect all StreamInfos bound on the remote (receiver) side
-	var (
-		boundStreamInfos []*interceptor.StreamInfo
-	)
-
-	mockInterceptor := &mock_interceptor.Interceptor{
-		BindRemoteStreamFn: func(info *interceptor.StreamInfo, reader interceptor.RTPReader) interceptor.RTPReader {
-			boundStreamInfos = append(boundStreamInfos, info)
-
-			return reader
-		},
-	}
-
-	ir := &interceptor.Registry{}
-	ir.Add(&mock_interceptor.Factory{
-		NewInterceptorFn: func(_ string) (interceptor.Interceptor, error) { return mockInterceptor, nil },
-	})
-
-	sender, receiver, err := NewAPI(WithInterceptorRegistry(ir)).newPair(Configuration{})
-	assert.NoError(t, err)
-
-	track, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
-	assert.NoError(t, err)
-
-	_, err = sender.AddTrack(track)
-	assert.NoError(t, err)
-
-	// Signal and wait until the receiver fires OnTrack (stream is negotiated + receiving)
-	trackReceived, trackReceivedCancel := context.WithCancel(context.Background())
-	receiver.OnTrack(func(_ *TrackRemote, _ *RTPReceiver) {
-		trackReceivedCancel()
-	})
-
-	assert.NoError(t, signalPair(sender, receiver))
-
-	// Send samples until the receiver sees the track (RTX SSRC gets registered during Receive)
-	func() {
-		ticker := time.NewTicker(time.Millisecond * 20)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-trackReceived.Done():
-				return
-			case <-ticker.C:
-				assert.NoError(t, track.WriteSample(media.Sample{Data: []byte{0xAA}, Duration: time.Second}))
+			mediaEngine := &MediaEngine{}
+			require.NoError(t, mediaEngine.RegisterDefaultCodecs())
+			ir := &interceptor.Registry{}
+			if tt.configureNack {
+				require.NoError(t, ConfigureNack(mediaEngine, ir))
 			}
-		}
-	}()
 
-	// Assert: exactly one bound stream must have MimeType == MimeTypeRTX
-	count := 0
-	for _, info := range boundStreamInfos {
-		if info.MimeType == MimeTypeRTX {
-			count++
-		}
+			// Collect the final readers and StreamInfos bound on the receiver side.
+			var (
+				boundStreamInfos        []*interceptor.StreamInfo
+				readerWrappedByMimeType = map[string]bool{}
+			)
+			mockInterceptor := &mock_interceptor.Interceptor{
+				BindRemoteStreamFn: func(
+					info *interceptor.StreamInfo,
+					reader interceptor.RTPReader,
+				) interceptor.RTPReader {
+					boundStreamInfos = append(boundStreamInfos, info)
+					_, passthrough := reader.(*srtpRTPReader)
+					readerWrappedByMimeType[info.MimeType] = !passthrough
+
+					return reader
+				},
+			}
+			ir.Add(&mock_interceptor.Factory{
+				NewInterceptorFn: func(_ string) (interceptor.Interceptor, error) { return mockInterceptor, nil },
+			})
+
+			sender, receiver, err := NewAPI(
+				WithMediaEngine(mediaEngine),
+				WithInterceptorRegistry(ir),
+			).newPair(Configuration{})
+			require.NoError(t, err)
+			defer closePairNow(t, sender, receiver)
+
+			track, err := NewTrackLocalStaticSample(
+				RTPCodecCapability{MimeType: MimeTypeVP8},
+				"video",
+				"pion",
+			)
+			require.NoError(t, err)
+
+			_, err = sender.AddTrack(track)
+			require.NoError(t, err)
+
+			// OnTrack is reached through internal probing, without a public TrackRemote.Read.
+			trackReceived, trackReceivedCancel := context.WithCancel(context.Background())
+			rtpReceiverReceived := make(chan *RTPReceiver, 1)
+			receiver.OnTrack(func(_ *TrackRemote, rtpReceiver *RTPReceiver) {
+				rtpReceiverReceived <- rtpReceiver
+				trackReceivedCancel()
+			})
+
+			require.NoError(t, signalPair(sender, receiver))
+
+			func() {
+				ticker := time.NewTicker(time.Millisecond * 20)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-trackReceived.Done():
+						return
+					case <-ticker.C:
+						require.NoError(t, track.WriteSample(media.Sample{Data: []byte{0xAA}, Duration: time.Second}))
+					}
+				}
+			}()
+
+			rtxCount := 0
+			for _, info := range boundStreamInfos {
+				if info.MimeType == MimeTypeRTX {
+					rtxCount++
+				}
+			}
+			assert.Equal(t, 1, rtxCount,
+				"expected exactly one RTX StreamInfo with MimeType %q, got %d (all types: %v)",
+				MimeTypeRTX, rtxCount, mimeTypes(boundStreamInfos))
+			assert.Equal(t, tt.configureNack, readerWrappedByMimeType[MimeTypeVP8], "primary reader wrapper")
+			assert.False(t, readerWrappedByMimeType[MimeTypeRTX], "RTX reader wrapper")
+
+			rtpReceiver := <-rtpReceiverReceived
+			rtpReceiver.mu.RLock()
+			trackCount := len(rtpReceiver.tracks)
+			repairReaderStarted := trackCount == 1 && rtpReceiver.tracks[0].repairReaderStarted
+			rtpReceiver.mu.RUnlock()
+			require.Equal(t, 1, trackCount)
+			assert.Equal(t, tt.configureNack, repairReaderStarted)
+		})
 	}
-	assert.Equal(t, 1, count,
-		"expected exactly one RTX StreamInfo with MimeType %q, got %d (all types: %v)",
-		MimeTypeRTX, count, mimeTypes(boundStreamInfos))
-
-	closePairNow(t, sender, receiver)
 }
 
 // helper to print all mime types for debugging.

--- a/track_remote.go
+++ b/track_remote.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pion/interceptor"
@@ -23,7 +24,8 @@ type peekedPacket struct {
 
 // TrackRemote represents a single inbound source of media.
 type TrackRemote struct {
-	mu sync.RWMutex
+	mu                  sync.RWMutex
+	repairReadRequested atomic.Bool
 
 	id       string
 	streamID string
@@ -120,6 +122,14 @@ func (t *TrackRemote) Codec() RTPCodecParameters {
 
 // Read reads data from the track.
 func (t *TrackRemote) Read(b []byte) (n int, attributes interceptor.Attributes, err error) {
+	if t.repairReadRequested.CompareAndSwap(false, true) {
+		t.receiver.requestRepairStreamReader(t)
+	}
+
+	return t.read(b)
+}
+
+func (t *TrackRemote) read(b []byte) (n int, attributes interceptor.Attributes, err error) {
 	t.mu.RLock()
 	receiver := t.receiver
 	var peekedPkt *peekedPacket
@@ -201,8 +211,9 @@ func (t *TrackRemote) ReadRTP() (*rtp.Packet, interceptor.Attributes, error) {
 }
 
 // peek is like Read, but it doesn't discard the packet read.
-func (t *TrackRemote) peek(b []byte) (n int, a interceptor.Attributes, err error) {
-	n, a, err = t.Read(b)
+func (t *TrackRemote) peek(b []byte) (n int, err error) {
+	var attr interceptor.Attributes
+	n, attr, err = t.read(b)
 	if err != nil {
 		return
 	}
@@ -213,7 +224,7 @@ func (t *TrackRemote) peek(b []byte) (n int, a interceptor.Attributes, err error
 	// that case.
 	data := make([]byte, n)
 	n = copy(data, b[:n])
-	t.peekedPackets = append(t.peekedPackets, &peekedPacket{payload: data, attributes: a})
+	t.peekedPackets = append(t.peekedPackets, &peekedPacket{payload: data, attributes: attr})
 	t.mu.Unlock()
 
 	return


### PR DESCRIPTION
#### Description
Currently Pion starts a RTX repair reader goroutine that loops forever even if the user doesn't use RTX interceptors or any interceptors that touches the stream. This is a problem for us because we use custom interceptors.
In the future I would like to move this logic away from pion/webrtc and move it to interceptors so we don't have to have a helper code for a technically another library.

To avoid breaking apps that use repair the fix had to be nuanced: 

Case | At RTX stream setup | Later TrackRemote.Read/ReadRTP
-- | -- | --
no custom buffer + passthrough interceptor | does not start repair reader | lazily starts repair reader
no custom buffer + wrapped interceptor | starts repair reader immediately | uses existing repair channel
custom buffer + passthrough interceptor | does not start repair reader | lazily starts repair reader if track is read
custom buffer + wrapped interceptor | does not start repair reader immediately | lazily starts repair reader if track is read

#### Reference issue
Fixes #2952
