### PR TITLE
sdp: order simulcast rids by the a=simulcast attribute, not a=rid line order

### DIFF
--- a/sdp.go
+++ b/sdp.go
@@ -6,9 +6,11 @@
 package webrtc
 
 import (
+	"cmp"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"regexp"
 	"slices"
@@ -282,7 +284,7 @@ func trackDetailsToRTPReceiveParameters(trackDetails *trackDetails) RTPReceivePa
 	return RTPReceiveParameters{Encodings: encodings}
 }
 
-func getRids(media *sdp.MediaDescription) []*simulcastRid { // nolint:cyclop
+func getRids(media *sdp.MediaDescription) []*simulcastRid {
 	rids := []*simulcastRid{}
 	var simulcastAttr string
 	for _, attr := range media.Attributes {
@@ -293,27 +295,57 @@ func getRids(media *sdp.MediaDescription) []*simulcastRid { // nolint:cyclop
 			simulcastAttr = attr.Value
 		}
 	}
-	// process paused stream like "a=simulcast:send 1;~2;~3"
 	if simulcastAttr != "" {
-		if space := strings.Index(simulcastAttr, " "); space > 0 {
-			simulcastAttr = simulcastAttr[space+1:]
-		}
-		ridStates := strings.SplitSeq(simulcastAttr, ";")
-		for ridState := range ridStates {
-			if len(ridState) > 0 && ridState[:1] == "~" {
-				ridID := ridState[1:]
-				for _, rid := range rids {
-					if rid.id == ridID {
-						rid.paused = true
-
-						break
-					}
-				}
-			}
-		}
+		orderRidsBySimulcast(rids, simulcastAttr)
 	}
 
 	return rids
+}
+
+// orderRidsBySimulcast marks the paused rids and reorders rids in place to
+// follow the a=simulcast send list. RFC 8853 §5.2: the send list "suggests a
+// proposed order of preference, in decreasing order"; the a=rid line order is
+// not significant. §5.1: the send list is a ";"-separated list of simulcast
+// streams, each a ","-separated list of alternative rids, and a leading "~"
+// marks a paused rid (e.g. "send f,~h;q"). The sort is stable, so any rid not
+// named in the attribute keeps its a=rid declaration order at the end.
+func orderRidsBySimulcast(rids []*simulcastRid, simulcastAttr string) {
+	if space := strings.Index(simulcastAttr, " "); space > 0 {
+		simulcastAttr = simulcastAttr[space+1:]
+	}
+	simulcastOrder := map[string]int{}
+	for stream := range strings.SplitSeq(simulcastAttr, ";") {
+		for scID := range strings.SplitSeq(stream, ",") {
+			ridID, paused := strings.CutPrefix(scID, "~")
+			if paused {
+				markRidPaused(rids, ridID)
+			}
+			if _, ok := simulcastOrder[ridID]; !ok {
+				simulcastOrder[ridID] = len(simulcastOrder)
+			}
+		}
+	}
+	orderOf := func(id string) int {
+		if idx, ok := simulcastOrder[id]; ok {
+			return idx
+		}
+
+		return math.MaxInt
+	}
+	slices.SortStableFunc(rids, func(a, b *simulcastRid) int {
+		return cmp.Compare(orderOf(a.id), orderOf(b.id))
+	})
+}
+
+// markRidPaused flags the rid with the given id as paused, if present.
+func markRidPaused(rids []*simulcastRid, ridID string) {
+	for _, rid := range rids {
+		if rid.id == ridID {
+			rid.paused = true
+
+			return
+		}
+	}
 }
 
 func addCandidatesToMediaDescriptions(

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -1306,6 +1306,66 @@ func TestGetRIDs(t *testing.T) {
 	}
 }
 
+// TestGetRIDsOrderFollowsSimulcast verifies that getRids orders the simulcast
+// streams by the a=simulcast attribute, not by the order of the a=rid lines.
+// RFC 8853 §5.2: the a=simulcast send list "suggests a proposed order of
+// preference, in decreasing order"; the order of the a=rid lines is not
+// significant. Here the a=rid lines are listed in the opposite order to
+// a=simulcast:send, so the result must follow the attribute (f, h, q).
+func TestGetRIDsOrderFollowsSimulcast(t *testing.T) {
+	media := &sdp.MediaDescription{
+		MediaName: sdp.MediaName{
+			Media: "video",
+		},
+		Attributes: []sdp.Attribute{
+			{Key: sdpAttributeRid, Value: "q send"},
+			{Key: sdpAttributeRid, Value: "h send"},
+			{Key: sdpAttributeRid, Value: "f send"},
+			{Key: sdpAttributeSimulcast, Value: "send f;h;q"},
+		},
+	}
+
+	got := make([]string, 0, 3)
+	for _, rid := range getRids(media) {
+		got = append(got, rid.id)
+	}
+
+	assert.Equal(t, []string{"f", "h", "q"}, got)
+}
+
+// TestGetRIDsOrderAlternativeRIDs verifies that getRids parses the a=simulcast
+// send list as a ";"-separated list of streams whose members are ","-separated
+// alternative rids (RFC 8853 §5.1). A value like "send f,h;q" must order the
+// rids f, h, q — and still detect a "~" paused alternative — rather than
+// treating "f,h" as a single opaque token.
+func TestGetRIDsOrderAlternativeRIDs(t *testing.T) {
+	media := &sdp.MediaDescription{
+		MediaName: sdp.MediaName{
+			Media: "video",
+		},
+		Attributes: []sdp.Attribute{
+			{Key: sdpAttributeRid, Value: "q send"},
+			{Key: sdpAttributeRid, Value: "h send"},
+			{Key: sdpAttributeRid, Value: "f send"},
+			{Key: sdpAttributeSimulcast, Value: "send f,~h;q"},
+		},
+	}
+
+	rids := getRids(media)
+
+	got := make([]string, 0, len(rids))
+	paused := map[string]bool{}
+	for _, rid := range rids {
+		got = append(got, rid.id)
+		paused[rid.id] = rid.paused
+	}
+
+	assert.Equal(t, []string{"f", "h", "q"}, got)
+	assert.True(t, paused["h"], "alternative rid h should be paused")
+	assert.False(t, paused["f"], "rid f should not be paused")
+	assert.False(t, paused["q"], "rid q should not be paused")
+}
+
 // TestGetRIDs_EmptySimulcastTokens verifies that getRids does not panic when the
 // a=simulcast: attribute contains empty tokens (trailing ";", ";;", or a
 // direction-only value with no rid list).


### PR DESCRIPTION
## Description

`getRids` returned the simulcast rids in `a=rid` line order, consulting `a=simulcast` only to mark `~` paused streams. Per **RFC 8853 §5.2**, the `a=simulcast` send list — not the `a=rid` line order — carries the stream preference:

> The order of the listed simulcast streams in the "send" direction suggests a proposed order of preference, in decreasing order

When a peer lists its `a=rid` lines in a different order than its `a=simulcast:send` list, the resulting `RTPReceiveParameters.Encodings` / `Tracks()` order — and the `a=simulcast:recv` list echoed in the answer — followed the `a=rid` order instead of the offered preference.

This stable-sorts the rids by their first position in the `a=simulcast` attribute; any rid absent from it keeps its `a=rid` declaration order at the end.

**Latent in practice** — browsers (Firefox 152, Chrome) emit both in the same order, and demux is by RID string — so this is a SHOULD-level alignment, not a spec violation: §5.2 "suggests" the order (non-normative), and §5.3.2 only mandates reversing send↔recv (`SHALL`) and forbids adding streams (`MUST NOT`); it does not itself require preserving order.

Closes #3471 (full reproduction and impact analysis there).

## Test plan

- Adds `TestGetRIDsOrderFollowsSimulcast`: an offer whose `a=rid` lines are in the opposite order (`q`, `h`, `f`) to `a=simulcast:send f;h;q`. `getRids` returns `[q, h, f]` before this change and `[f, h, q]` after.
- `go build ./...`, `go vet .`, `gofmt`, and `golangci-lint run` (v2.10.1, `--new-from-rev=main`) are all clean.
