### PR TITLE
Fix late assert panic in TestInterceptorNack

### DIFF
--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -507,13 +507,15 @@ func testInterceptorNack(t *testing.T, requestNack bool) { //nolint:cyclop
 		buf := make([]byte, 1500)
 		for {
 			n, _, err2 := sender.Read(buf)
-			// nolint
-			if err2 == io.EOF {
+			if err2 != nil {
+				// Reads fail once the test closes the peer connections, so
+				// treat any error as end-of-stream, not as a test failure.
 				break
 			}
-			assert.NoError(t, err2)
 			ps, err2 := rtcp.Unmarshal(buf[:n])
-			assert.NoError(t, err2)
+			if err2 != nil {
+				break
+			}
 			for _, p := range ps {
 				if pn, ok := p.(*rtcp.TransportLayerNack); ok {
 					assert.Equal(t, len(pn.Nacks), 1)
@@ -566,6 +568,10 @@ func testInterceptorNack(t *testing.T, requestNack bool) { //nolint:cyclop
 	assert.NoError(t, err)
 	err = pc2.Close()
 	assert.NoError(t, err)
+
+	// Wait for the RTCP reader goroutine to exit, so it cannot outlive the
+	// test and fail it after completion.
+	<-rtcpDone
 
 	if requestNack {
 		assert.True(t, gotNack.Load(), "Expected to get a NACK, got none")


### PR DESCRIPTION
On slow or loaded machines (easily reproduced with `-race` on a busy CI runner), `TestInterceptorNack/Nack` can kill the whole test binary:

```
panic: Fail in goroutine after TestInterceptorNack/Nack has completed
```

**Root cause:** the RTCP reader goroutine spawned by `testInterceptorNack` only stops on `io.EOF` and calls `assert.NoError` on every other error. Nothing waits for the goroutine (the `rtcpDone` channel it closes is never received from). When the test body closes the peer connections and returns, the interrupted read can surface as `io: read/write on closed pipe` instead of `io.EOF` — and a trailing partial read can fail `rtcp.Unmarshal` with `rtcp: invalid header` — so the goroutine asserts on a completed test, which panics by design.

**Fix:**
- Treat any read or unmarshal error in the goroutine as end-of-stream instead of a test failure — errors there are expected once the test closes the peer connections.
- Wait on `rtcpDone` before the test returns, so the goroutine can never outlive the test.

No test signal is lost: if the stream genuinely died early, `gotNack` stays false and the existing `Expected to get a NACK, got none` assertion fails the test meaningfully.

Verified with `go test -race -count=10 -run TestInterceptorNack` at `GOMAXPROCS=2` (simulating a starved runner): all pass; before the fix the panic reproduces readily under CI load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)