### PR TITLE
Defer ICE restart until SetLocalDescription

### DIFF
--- a/gathering_complete_promise.go
+++ b/gathering_complete_promise.go
@@ -28,8 +28,7 @@ func GatheringCompletePromise(pc *PeerConnection) (gatherComplete <-chan struct{
 	pc.setGatherCompleteHandler(func() { done() })
 	// While a restart is pending, the current Complete belongs to the previous cycle, so let the
 	// handler resolve once SetLocalDescription starts the new one instead of resolving now.
-	pending, _ := pc.pendingICERestartCredentials.Load().(*iceCredentials)
-	if pending == nil && pc.ICEGatheringState() == ICEGatheringStateComplete {
+	if !pc.hasPendingICERestart() && pc.ICEGatheringState() == ICEGatheringStateComplete {
 		done()
 	}
 

--- a/gathering_complete_promise.go
+++ b/gathering_complete_promise.go
@@ -14,6 +14,11 @@ import (
 // It is better to not use this function, and instead trickle candidates.
 // If you use this function you will see longer connection startup times.
 // When the call is connected you will see no impact however.
+//
+// A promise created after CreateOffer(ICERestart) waits for the restart's gathering cycle,
+// which only begins on SetLocalDescription. If that offer is never applied, whether abandoned
+// or superseded by a later offer, the returned channel stays open, so wait on it with a
+// timeout or a context rather than blocking indefinitely.
 func GatheringCompletePromise(pc *PeerConnection) (gatherComplete <-chan struct{}) {
 	gatheringComplete, done := context.WithCancel(context.Background())
 
@@ -21,7 +26,10 @@ func GatheringCompletePromise(pc *PeerConnection) (gatherComplete <-chan struct{
 	// promise might have been created after the gathering is finished. Therefore, we need to check if the ICE gathering
 	// state has changed to complete so that we don't block the caller forever.
 	pc.setGatherCompleteHandler(func() { done() })
-	if pc.ICEGatheringState() == ICEGatheringStateComplete {
+	// While a restart is pending, the current Complete belongs to the previous cycle, so let the
+	// handler resolve once SetLocalDescription starts the new one instead of resolving now.
+	pending, _ := pc.pendingICERestartCredentials.Load().(*iceCredentials)
+	if pending == nil && pc.ICEGatheringState() == ICEGatheringStateComplete {
 		done()
 	}
 

--- a/ice_credentials.go
+++ b/ice_credentials.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package webrtc
+
+import "github.com/pion/randutil"
+
+// ufrag/pwd length and charset for a restart offer's credentials; any values
+// clearing the ICE credential minimums (RFC 8445 section 5.3) are valid.
+const (
+	iceCredentialUfragLength = 16
+	iceCredentialPwdLength   = 32
+	iceCredentialRunesAlpha  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+// iceCredentials is a ufrag/pwd pair not tied to any live ICEAgent, used to stage
+// an ICE restart's new credentials in an offer before they are applied.
+type iceCredentials struct {
+	ufrag string
+	pwd   string
+}
+
+func generateICECredentials() (iceCredentials, error) {
+	ufrag, err := randutil.GenerateCryptoRandomString(iceCredentialUfragLength, iceCredentialRunesAlpha)
+	if err != nil {
+		return iceCredentials{}, err
+	}
+	pwd, err := randutil.GenerateCryptoRandomString(iceCredentialPwdLength, iceCredentialRunesAlpha)
+	if err != nil {
+		return iceCredentials{}, err
+	}
+
+	return iceCredentials{ufrag: ufrag, pwd: pwd}, nil
+}

--- a/icetransport.go
+++ b/icetransport.go
@@ -208,6 +208,12 @@ func (t *ICETransport) StartContext(
 // restart is not exposed currently because ORTC has users create a whole new ICETransport
 // so for now lets keep it private so we don't cause ORTC users to depend on non-standard APIs.
 func (t *ICETransport) restart() error {
+	return t.restartWithCredentials("", "") // "" means use the SettingEngine defaults
+}
+
+// restartWithCredentials restarts the live ICE transport with ufrag/pwd,
+// or the SettingEngine default for whichever is empty.
+func (t *ICETransport) restartWithCredentials(ufrag, pwd string) error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
@@ -216,10 +222,14 @@ func (t *ICETransport) restart() error {
 		return fmt.Errorf("%w: unable to restart ICETransport", errICEAgentNotExist)
 	}
 
-	if err := agent.Restart(
-		t.gatherer.api.settingEngine.candidates.UsernameFragment,
-		t.gatherer.api.settingEngine.candidates.Password,
-	); err != nil {
+	if ufrag == "" {
+		ufrag = t.gatherer.api.settingEngine.candidates.UsernameFragment
+	}
+	if pwd == "" {
+		pwd = t.gatherer.api.settingEngine.candidates.Password
+	}
+
+	if err := agent.Restart(ufrag, pwd); err != nil {
 		return err
 	}
 

--- a/offeransweroptions.go
+++ b/offeransweroptions.go
@@ -28,6 +28,9 @@ type OfferOptions struct {
 
 	// ICERestart forces the underlying ice gathering process to be restarted.
 	// When this value is true, the generated description will have ICE
-	// credentials that are different from the current credentials
+	// credentials that are different from the current credentials.
+	//
+	// The restart takes effect when SetLocalDescription applies the offer, not when
+	// CreateOffer creates it, so an unused restart offer leaves the live connection intact.
 	ICERestart bool
 }

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -73,8 +73,9 @@ type PeerConnection struct {
 	// should be defined (see JSEP 3.4.1).
 	greaterMid int
 
-	rtpTransceivers        []*RTPTransceiver
-	nonMediaBandwidthProbe atomic.Value // RTPReceiver
+	rtpTransceivers              []*RTPTransceiver
+	nonMediaBandwidthProbe       atomic.Value // RTPReceiver
+	pendingICERestartCredentials atomic.Value // *iceCredentials
 
 	onSignalingStateChangeHandler     func(SignalingState)
 	onICEConnectionStateChangeHandler atomic.Value // func(ICEConnectionState)
@@ -662,6 +663,75 @@ func (pc *PeerConnection) ID() string {
 	return pc.id
 }
 
+// prepareICERestartForOffer stores or clears the credentials this offer will
+// propose for an ICE restart.
+func (pc *PeerConnection) prepareICERestartForOffer(options *OfferOptions) error {
+	if options == nil || !options.ICERestart {
+		pc.pendingICERestartCredentials.Store((*iceCredentials)(nil))
+
+		return nil
+	}
+
+	credentials, err := generateICECredentials()
+	if err != nil {
+		return err
+	}
+	pc.pendingICERestartCredentials.Store(&credentials)
+
+	return nil
+}
+
+// effectiveLocalICEParameters returns the ICE credentials CreateOffer proposes:
+// the pending restart's if one is staged, otherwise the live transport's.
+func (pc *PeerConnection) effectiveLocalICEParameters() (ICEParameters, error) {
+	if pending, ok := pc.pendingICERestartCredentials.Load().(*iceCredentials); ok && pending != nil {
+		// a=ice-lite is emitted from the SettingEngine in populateSDP, so it is not
+		// carried on this ICEParameters value.
+		return ICEParameters{UsernameFragment: pending.ufrag, Password: pending.pwd}, nil
+	}
+
+	return pc.iceGatherer.GetLocalParameters()
+}
+
+// effectiveLocalCandidates returns CreateOffer's local candidates, or none while a restart is
+// pending: the live candidates predate the restart and belong to the old ufrag, not the new one.
+func (pc *PeerConnection) effectiveLocalCandidates() ([]ICECandidate, error) {
+	if pending, ok := pc.pendingICERestartCredentials.Load().(*iceCredentials); ok && pending != nil {
+		return nil, nil
+	}
+
+	return pc.iceGatherer.GetLocalCandidates()
+}
+
+// applyPendingICERestart restarts the ICE transport with the pending restart credentials
+// when SetLocalDescription commits the offer, matching what the peer already received.
+func (pc *PeerConnection) applyPendingICERestart(desc *SessionDescription) error {
+	// Loaded outside pc.mu; safe because JSEP requires the application to serialize
+	// SetLocalDescription with CreateOffer, so pending cannot change under us.
+	pending, ok := pc.pendingICERestartCredentials.Load().(*iceCredentials)
+	if !ok || pending == nil {
+		return nil
+	}
+	// ice-ufrag lives on the media sections, so read it via extractICEDetails.
+	details, err := extractICEDetails(desc.parsed, pc.log)
+	if err != nil {
+		return err
+	}
+	if details.Ufrag != pending.ufrag {
+		// The applied offer isn't the one that staged this restart (normally unreachable).
+		pc.log.Warnf("ice restart skipped: offer ufrag %q != pending %q", details.Ufrag, pending.ufrag)
+
+		return nil
+	}
+
+	if err := pc.iceTransport.restartWithCredentials(pending.ufrag, pending.pwd); err != nil {
+		return err
+	}
+	pc.pendingICERestartCredentials.Store((*iceCredentials)(nil))
+
+	return nil
+}
+
 // hasLocalDescriptionChanged returns whether local media (rtpTransceivers) has changed
 // caller of this method should hold `pc.mu` lock.
 func (pc *PeerConnection) hasLocalDescriptionChanged(desc *SessionDescription) bool {
@@ -692,17 +762,8 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 		return SessionDescription{}, &rtcerr.InvalidStateError{Err: ErrConnectionClosed}
 	}
 
-	if options != nil && options.ICERestart {
-		if err := pc.iceTransport.restart(); err != nil {
-			return SessionDescription{}, err
-		}
-	}
-
-	var (
-		descr *sdp.SessionDescription
-		offer SessionDescription
-		err   error
-	)
+	var descr *sdp.SessionDescription
+	var offer SessionDescription
 
 	// This may be necessary to recompute if, for example, createOffer was called when only an
 	// audio RTCRtpTransceiver was added to connection, but while performing the in-parallel
@@ -711,6 +772,30 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 	count := 0
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
+
+	// Under pc.mu so a concurrent CreateOffer can't interleave and clobber
+	// pendingICERestartCredentials between preparing it here and reading it below.
+	prevPending, _ := pc.pendingICERestartCredentials.Load().(*iceCredentials)
+	if err := pc.prepareICERestartForOffer(options); err != nil {
+		return SessionDescription{}, err
+	}
+	// prepareICERestartForOffer stages pending before the SDP is built from it;
+	// roll back if offer generation fails so pending never diverges from lastOffer.
+	offerCommitted := false
+	defer func() {
+		if !offerCommitted {
+			pc.pendingICERestartCredentials.Store(prevPending)
+		}
+	}()
+
+	iceParams, err := pc.effectiveLocalICEParameters()
+	if err != nil {
+		return SessionDescription{}, err
+	}
+	candidates, err := pc.effectiveLocalCandidates()
+	if err != nil {
+		return SessionDescription{}, err
+	}
 	for {
 		// We cache current transceivers to ensure they aren't
 		// mutated during offer generation. We later check if they have
@@ -763,7 +848,7 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 		}
 
 		if pc.currentRemoteDescription == nil {
-			descr, err = pc.generateUnmatchedSDP(currentTransceivers, useIdentity)
+			descr, err = pc.generateUnmatchedSDP(currentTransceivers, useIdentity, iceParams, candidates)
 		} else {
 			descr, err = pc.generateMatchedSDP(
 				currentTransceivers,
@@ -771,6 +856,8 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 				true, /*includeUnmatched */
 				connectionRoleFromDtlsRole(defaultDtlsRoleOffer),
 				false,
+				iceParams,
+				candidates,
 			)
 		}
 
@@ -809,6 +896,7 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 	}
 
 	pc.lastOffer = offer.SDP
+	offerCommitted = true
 
 	return offer, nil
 }
@@ -947,12 +1035,25 @@ func (pc *PeerConnection) CreateAnswer(options *AnswerOptions) (SessionDescripti
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 
+	// An answer never proposes its own ICE restart, so unlike CreateOffer it
+	// always uses the live transport's current credentials/candidates directly.
+	iceParams, err := pc.iceGatherer.GetLocalParameters()
+	if err != nil {
+		return SessionDescription{}, err
+	}
+	candidates, err := pc.iceGatherer.GetLocalCandidates()
+	if err != nil {
+		return SessionDescription{}, err
+	}
+
 	descr, err := pc.generateMatchedSDP(
 		pc.rtpTransceivers,
 		useIdentity,
 		false, /*includeUnmatched */
 		connectionRole,
 		pc.api.settingEngine.ignoreRidPauseForRecv,
+		iceParams,
+		candidates,
 	)
 	if err != nil {
 		return SessionDescription{}, err
@@ -1131,6 +1232,12 @@ func (pc *PeerConnection) SetLocalDescription(desc SessionDescription) error {
 	}
 	if err := pc.setDescription(&desc, stateChangeOpSetLocal); err != nil {
 		return err
+	}
+
+	if desc.Type == SDPTypeOffer {
+		if err := pc.applyPendingICERestart(&desc); err != nil {
+			return err
+		}
 	}
 
 	currentTransceivers := append([]*RTPTransceiver{}, pc.GetTransceivers()...)
@@ -2857,22 +2964,14 @@ func (pc *PeerConnection) startRTP(
 func (pc *PeerConnection) generateUnmatchedSDP(
 	transceivers []*RTPTransceiver,
 	useIdentity bool,
+	iceParams ICEParameters,
+	candidates []ICECandidate,
 ) (*sdp.SessionDescription, error) {
 	desc, err := sdp.NewJSEPSessionDescription(useIdentity)
 	if err != nil {
 		return nil, err
 	}
 	desc.Attributes = append(desc.Attributes, sdp.Attribute{Key: sdp.AttrKeyMsidSemantic, Value: "WMS *"})
-
-	iceParams, err := pc.iceGatherer.GetLocalParameters()
-	if err != nil {
-		return nil, err
-	}
-
-	candidates, err := pc.iceGatherer.GetLocalCandidates()
-	if err != nil {
-		return nil, err
-	}
 
 	isPlanB := pc.configuration.SDPSemantics == SDPSemanticsPlanB
 	mediaSections := []mediaSection{}
@@ -2961,22 +3060,14 @@ func (pc *PeerConnection) generateMatchedSDP(
 	useIdentity, includeUnmatched bool,
 	connectionRole sdp.ConnectionRole,
 	ignoreRidPauseForRecv bool,
+	iceParams ICEParameters,
+	candidates []ICECandidate,
 ) (*sdp.SessionDescription, error) {
 	desc, err := sdp.NewJSEPSessionDescription(useIdentity)
 	if err != nil {
 		return nil, err
 	}
 	desc.Attributes = append(desc.Attributes, sdp.Attribute{Key: sdp.AttrKeyMsidSemantic, Value: "WMS *"})
-
-	iceParams, err := pc.iceGatherer.GetLocalParameters()
-	if err != nil {
-		return nil, err
-	}
-
-	candidates, err := pc.iceGatherer.GetLocalCandidates()
-	if err != nil {
-		return nil, err
-	}
 
 	var transceiver *RTPTransceiver
 	remoteDescription := pc.currentRemoteDescription

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -681,6 +681,13 @@ func (pc *PeerConnection) prepareICERestartForOffer(options *OfferOptions) error
 	return nil
 }
 
+// hasPendingICERestart reports whether a restart's credentials are staged but not yet applied.
+func (pc *PeerConnection) hasPendingICERestart() bool {
+	pending, _ := pc.pendingICERestartCredentials.Load().(*iceCredentials)
+
+	return pending != nil
+}
+
 // effectiveLocalICEParameters returns the ICE credentials CreateOffer proposes:
 // the pending restart's if one is staged, otherwise the live transport's.
 func (pc *PeerConnection) effectiveLocalICEParameters() (ICEParameters, error) {

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -913,6 +913,192 @@ func TestMulticastDNSHostNameConnection(t *testing.T) {
 	}
 }
 
+// Assert that CreateOffer(ICERestart) alone does not touch the live ICE transport.
+func TestPeerConnection_CreateOffer_ICERestart_DoesNotMutateLiveTransport(t *testing.T) {
+	defer test.TimeOut(time.Second * 10).Stop()
+	defer test.CheckRoutines(t)()
+
+	pc, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, pc.Close()) }()
+
+	_, err = pc.AddTransceiverFromKind(RTPCodecTypeVideo)
+	assert.NoError(t, err)
+
+	offer1, err := pc.CreateOffer(nil)
+	assert.NoError(t, err)
+	assert.NoError(t, pc.SetLocalDescription(offer1))
+
+	before, err := pc.iceGatherer.GetLocalParameters()
+	assert.NoError(t, err)
+
+	_, err = pc.CreateOffer(&OfferOptions{ICERestart: true})
+	assert.NoError(t, err)
+
+	after, err := pc.iceGatherer.GetLocalParameters()
+	assert.NoError(t, err)
+	assert.Equal(t, before.UsernameFragment, after.UsernameFragment)
+	assert.Equal(t, before.Password, after.Password)
+}
+
+// Assert that a CreateOffer(ICERestart) racing a concurrent CreateOffer(nil) always proposes
+// new credentials: pc.mu serializes the two calls so neither clobbers the other's pending
+// restart. Such a clobber is a logical race -race can't catch, hence the stress loop.
+func TestPeerConnection_CreateOffer_ICERestart_ConcurrentWithPlainOffer(t *testing.T) {
+	defer test.TimeOut(time.Second * 30).Stop()
+	defer test.CheckRoutines(t)()
+
+	pc, err := NewPeerConnection(Configuration{})
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, pc.Close()) }()
+
+	_, err = pc.AddTransceiverFromKind(RTPCodecTypeVideo)
+	assert.NoError(t, err)
+	offer1, err := pc.CreateOffer(nil)
+	assert.NoError(t, err)
+	assert.NoError(t, pc.SetLocalDescription(offer1))
+
+	live, err := pc.iceGatherer.GetLocalParameters()
+	assert.NoError(t, err)
+
+	// Fire all iterations without a barrier between them so restart and plain
+	// offer calls stay under sustained concurrent pressure.
+	const iterations = 200
+	proposedUfrags := make([]string, iterations)
+	var wg sync.WaitGroup
+	wg.Add(iterations * 2)
+	for i := range iterations {
+		go func() {
+			defer wg.Done()
+			restartOffer, err := pc.CreateOffer(&OfferOptions{ICERestart: true})
+			assert.NoError(t, err)
+			proposed, err := extractICEDetails(restartOffer.parsed, pc.log)
+			assert.NoError(t, err)
+			proposedUfrags[i] = proposed.Ufrag
+		}()
+		go func() {
+			defer wg.Done()
+			_, err := pc.CreateOffer(nil)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	for i, ufrag := range proposedUfrags {
+		assert.NotEqualf(t, live.UsernameFragment, ufrag, "iteration %d", i)
+	}
+}
+
+// Assert that credentials CreateOffer(ICERestart) proposes apply to the transport only once committed.
+func TestPeerConnection_SetLocalDescription_AppliesPendingICERestart(t *testing.T) {
+	defer test.TimeOut(time.Second * 10).Stop()
+	defer test.CheckRoutines(t)()
+
+	pcOffer, pcAnswer, err := newPair()
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, pcOffer.Close()) }()
+	defer func() { assert.NoError(t, pcAnswer.Close()) }()
+
+	_, err = pcOffer.AddTransceiverFromKind(RTPCodecTypeVideo)
+	assert.NoError(t, err)
+	assert.NoError(t, signalPair(pcOffer, pcAnswer))
+
+	before, err := pcOffer.iceGatherer.GetLocalParameters()
+	assert.NoError(t, err)
+
+	offer2, err := pcOffer.CreateOffer(&OfferOptions{ICERestart: true})
+	assert.NoError(t, err)
+	proposed, err := extractICEDetails(offer2.parsed, pcOffer.log)
+	assert.NoError(t, err)
+	assert.NotEqual(t, before.UsernameFragment, proposed.Ufrag)
+
+	stillBefore, err := pcOffer.iceGatherer.GetLocalParameters()
+	assert.NoError(t, err)
+	assert.Equal(t, before.UsernameFragment, stillBefore.UsernameFragment)
+
+	assert.NoError(t, pcOffer.SetLocalDescription(offer2))
+
+	after, err := pcOffer.iceGatherer.GetLocalParameters()
+	assert.NoError(t, err)
+	assert.Equal(t, proposed.Ufrag, after.UsernameFragment)
+}
+
+// Assert that a GatheringCompletePromise created after CreateOffer(ICERestart) but before
+// SetLocalDescription resolves against the new gathering cycle, not the previous one's Complete state.
+func TestPeerConnection_ICERestart_GatheringCompletePromiseAwaitsNewCycle(t *testing.T) {
+	defer test.TimeOut(time.Second * 30).Stop()
+	defer test.CheckRoutines(t)()
+
+	pcOffer, pcAnswer, err := newPair()
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, pcOffer.Close()) }()
+	defer func() { assert.NoError(t, pcAnswer.Close()) }()
+
+	_, err = pcOffer.AddTransceiverFromKind(RTPCodecTypeVideo)
+	assert.NoError(t, err)
+	assert.NoError(t, signalPair(pcOffer, pcAnswer))
+
+	offer2, err := pcOffer.CreateOffer(&OfferOptions{ICERestart: true})
+	assert.NoError(t, err)
+	gatherComplete := GatheringCompletePromise(pcOffer)
+
+	select {
+	case <-gatherComplete:
+		assert.Fail(t, "promise resolved against the stale gathering cycle before SetLocalDescription")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	assert.NoError(t, pcOffer.SetLocalDescription(offer2))
+	<-gatherComplete
+}
+
+// Assert that a CreateOffer(ICERestart) superseded by a plain CreateOffer leaves the live
+// transport untouched: applying the plain offer must not restart with the abandoned credentials.
+func TestPeerConnection_CreateOffer_ICERestart_SupersededByPlainOffer_LeavesTransportIntact(t *testing.T) {
+	defer test.TimeOut(time.Second * 10).Stop()
+	defer test.CheckRoutines(t)()
+
+	pcOffer, pcAnswer, err := newPair()
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, pcOffer.Close()) }()
+	defer func() { assert.NoError(t, pcAnswer.Close()) }()
+
+	_, err = pcOffer.AddTransceiverFromKind(RTPCodecTypeVideo)
+	assert.NoError(t, err)
+	assert.NoError(t, signalPair(pcOffer, pcAnswer))
+
+	before, err := pcOffer.iceGatherer.GetLocalParameters()
+	assert.NoError(t, err)
+
+	restartOffer, err := pcOffer.CreateOffer(&OfferOptions{ICERestart: true})
+	assert.NoError(t, err)
+	proposed, err := extractICEDetails(restartOffer.parsed, pcOffer.log)
+	assert.NoError(t, err)
+	assert.NotEqual(t, before.UsernameFragment, proposed.Ufrag)
+
+	plainOffer, err := pcOffer.CreateOffer(nil)
+	assert.NoError(t, err)
+	assert.NoError(t, pcOffer.SetLocalDescription(plainOffer))
+
+	after, err := pcOffer.iceGatherer.GetLocalParameters()
+	assert.NoError(t, err)
+	assert.Equal(t, before.UsernameFragment, after.UsernameFragment)
+}
+
+// Assert that generateICECredentials returns distinct values clearing the ICE minimums.
+func TestGenerateICECredentials(t *testing.T) {
+	first, err := generateICECredentials()
+	assert.NoError(t, err)
+	// Must clear the ICE credential minimums (RFC 8445 section 5.3).
+	assert.GreaterOrEqual(t, len(first.ufrag), 4)
+	assert.GreaterOrEqual(t, len(first.pwd), 22)
+
+	second, err := generateICECredentials()
+	assert.NoError(t, err)
+	assert.NotEqual(t, first.ufrag, second.ufrag)
+	assert.NotEqual(t, first.pwd, second.pwd)
+}
+
 func TestICERestart(t *testing.T) {
 	extractCandidates := func(sdp string) (candidates []string) {
 		sc := bufio.NewScanner(strings.NewReader(sdp))

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -505,6 +505,11 @@ func (pc *PeerConnection) ConnectionState() PeerConnectionState {
 	return newPeerConnectionState(rawState)
 }
 
+// hasPendingICERestart is always false in the WASM build; the browser performs the ICE restart.
+func (pc *PeerConnection) hasPendingICERestart() bool {
+	return false
+}
+
 func (pc *PeerConnection) setGatherCompleteHandler(handler func()) {
 	pc.onGatherCompleteHandler = handler
 


### PR DESCRIPTION
`CreateOffer(&OfferOptions{ICERestart: true})` restarts the ICE transport immediately, before the offer is ever applied. The restart synchronously drops the selected candidate pair and moves the connection back to checking, so merely creating a restart offer tears down an active connection whether or not the offer is ever used.

The iceRestart definition states "Applying the generated description will restart ICE" ([webrtc-pc §4.2.6](https://www.w3.org/TR/webrtc/#dom-rtcofferoptions-icerestart)), so creating the offer should not.

## Fix

Generate the new ICE credentials and hold them pending, applying them to the transport only when `SetLocalDescription` commits the offer. While pending, the offer advertises the new credentials but the live transport keeps the old ones, so an unused restart offer no longer drops the connection.

Deferring the restart also defers its gathering cycle to `SetLocalDescription`. A `GatheringCompletePromise` created in between would otherwise resolve against the previous cycle's Complete state; it now waits for the new cycle, so non-trickle callers need no change.

## Behavior note

The restart now takes effect at `SetLocalDescription` rather than at `CreateOffer`. Standard `CreateOffer` → `SetLocalDescription` flows and `GatheringCompletePromise` are unaffected. The narrow observable change: code that created a restart offer and relied on the transport restarting before (or without) applying it now sees the restart only once `SetLocalDescription` commits the offer.

An offerer ICE restart now proposes freshly generated credentials rather than any static ufrag/pwd configured via `SetICECredentials`, so the restart's credentials always differ from the current ones (webrtc-pc §4.2.6). The answerer's restart path is unchanged here.

## Testing

- `CreateOffer(ICERestart)` no longer mutates the live transport, and the proposed credentials apply only once `SetLocalDescription` commits the offer.
- A `GatheringCompletePromise` created before `SetLocalDescription` resolves against the new gathering cycle.
- Concurrent `CreateOffer(ICERestart)` / `CreateOffer(nil)` calls, serialized by `pc.mu`, always propose new credentials.
- `go test -race` across the ICE-restart and signaling suites; `golangci-lint` clean.
