### PR TITLE
Fix #2867

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -121,10 +121,14 @@ func (r *SCTPTransport) GetCapabilities() SCTPCapabilities {
 //
 //nolint:cyclop
 func (r *SCTPTransport) Start(capabilities SCTPCapabilities) error {
-	if r.isStarted {
+	r.lock.Lock()
+	if r.isStarted || r.state == SCTPTransportStateClosed {
+		r.lock.Unlock()
+
 		return nil
 	}
 	r.isStarted = true
+	r.lock.Unlock()
 
 	maxMessageSize := capabilities.MaxMessageSize
 	if maxMessageSize == 0 {
@@ -149,6 +153,12 @@ func (r *SCTPTransport) Start(capabilities SCTPCapabilities) error {
 	}
 
 	r.lock.Lock()
+	if r.state == SCTPTransportStateClosed {
+		r.lock.Unlock()
+		sctpAssociation.Abort("")
+
+		return nil
+	}
 	r.sctpAssociation = sctpAssociation
 	r.state = SCTPTransportStateConnected
 	dataChannels := append([]*DataChannel{}, r.dataChannels...)
@@ -228,6 +238,9 @@ func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
 func (r *SCTPTransport) Stop() error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
+
+	r.state = SCTPTransportStateClosed
+
 	if r.sctpAssociation == nil {
 		return nil
 	}
@@ -235,7 +248,6 @@ func (r *SCTPTransport) Stop() error {
 	r.sctpAssociation.Abort("")
 
 	r.sctpAssociation = nil
-	r.state = SCTPTransportStateClosed
 
 	return nil
 }


### PR DESCRIPTION
#### Description
This fixes #2867. `Stop()` now changes the state to closed always, and `Start()` checks the state twice, once at the start and once before allocating an association, and aborting in case `Stop()` was called during the handshake.

#### Testing
The only way I could test this locally is by sleeping inside `Start()`.
Add a hook to `sctptransport.go`:
```Go
var sctpStartDelay = func(*SCTPTransport) {}
```
And call it in line 150:
```Go
sctpStartDelay(r)
```

And test:
```Go
func TestSCTPTransportStartStopRace(t *testing.T) {
	const startDelay = 3 * time.Second

	offerPC, answerPC, err := newPair()
	require.NoError(t, err)

	defer closePairNow(t, offerPC, answerPC)

	answerSCTP := answerPC.SCTP()
	inStart := make(chan struct{})

	sctpStartDelay = func(r *SCTPTransport) {
		if r != answerSCTP {
			return
		}

		close(inStart)
		time.Sleep(startDelay)
	}

	_, err = offerPC.CreateDataChannel("race", nil)
	require.NoError(t, err)

	require.NoError(t, signalPair(offerPC, answerPC))

	<-inStart

	require.NoError(t, answerPC.Close())

	time.Sleep(startDelay)


	// wasn't the main issue, but this passes too now
	// assert.Equal(t, SCTPTransportStateClosed, answerSCTP.State())
	assert.Nil(t, answerSCTP.association())
}
```