### PR TITLE
Reuse DataChannel IDs safely within negotiated SCTP limits

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -183,10 +183,10 @@ func (d *DataChannel) open(sctpTransport *SCTPTransport) error { //nolint:cyclop
 
 		return err
 	}
-	d.sctpTransport.registerLocalDataChannelStream(stream)
+	generation := d.sctpTransport.registerLocalDataChannelGeneration(*d.id)
 	dc, err := datachannel.Client(stream, cfg)
 	if err != nil {
-		d.sctpTransport.unregisterLocalDataChannelStream(stream)
+		d.sctpTransport.unregisterLocalDataChannelGeneration(*d.id, generation)
 		d.mu.Unlock()
 
 		return err

--- a/datachannel.go
+++ b/datachannel.go
@@ -39,6 +39,7 @@ type DataChannel struct {
 	detachCalled               bool
 	readLoopActive             chan struct{}
 	isGracefulClosed           bool
+	isRemote                   bool
 
 	// The binaryType represents attribute MUST, on getting, return the value to
 	// which it was last set. On setting, if the new value is either the string
@@ -335,6 +336,7 @@ func (d *DataChannel) onMessage(msg DataChannelMessage) {
 
 func (d *DataChannel) handleOpen(dc *datachannel.DataChannel, isRemote, isAlreadyNegotiated bool) {
 	d.mu.Lock()
+	d.isRemote = isRemote
 	if d.isGracefulClosed { // The channel was closed during the connecting state
 		d.mu.Unlock()
 		if err := dc.Close(); err != nil {

--- a/datachannel.go
+++ b/datachannel.go
@@ -177,6 +177,11 @@ func (d *DataChannel) open(sctpTransport *SCTPTransport) error { //nolint:cyclop
 		d.mu.Lock()
 		d.id = dcID
 	}
+	if *d.id >= sctpTransport.MaxChannels() {
+		d.mu.Unlock()
+
+		return &rtcerr.OperationError{Err: ErrMaxDataChannelID}
+	}
 	stream, err := association.OpenStream(*d.id, sctp.PayloadTypeWebRTCBinary)
 	if err != nil {
 		d.mu.Unlock()

--- a/datachannel.go
+++ b/datachannel.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pion/datachannel"
 	"github.com/pion/logging"
+	"github.com/pion/sctp"
 	"github.com/pion/webrtc/v4/pkg/rtcerr"
 )
 
@@ -39,7 +40,6 @@ type DataChannel struct {
 	detachCalled               bool
 	readLoopActive             chan struct{}
 	isGracefulClosed           bool
-	isRemote                   bool
 
 	// The binaryType represents attribute MUST, on getting, return the value to
 	// which it was last set. On setting, if the new value is either the string
@@ -177,8 +177,16 @@ func (d *DataChannel) open(sctpTransport *SCTPTransport) error { //nolint:cyclop
 		d.mu.Lock()
 		d.id = dcID
 	}
-	dc, err := datachannel.Dial(association, *d.id, cfg)
+	stream, err := association.OpenStream(*d.id, sctp.PayloadTypeWebRTCBinary)
 	if err != nil {
+		d.mu.Unlock()
+
+		return err
+	}
+	d.sctpTransport.registerLocalDataChannelStream(stream)
+	dc, err := datachannel.Client(stream, cfg)
+	if err != nil {
+		d.sctpTransport.unregisterLocalDataChannelStream(stream)
 		d.mu.Unlock()
 
 		return err
@@ -336,7 +344,6 @@ func (d *DataChannel) onMessage(msg DataChannelMessage) {
 
 func (d *DataChannel) handleOpen(dc *datachannel.DataChannel, isRemote, isAlreadyNegotiated bool) {
 	d.mu.Lock()
-	d.isRemote = isRemote
 	if d.isGracefulClosed { // The channel was closed during the connecting state
 		d.mu.Unlock()
 		if err := dc.Close(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260807061109-637102c36664
+replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260807094155-cb2d223c9f55

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260806123009-d6d45c28955c
+replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260806143535-4889afb0bdcb

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260806150545-1314565dcbc5
+replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260807033615-feaa3689bd19

--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,5 @@ require (
 	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260806123009-d6d45c28955c

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260806143535-4889afb0bdcb
+replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260806150545-1314565dcbc5

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260807053818-db7098874774
+replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260807061109-637102c36664

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260807033615-feaa3689bd19
+replace github.com/pion/sctp => github.com/GizClaw/pion-sctp v0.0.0-20260807053818-db7098874774

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/pion-sctp v0.0.0-20260806143535-4889afb0bdcb h1:qnnCWZ8opOAA4tPF7e5EAQ4unr8zvsrkZN+DC7Rq3IY=
-github.com/GizClaw/pion-sctp v0.0.0-20260806143535-4889afb0bdcb/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
+github.com/GizClaw/pion-sctp v0.0.0-20260806150545-1314565dcbc5 h1:s+8wtkBW4dwotUFT9gzkA/Ct7nqjk8N6r53+LtvREyM=
+github.com/GizClaw/pion-sctp v0.0.0-20260806150545-1314565dcbc5/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/pion-sctp v0.0.0-20260807033615-feaa3689bd19 h1:o4mHQmK7t1n2GvM9T4bV962N0XJpDFnMDIs4Q9bSjd0=
-github.com/GizClaw/pion-sctp v0.0.0-20260807033615-feaa3689bd19/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
+github.com/GizClaw/pion-sctp v0.0.0-20260807053818-db7098874774 h1:PGYsxXpcdkBAv4knL4o0Ja6kdfVsHB+jyvUSwqDs034=
+github.com/GizClaw/pion-sctp v0.0.0-20260807053818-db7098874774/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/pion-sctp v0.0.0-20260806123009-d6d45c28955c h1:/tiyfYTY8lB91pQYJo/dC/tWUJQicOZ18uTp1fZuRd4=
-github.com/GizClaw/pion-sctp v0.0.0-20260806123009-d6d45c28955c/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
+github.com/GizClaw/pion-sctp v0.0.0-20260806143535-4889afb0bdcb h1:qnnCWZ8opOAA4tPF7e5EAQ4unr8zvsrkZN+DC7Rq3IY=
+github.com/GizClaw/pion-sctp v0.0.0-20260806143535-4889afb0bdcb/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/pion-sctp v0.0.0-20260807061109-637102c36664 h1:hKI/MXkEZWitIlvwKzcPYNIYAhuqKMZrKuyLezkMzJQ=
-github.com/GizClaw/pion-sctp v0.0.0-20260807061109-637102c36664/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
+github.com/GizClaw/pion-sctp v0.0.0-20260807094155-cb2d223c9f55 h1:HILgBYgRz7HVr1q/m1hNrFPfbhXZoY10j8uekoyEu+I=
+github.com/GizClaw/pion-sctp v0.0.0-20260807094155-cb2d223c9f55/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/pion-sctp v0.0.0-20260806150545-1314565dcbc5 h1:s+8wtkBW4dwotUFT9gzkA/Ct7nqjk8N6r53+LtvREyM=
-github.com/GizClaw/pion-sctp v0.0.0-20260806150545-1314565dcbc5/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
+github.com/GizClaw/pion-sctp v0.0.0-20260807033615-feaa3689bd19 h1:o4mHQmK7t1n2GvM9T4bV962N0XJpDFnMDIs4Q9bSjd0=
+github.com/GizClaw/pion-sctp v0.0.0-20260807033615-feaa3689bd19/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/pion-sctp v0.0.0-20260807053818-db7098874774 h1:PGYsxXpcdkBAv4knL4o0Ja6kdfVsHB+jyvUSwqDs034=
-github.com/GizClaw/pion-sctp v0.0.0-20260807053818-db7098874774/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
+github.com/GizClaw/pion-sctp v0.0.0-20260807061109-637102c36664 h1:hKI/MXkEZWitIlvwKzcPYNIYAhuqKMZrKuyLezkMzJQ=
+github.com/GizClaw/pion-sctp v0.0.0-20260807061109-637102c36664/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/GizClaw/pion-sctp v0.0.0-20260806123009-d6d45c28955c h1:/tiyfYTY8lB91pQYJo/dC/tWUJQicOZ18uTp1fZuRd4=
+github.com/GizClaw/pion-sctp v0.0.0-20260806123009-d6d45c28955c/go.mod h1:UeyX8aRca892UhRetke5BTkhvISxX/wiBdLl+njo1Lo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -55,8 +57,6 @@ github.com/pion/rtcp v1.2.17 h1:PxiT6L79yPZKtXIsXdG1eakBl6dtBj4x+4oVEL0DlSw=
 github.com/pion/rtcp v1.2.17/go.mod h1:7kBpuBJaWwax4hzc/pgexY8vkOpvh8atgYDbaKZq0iU=
 github.com/pion/rtp v1.10.5 h1:ip0HhO/wYZqQ4bKS+R99KnZh/GRCmIT0jDXikub7vlE=
 github.com/pion/rtp v1.10.5/go.mod h1:Au8fc6cEByy8RLTwKTQTEeQqDB/SJDxwL4mZuxYA5Pk=
-github.com/pion/sctp v1.11.1 h1:O4dIFyURw1KTST7w+gtD4gLeYXkhPa0xXLHMMoe/OSA=
-github.com/pion/sctp v1.11.1/go.mod h1:7KFmTwLcoYgJs/Z+99nJvsWL0qDpuyloSI0RbAqlrz0=
 github.com/pion/sdp/v3 v3.0.19 h1:1VMKs3gIkTQV5M3hNKfTAPrDXSNrYtOlmOD8+mSZUGQ=
 github.com/pion/sdp/v3 v3.0.19/go.mod h1:dE5WOSlzXrtiE/iuZqe9n+AcEbOjtAd3k5m5NtlV/qU=
 github.com/pion/srtp/v3 v3.0.13 h1:FmQaqgNbN1vUtMhEsmj8trldc3lNZr1xmN7nl8CyX+Q=

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2458,6 +2458,8 @@ func (pc *PeerConnection) CreateDataChannel(label string, options *DataChannelIn
 	// If SCTP already connected open all the channels
 	if pc.sctpTransport.State() == SCTPTransportStateConnected {
 		if err = dataChannel.open(pc.sctpTransport); err != nil {
+			pc.sctpTransport.discardFailedDataChannel(dataChannel)
+
 			return nil, err
 		}
 	}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2450,7 +2450,7 @@ func (pc *PeerConnection) CreateDataChannel(label string, options *DataChannelIn
 	pc.sctpTransport.lock.Lock()
 	pc.sctpTransport.dataChannels = append(pc.sctpTransport.dataChannels, dataChannel)
 	if dataChannel.ID() != nil {
-		pc.sctpTransport.dataChannelIDsUsed[*dataChannel.ID()] = struct{}{}
+		pc.sctpTransport.dataChannelIDsUsed[*dataChannel.ID()]++
 	}
 	pc.sctpTransport.dataChannelsRequested++
 	pc.sctpTransport.lock.Unlock()

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -74,11 +74,13 @@ type SCTPTransport struct {
 	dataChannelIDsUsed map[uint16]uint32
 	// Detach removes DataChannels from dataChannels before their ACK can arrive.
 	// Keep each locally opened stream generation classified independently from
-	// that garbage-collection list until its reset completes.
-	localDataChannelStreams map[uint16][]*sctp.Stream
-	dataChannelsOpened      uint32
-	dataChannelsRequested   uint32
-	dataChannelsAccepted    uint32
+	// that garbage-collection list until its reset completes. SCTP may recreate
+	// the Go Stream object for the same ID while completing a reset, so identity
+	// here must be the ordered generation, not a Stream pointer.
+	localDataChannelGenerations map[uint16][]*localDataChannelGeneration
+	dataChannelsOpened          uint32
+	dataChannelsRequested       uint32
+	dataChannelsAccepted        uint32
 
 	localSctpInit []byte
 
@@ -91,12 +93,12 @@ type SCTPTransport struct {
 // meant to be used together with the basic WebRTC API.
 func (api *API) NewSCTPTransport(dtls *DTLSTransport) *SCTPTransport {
 	res := &SCTPTransport{
-		dtlsTransport:           dtls,
-		state:                   SCTPTransportStateConnecting,
-		api:                     api,
-		log:                     api.settingEngine.LoggerFactory.NewLogger("ortc"),
-		dataChannelIDsUsed:      make(map[uint16]uint32),
-		localDataChannelStreams: make(map[uint16][]*sctp.Stream),
+		dtlsTransport:               dtls,
+		state:                       SCTPTransportStateConnecting,
+		api:                         api,
+		log:                         api.settingEngine.LoggerFactory.NewLogger("ortc"),
+		dataChannelIDsUsed:          make(map[uint16]uint32),
+		localDataChannelGenerations: make(map[uint16][]*localDataChannelGeneration),
 	}
 
 	res.updateMaxChannels()
@@ -371,7 +373,7 @@ func (r *SCTPTransport) acceptDataChannel(
 	}
 
 	stream.SetDefaultPayloadType(sctp.PayloadTypeWebRTCBinary)
-	if r.isLocalDataChannelStream(stream) {
+	if r.acceptLocalDataChannelGeneration(stream.StreamIdentifier()) {
 		return nil, true, nil
 	}
 
@@ -385,22 +387,30 @@ func (r *SCTPTransport) acceptDataChannel(
 	return dc, false, nil
 }
 
-func (r *SCTPTransport) registerLocalDataChannelStream(stream *sctp.Stream) {
-	r.lock.Lock()
-	if r.localDataChannelStreams == nil {
-		r.localDataChannelStreams = make(map[uint16][]*sctp.Stream)
-	}
-	streamID := stream.StreamIdentifier()
-	r.localDataChannelStreams[streamID] = append(r.localDataChannelStreams[streamID], stream)
-	r.lock.Unlock()
+type localDataChannelGeneration struct {
+	accepted bool
 }
 
-func (r *SCTPTransport) isLocalDataChannelStream(stream *sctp.Stream) bool {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
+func (r *SCTPTransport) registerLocalDataChannelGeneration(streamID uint16) *localDataChannelGeneration {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.localDataChannelGenerations == nil {
+		r.localDataChannelGenerations = make(map[uint16][]*localDataChannelGeneration)
+	}
+	generation := &localDataChannelGeneration{}
+	r.localDataChannelGenerations[streamID] = append(r.localDataChannelGenerations[streamID], generation)
 
-	for _, localStream := range r.localDataChannelStreams[stream.StreamIdentifier()] {
-		if localStream == stream {
+	return generation
+}
+
+func (r *SCTPTransport) acceptLocalDataChannelGeneration(streamID uint16) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for _, generation := range r.localDataChannelGenerations[streamID] {
+		if !generation.accepted {
+			generation.accepted = true
+
 			return true
 		}
 	}
@@ -408,21 +418,23 @@ func (r *SCTPTransport) isLocalDataChannelStream(stream *sctp.Stream) bool {
 	return false
 }
 
-func (r *SCTPTransport) unregisterLocalDataChannelStream(stream *sctp.Stream) {
+func (r *SCTPTransport) unregisterLocalDataChannelGeneration(
+	streamID uint16,
+	generation *localDataChannelGeneration,
+) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	streamID := stream.StreamIdentifier()
-	localStreams := r.localDataChannelStreams[streamID]
-	for i := range localStreams {
-		if localStreams[i] != stream {
+	generations := r.localDataChannelGenerations[streamID]
+	for i := range generations {
+		if generations[i] != generation {
 			continue
 		}
-		localStreams = append(localStreams[:i], localStreams[i+1:]...)
-		if len(localStreams) == 0 {
-			delete(r.localDataChannelStreams, streamID)
+		generations = append(generations[:i], generations[i+1:]...)
+		if len(generations) == 0 {
+			delete(r.localDataChannelGenerations, streamID)
 		} else {
-			r.localDataChannelStreams[streamID] = localStreams
+			r.localDataChannelGenerations[streamID] = generations
 		}
 
 		return
@@ -530,10 +542,10 @@ func maxChannelsForAssociation(association *sctp.Association) *uint16 {
 
 func (r *SCTPTransport) releaseDataChannelID(streamID uint16) {
 	r.lock.Lock()
-	if localStreams := r.localDataChannelStreams[streamID]; len(localStreams) <= 1 {
-		delete(r.localDataChannelStreams, streamID)
+	if generations := r.localDataChannelGenerations[streamID]; len(generations) <= 1 {
+		delete(r.localDataChannelGenerations, streamID)
 	} else {
-		r.localDataChannelStreams[streamID] = localStreams[1:]
+		r.localDataChannelGenerations[streamID] = generations[1:]
 	}
 	if r.dataChannelIDsUsed[streamID] > 1 {
 		r.dataChannelIDsUsed[streamID]--

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -71,10 +71,14 @@ type SCTPTransport struct {
 	dataChannels []*DataChannel
 	// Count reservations because a reused stream can arrive before the old
 	// generation's reset-complete callback runs on this association.
-	dataChannelIDsUsed    map[uint16]uint32
-	dataChannelsOpened    uint32
-	dataChannelsRequested uint32
-	dataChannelsAccepted  uint32
+	dataChannelIDsUsed map[uint16]uint32
+	// Detach removes DataChannels from dataChannels before their ACK can arrive.
+	// Keep each locally opened stream generation classified independently from
+	// that garbage-collection list until its reset completes.
+	localDataChannelStreams map[uint16][]*sctp.Stream
+	dataChannelsOpened      uint32
+	dataChannelsRequested   uint32
+	dataChannelsAccepted    uint32
 
 	localSctpInit []byte
 
@@ -87,11 +91,12 @@ type SCTPTransport struct {
 // meant to be used together with the basic WebRTC API.
 func (api *API) NewSCTPTransport(dtls *DTLSTransport) *SCTPTransport {
 	res := &SCTPTransport{
-		dtlsTransport:      dtls,
-		state:              SCTPTransportStateConnecting,
-		api:                api,
-		log:                api.settingEngine.LoggerFactory.NewLogger("ortc"),
-		dataChannelIDsUsed: make(map[uint16]uint32),
+		dtlsTransport:           dtls,
+		state:                   SCTPTransportStateConnecting,
+		api:                     api,
+		log:                     api.settingEngine.LoggerFactory.NewLogger("ortc"),
+		dataChannelIDsUsed:      make(map[uint16]uint32),
+		localDataChannelStreams: make(map[uint16][]*sctp.Stream),
 	}
 
 	res.updateMaxChannels()
@@ -366,22 +371,9 @@ func (r *SCTPTransport) acceptDataChannel(
 	}
 
 	stream.SetDefaultPayloadType(sctp.PayloadTypeWebRTCBinary)
-	streamID := stream.StreamIdentifier()
-
-	r.lock.RLock()
-	for i := len(r.dataChannels) - 1; i >= 0; i-- {
-		dc := r.dataChannels[i]
-		dc.mu.RLock()
-		isLocalMatch := !dc.isRemote && dc.id != nil && *dc.id == streamID &&
-			dc.ReadyState() != DataChannelStateClosed
-		dc.mu.RUnlock()
-		if isLocalMatch {
-			r.lock.RUnlock()
-
-			return nil, true, nil
-		}
+	if r.isLocalDataChannelStream(stream) {
+		return nil, true, nil
 	}
-	r.lock.RUnlock()
 
 	dc, err := datachannel.Server(stream, &datachannel.Config{
 		LoggerFactory: r.api.settingEngine.LoggerFactory,
@@ -391,6 +383,50 @@ func (r *SCTPTransport) acceptDataChannel(
 	}
 
 	return dc, false, nil
+}
+
+func (r *SCTPTransport) registerLocalDataChannelStream(stream *sctp.Stream) {
+	r.lock.Lock()
+	if r.localDataChannelStreams == nil {
+		r.localDataChannelStreams = make(map[uint16][]*sctp.Stream)
+	}
+	streamID := stream.StreamIdentifier()
+	r.localDataChannelStreams[streamID] = append(r.localDataChannelStreams[streamID], stream)
+	r.lock.Unlock()
+}
+
+func (r *SCTPTransport) isLocalDataChannelStream(stream *sctp.Stream) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	for _, localStream := range r.localDataChannelStreams[stream.StreamIdentifier()] {
+		if localStream == stream {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *SCTPTransport) unregisterLocalDataChannelStream(stream *sctp.Stream) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	streamID := stream.StreamIdentifier()
+	localStreams := r.localDataChannelStreams[streamID]
+	for i := range localStreams {
+		if localStreams[i] != stream {
+			continue
+		}
+		localStreams = append(localStreams[:i], localStreams[i+1:]...)
+		if len(localStreams) == 0 {
+			delete(r.localDataChannelStreams, streamID)
+		} else {
+			r.localDataChannelStreams[streamID] = localStreams
+		}
+
+		return
+	}
 }
 
 // OnError sets an event handler which is invoked when the SCTP Association errors.
@@ -494,6 +530,11 @@ func maxChannelsForAssociation(association *sctp.Association) *uint16 {
 
 func (r *SCTPTransport) releaseDataChannelID(streamID uint16) {
 	r.lock.Lock()
+	if localStreams := r.localDataChannelStreams[streamID]; len(localStreams) <= 1 {
+		delete(r.localDataChannelStreams, streamID)
+	} else {
+		r.localDataChannelStreams[streamID] = localStreams[1:]
+	}
 	if r.dataChannelIDsUsed[streamID] > 1 {
 		r.dataChannelIDsUsed[streamID]--
 	} else {

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -172,6 +172,7 @@ func (r *SCTPTransport) Start(capabilities SCTPCapabilities) error {
 		if d.ReadyState() == DataChannelStateConnecting {
 			err := d.open(r)
 			if err != nil {
+				r.discardFailedDataChannel(d)
 				r.log.Warnf("failed to open data channel: %s", err)
 
 				continue
@@ -547,12 +548,37 @@ func (r *SCTPTransport) releaseDataChannelID(streamID uint16) {
 	} else {
 		r.localDataChannelGenerations[streamID] = generations[1:]
 	}
+	r.releaseDataChannelReservationLocked(streamID)
+	r.lock.Unlock()
+}
+
+func (r *SCTPTransport) discardFailedDataChannel(dataChannel *DataChannel) {
+	streamID := dataChannel.ID()
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for i, existing := range r.dataChannels {
+		if existing != dataChannel {
+			continue
+		}
+		copy(r.dataChannels[i:], r.dataChannels[i+1:])
+		r.dataChannels[len(r.dataChannels)-1] = nil
+		r.dataChannels = r.dataChannels[:len(r.dataChannels)-1]
+
+		break
+	}
+	if streamID != nil {
+		r.releaseDataChannelReservationLocked(*streamID)
+	}
+}
+
+// The caller should hold the SCTPTransport lock.
+func (r *SCTPTransport) releaseDataChannelReservationLocked(streamID uint16) {
 	if r.dataChannelIDsUsed[streamID] > 1 {
 		r.dataChannelIDsUsed[streamID]--
 	} else {
 		delete(r.dataChannelIDsUsed, streamID)
 	}
-	r.lock.Unlock()
 }
 
 // MaxChannels is the maximum number of RTCDataChannels that can be open simultaneously.

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -194,7 +194,7 @@ func (r *SCTPTransport) sctpClientOptions(netConn net.Conn, maxMessageSize uint3
 }
 
 func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
-	opts := make([]sctp.ClientOption, 0, 7)
+	opts := make([]sctp.ClientOption, 0, 8)
 
 	if r.api.settingEngine.sctp.maxReceiveBufferSize != 0 {
 		opts = append(opts, sctp.WithMaxReceiveBufferSize(r.api.settingEngine.sctp.maxReceiveBufferSize))
@@ -212,6 +212,15 @@ func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
 		opts = append(
 			opts,
 			sctp.WithRTOMax(float64(r.api.settingEngine.sctp.rtoMax)/float64(time.Millisecond)),
+		)
+	}
+
+	if r.api.settingEngine.sctp.handshakeRTOMax > 0 {
+		opts = append(
+			opts,
+			sctp.WithHandshakeRTOMax(
+				float64(r.api.settingEngine.sctp.handshakeRTOMax)/float64(time.Millisecond),
+			),
 		)
 	}
 

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -177,7 +177,7 @@ func (r *SCTPTransport) Start(capabilities SCTPCapabilities) error {
 	r.dataChannelsOpened += openedDCCount
 	r.lock.Unlock()
 
-	go r.acceptDataChannels(sctpAssociation, dataChannels)
+	go r.acceptDataChannels(sctpAssociation)
 
 	return nil
 }
@@ -252,18 +252,7 @@ func (r *SCTPTransport) Stop() error {
 //nolint:cyclop
 func (r *SCTPTransport) acceptDataChannels(
 	assoc *sctp.Association,
-	existingDataChannels []*DataChannel,
 ) {
-	dataChannels := make([]*datachannel.DataChannel, 0, len(existingDataChannels))
-	for _, dc := range existingDataChannels {
-		dc.mu.Lock()
-		isNil := dc.dataChannel == nil
-		dc.mu.Unlock()
-		if isNil {
-			continue
-		}
-		dataChannels = append(dataChannels, dc.dataChannel)
-	}
 ACCEPT:
 	for {
 		// check if the association has been stopped before calling accept.
@@ -277,9 +266,7 @@ ACCEPT:
 			return
 		}
 
-		dc, err := datachannel.Accept(assoc, &datachannel.Config{
-			LoggerFactory: r.api.settingEngine.LoggerFactory,
-		}, dataChannels...)
+		dc, existing, err := r.acceptDataChannel(assoc)
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
 				r.log.Errorf("Failed to accept data channel: %v", err)
@@ -291,10 +278,8 @@ ACCEPT:
 
 			return
 		}
-		for _, ch := range dataChannels {
-			if ch.StreamIdentifier() == dc.StreamIdentifier() {
-				continue ACCEPT
-			}
+		if existing {
+			continue ACCEPT
 		}
 
 		var (
@@ -357,6 +342,46 @@ ACCEPT:
 			handler(rtcDC)
 		}
 	}
+}
+
+// acceptDataChannel classifies an accepted SCTP stream against the live local
+// DataChannel registry. A startup snapshot is insufficient because applications
+// may create local DataChannels after the SCTP association has started; the
+// first inbound packet on those streams is a DataChannelAck, not a new Open.
+func (r *SCTPTransport) acceptDataChannel(
+	assoc *sctp.Association,
+) (*datachannel.DataChannel, bool, error) {
+	stream, err := assoc.AcceptStream()
+	if err != nil {
+		return nil, false, err
+	}
+
+	stream.SetDefaultPayloadType(sctp.PayloadTypeWebRTCBinary)
+	streamID := stream.StreamIdentifier()
+
+	r.lock.RLock()
+	for i := len(r.dataChannels) - 1; i >= 0; i-- {
+		dc := r.dataChannels[i]
+		dc.mu.RLock()
+		isLocalMatch := !dc.isRemote && dc.id != nil && *dc.id == streamID &&
+			dc.ReadyState() != DataChannelStateClosed
+		dc.mu.RUnlock()
+		if isLocalMatch {
+			r.lock.RUnlock()
+
+			return nil, true, nil
+		}
+	}
+	r.lock.RUnlock()
+
+	dc, err := datachannel.Server(stream, &datachannel.Config{
+		LoggerFactory: r.api.settingEngine.LoggerFactory,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	return dc, false, nil
 }
 
 // OnError sets an event handler which is invoked when the SCTP Association errors.

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -72,6 +72,12 @@ type SCTPTransport struct {
 	// Count reservations because a reused stream can arrive before the old
 	// generation's reset-complete callback runs on this association.
 	dataChannelIDsUsed map[uint16]uint32
+	// Advance allocations within the negotiated DTLS-role parity instead of
+	// immediately selecting the lowest released ID again. Reset completion is
+	// still the reuse boundary, while spreading successive short-lived channels
+	// across the available stream space avoids coupling every new generation to
+	// the immediately preceding reset exchange.
+	nextDataChannelID uint16
 	// Detach removes DataChannels from dataChannels before their ACK can arrive.
 	// Keep each locally opened stream generation classified independently from
 	// that garbage-collection list until its reset completes. SCTP may recreate
@@ -659,13 +665,27 @@ func (r *SCTPTransport) generateAndSetDataChannelID(dtlsRole DTLSRole, idOut **u
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	for candidate := firstID; candidate < maxVal; candidate += 2 {
+	if maxVal <= firstID {
+		return &rtcerr.OperationError{Err: ErrMaxDataChannelID}
+	}
+	start := uint32(r.nextDataChannelID)
+	if start < firstID || start >= maxVal || start%2 != firstID {
+		start = firstID
+	}
+	candidateCount := (maxVal - firstID + 1) / 2
+	for range candidateCount {
+		candidate := start
+		start += 2
+		if start >= maxVal {
+			start = firstID
+		}
 		id := uint16(candidate)
 		if _, ok := r.dataChannelIDsUsed[id]; ok {
 			continue
 		}
 		*idOut = &id
 		r.dataChannelIDsUsed[id] = 1
+		r.nextDataChannelID = uint16(start)
 
 		return nil
 	}

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -68,8 +68,10 @@ type SCTPTransport struct {
 	onDataChannelOpenedHandler func(*DataChannel)
 
 	// DataChannels
-	dataChannels          []*DataChannel
-	dataChannelIDsUsed    map[uint16]struct{}
+	dataChannels []*DataChannel
+	// Count reservations because a reused stream can arrive before the old
+	// generation's reset-complete callback runs on this association.
+	dataChannelIDsUsed    map[uint16]uint32
 	dataChannelsOpened    uint32
 	dataChannelsRequested uint32
 	dataChannelsAccepted  uint32
@@ -89,7 +91,7 @@ func (api *API) NewSCTPTransport(dtls *DTLSTransport) *SCTPTransport {
 		state:              SCTPTransportStateConnecting,
 		api:                api,
 		log:                api.settingEngine.LoggerFactory.NewLogger("ortc"),
-		dataChannelIDsUsed: make(map[uint16]struct{}),
+		dataChannelIDsUsed: make(map[uint16]uint32),
 	}
 
 	res.updateMaxChannels()
@@ -412,7 +414,7 @@ func (r *SCTPTransport) onDataChannel(dc *DataChannel) (done chan struct{}) {
 	r.dataChannels = append(r.dataChannels, dc)
 	r.dataChannelsAccepted++
 	if dc.ID() != nil {
-		r.dataChannelIDsUsed[*dc.ID()] = struct{}{}
+		r.dataChannelIDsUsed[*dc.ID()]++
 	} else {
 		// This cannot happen, the constructor for this datachannel in the caller
 		// takes a pointer to the id.
@@ -458,7 +460,11 @@ func maxChannelsForAssociation(association *sctp.Association) *uint16 {
 
 func (r *SCTPTransport) releaseDataChannelID(streamID uint16) {
 	r.lock.Lock()
-	delete(r.dataChannelIDsUsed, streamID)
+	if r.dataChannelIDsUsed[streamID] > 1 {
+		r.dataChannelIDsUsed[streamID]--
+	} else {
+		delete(r.dataChannelIDsUsed, streamID)
+	}
 	r.lock.Unlock()
 }
 
@@ -546,7 +552,7 @@ func (r *SCTPTransport) generateAndSetDataChannelID(dtlsRole DTLSRole, idOut **u
 			continue
 		}
 		*idOut = &id
-		r.dataChannelIDsUsed[id] = struct{}{}
+		r.dataChannelIDsUsed[id] = 1
 
 		return nil
 	}

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -36,6 +36,8 @@ func newSCTPTransportMetadata(metadata sctp.AssociationMetadata) SCTPTransportMe
 		PartialReliabilityMode:       partialReliabilityMode,
 		ZeroChecksumSendingEnabled:   metadata.ZeroChecksumSendingEnabled,
 		ZeroChecksumReceivingEnabled: metadata.ZeroChecksumReceivingEnabled,
+		NumInboundStreams:            metadata.NumInboundStreams,
+		NumOutboundStreams:           metadata.NumOutboundStreams,
 	}
 }
 
@@ -147,10 +149,12 @@ func (r *SCTPTransport) Start(capabilities SCTPCapabilities) error {
 	if err != nil {
 		return err
 	}
+	sctpAssociation.OnStreamResetComplete(r.releaseDataChannelID)
 
 	r.lock.Lock()
 	r.sctpAssociation = sctpAssociation
 	r.state = SCTPTransportStateConnected
+	r.maxChannels = maxChannelsForAssociation(sctpAssociation)
 	dataChannels := append([]*DataChannel{}, r.dataChannels...)
 	r.lock.Unlock()
 
@@ -227,15 +231,18 @@ func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
 // Stop stops the SCTPTransport.
 func (r *SCTPTransport) Stop() error {
 	r.lock.Lock()
-	defer r.lock.Unlock()
-	if r.sctpAssociation == nil {
+	association := r.sctpAssociation
+	if association == nil {
+		r.lock.Unlock()
+
 		return nil
 	}
-
-	r.sctpAssociation.Abort("")
-
 	r.sctpAssociation = nil
 	r.state = SCTPTransportStateClosed
+	r.lock.Unlock()
+
+	association.OnStreamResetComplete(nil)
+	association.Abort("")
 
 	return nil
 }
@@ -432,14 +439,33 @@ func (r *SCTPTransport) onDataChannel(dc *DataChannel) (done chan struct{}) {
 }
 
 func (r *SCTPTransport) updateMaxChannels() {
-	val := sctpMaxChannels
-	r.maxChannels = &val
+	maxChannels := maxChannelsForAssociation(r.association())
+	r.lock.Lock()
+	r.maxChannels = maxChannels
+	r.lock.Unlock()
+}
+
+func maxChannelsForAssociation(association *sctp.Association) *uint16 {
+	maxChannels := sctpMaxChannels
+	if association != nil {
+		if metadata, ok := association.Metadata(); ok {
+			maxChannels = min(maxChannels, metadata.NumInboundStreams, metadata.NumOutboundStreams)
+		}
+	}
+
+	return &maxChannels
+}
+
+func (r *SCTPTransport) releaseDataChannelID(streamID uint16) {
+	r.lock.Lock()
+	delete(r.dataChannelIDsUsed, streamID)
+	r.lock.Unlock()
 }
 
 // MaxChannels is the maximum number of RTCDataChannels that can be open simultaneously.
 func (r *SCTPTransport) MaxChannels() uint16 {
-	r.lock.Lock()
-	defer r.lock.Unlock()
+	r.lock.RLock()
+	defer r.lock.RUnlock()
 
 	if r.maxChannels == nil {
 		return sctpMaxChannels
@@ -504,17 +530,18 @@ func (r *SCTPTransport) collectStats(collector *statsReportCollector) {
 }
 
 func (r *SCTPTransport) generateAndSetDataChannelID(dtlsRole DTLSRole, idOut **uint16) error {
-	var id uint16
+	var firstID uint32
 	if dtlsRole != DTLSRoleClient {
-		id++
+		firstID++
 	}
 
-	maxVal := r.MaxChannels()
+	maxVal := uint32(r.MaxChannels())
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	for ; id < maxVal-1; id += 2 {
+	for candidate := firstID; candidate < maxVal; candidate += 2 {
+		id := uint16(candidate)
 		if _, ok := r.dataChannelIDsUsed[id]; ok {
 			continue
 		}

--- a/sctptransport.go
+++ b/sctptransport.go
@@ -208,10 +208,17 @@ func (r *SCTPTransport) sctpClientOptions(netConn net.Conn, maxMessageSize uint3
 }
 
 func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
-	opts := make([]sctp.ClientOption, 0, 8)
+	opts := make([]sctp.ClientOption, 0, 9)
 
 	if r.api.settingEngine.sctp.maxReceiveBufferSize != 0 {
 		opts = append(opts, sctp.WithMaxReceiveBufferSize(r.api.settingEngine.sctp.maxReceiveBufferSize))
+	}
+
+	if r.api.settingEngine.sctp.numInboundStreams != 0 || r.api.settingEngine.sctp.numOutboundStreams != 0 {
+		opts = append(opts, sctp.WithNumStreams(
+			r.api.settingEngine.sctp.numInboundStreams,
+			r.api.settingEngine.sctp.numOutboundStreams,
+		))
 	}
 
 	if r.api.settingEngine.sctp.enableZeroChecksum {
@@ -722,6 +729,8 @@ func (r *SCTPTransport) GetSctpInit() []byte {
 		var err error
 		r.localSctpInit, err = sctp.GenerateOutOfBandToken(sctp.Config{
 			MaxReceiveBufferSize: r.api.settingEngine.sctp.maxReceiveBufferSize,
+			NumInboundStreams:    r.api.settingEngine.sctp.numInboundStreams,
+			NumOutboundStreams:   r.api.settingEngine.sctp.numOutboundStreams,
 			EnableZeroChecksum:   r.api.settingEngine.sctp.enableZeroChecksum,
 		})
 		if err != nil {

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -470,6 +470,14 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 			wantExtra: 1,
 		},
 		{
+			name: "NumStreams",
+			configure: func(se *SettingEngine) {
+				se.sctp.numInboundStreams = 7
+				se.sctp.numOutboundStreams = 9
+			},
+			wantExtra: 1,
+		},
+		{
 			name: "EnableZeroChecksum",
 			configure: func(se *SettingEngine) {
 				se.sctp.enableZeroChecksum = true
@@ -523,6 +531,8 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 			name: "AllOptional",
 			configure: func(se *SettingEngine) {
 				se.sctp.maxReceiveBufferSize = 1024
+				se.sctp.numInboundStreams = 7
+				se.sctp.numOutboundStreams = 9
 				se.sctp.enableZeroChecksum = true
 				se.detach.DataChannels = true
 				se.dataChannelBlockWrite = true
@@ -532,7 +542,7 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 				se.sctp.fastRtxWnd = 22
 				se.sctp.cwndCAStep = 33
 			},
-			wantExtra: 8,
+			wantExtra: 9,
 		},
 	}
 

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -63,6 +63,55 @@ func TestGenerateDataChannelID(t *testing.T) {
 	}
 }
 
+func TestGenerateDataChannelIDRespectsNegotiatedLimitAndParity(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		role     DTLSRole
+		expected []uint16
+	}{
+		{name: "client", role: DTLSRoleClient, expected: []uint16{0, 2}},
+		{name: "server", role: DTLSRoleServer, expected: []uint16{1, 3}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			maxChannels := uint16(4)
+			transport := &SCTPTransport{
+				maxChannels:        &maxChannels,
+				dataChannelIDsUsed: make(map[uint16]struct{}),
+			}
+
+			for _, expected := range testCase.expected {
+				id := new(uint16)
+				require.NoError(t, transport.generateAndSetDataChannelID(testCase.role, &id))
+				require.Equal(t, expected, *id)
+			}
+
+			id := new(uint16)
+			err := transport.generateAndSetDataChannelID(testCase.role, &id)
+			require.ErrorIs(t, err, ErrMaxDataChannelID)
+		})
+	}
+}
+
+func TestGenerateDataChannelIDReusesReleasedID(t *testing.T) {
+	maxChannels := uint16(2)
+	transport := &SCTPTransport{
+		maxChannels:        &maxChannels,
+		dataChannelIDsUsed: make(map[uint16]struct{}),
+	}
+
+	first := new(uint16)
+	require.NoError(t, transport.generateAndSetDataChannelID(DTLSRoleClient, &first))
+	require.Equal(t, uint16(0), *first)
+
+	exhausted := new(uint16)
+	require.ErrorIs(t, transport.generateAndSetDataChannelID(DTLSRoleClient, &exhausted), ErrMaxDataChannelID)
+
+	transport.releaseDataChannelID(*first)
+	reused := new(uint16)
+	require.NoError(t, transport.generateAndSetDataChannelID(DTLSRoleClient, &reused))
+	require.Equal(t, *first, *reused)
+}
+
 func TestSCTPTransportMetadataNotReady(t *testing.T) {
 	metadata, ok := (&SCTPTransport{}).Metadata()
 	assert.False(t, ok)
@@ -75,6 +124,8 @@ func TestNewSCTPTransportMetadata(t *testing.T) {
 		PartialReliabilityMode:       sctp.PartialReliabilityModeIForwardTSN,
 		ZeroChecksumSendingEnabled:   true,
 		ZeroChecksumReceivingEnabled: true,
+		NumInboundStreams:            10,
+		NumOutboundStreams:           20,
 	})
 
 	assert.Equal(t, SCTPTransportMetadata{
@@ -82,7 +133,80 @@ func TestNewSCTPTransportMetadata(t *testing.T) {
 		PartialReliabilityMode:       SCTPTransportPartialReliabilityModeIForwardTSN,
 		ZeroChecksumSendingEnabled:   true,
 		ZeroChecksumReceivingEnabled: true,
+		NumInboundStreams:            10,
+		NumOutboundStreams:           20,
 	}, metadata)
+}
+
+func TestSCTPTransportReusesDataChannelIDAfterResetCompletion(t *testing.T) {
+	offerPC, answerPC, wan := createVNetPair(t, nil)
+	defer func() {
+		require.NoError(t, wan.Stop())
+		closePairNow(t, offerPC, answerPC)
+	}()
+
+	accepted := make(chan *DataChannel, 2)
+	answerPC.OnDataChannel(func(dataChannel *DataChannel) {
+		accepted <- dataChannel
+	})
+
+	first, err := offerPC.CreateDataChannel("first", nil)
+	require.NoError(t, err)
+	firstOpened := make(chan struct{})
+	first.OnOpen(func() { close(firstOpened) })
+	require.NoError(t, signalPairWithOptions(offerPC, answerPC, withDisableInitialDataChannel(true)))
+
+	select {
+	case <-firstOpened:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first DataChannel to open")
+	}
+	firstRemote := waitForAcceptedDataChannel(t, accepted)
+	require.NotNil(t, first.ID())
+	require.NotNil(t, firstRemote.ID())
+	firstID := *first.ID()
+	require.Equal(t, firstID, *firstRemote.ID())
+
+	require.NoError(t, first.Close())
+	require.Eventually(t, func() bool {
+		return !dataChannelIDInUse(offerPC.SCTP(), firstID) && !dataChannelIDInUse(answerPC.SCTP(), firstID)
+	}, 5*time.Second, time.Millisecond)
+
+	second, err := offerPC.CreateDataChannel("second", nil)
+	require.NoError(t, err)
+	require.NotNil(t, second.ID())
+	require.Equal(t, firstID, *second.ID())
+	secondOpened := make(chan struct{})
+	second.OnOpen(func() { close(secondOpened) })
+
+	select {
+	case <-secondOpened:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reused DataChannel to open")
+	}
+	secondRemote := waitForAcceptedDataChannel(t, accepted)
+	require.NotNil(t, secondRemote.ID())
+	require.Equal(t, firstID, *secondRemote.ID())
+}
+
+func dataChannelIDInUse(transport *SCTPTransport, id uint16) bool {
+	transport.lock.RLock()
+	defer transport.lock.RUnlock()
+	_, ok := transport.dataChannelIDsUsed[id]
+
+	return ok
+}
+
+func waitForAcceptedDataChannel(t *testing.T, accepted <-chan *DataChannel) *DataChannel {
+	t.Helper()
+	select {
+	case dataChannel := <-accepted:
+		return dataChannel
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for remote DataChannel")
+
+		return nil
+	}
 }
 
 func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -23,13 +23,13 @@ func TestGenerateDataChannelID(t *testing.T) {
 	sctpTransportWithChannels := func(ids []uint16) *SCTPTransport {
 		ret := &SCTPTransport{
 			dataChannels:       []*DataChannel{},
-			dataChannelIDsUsed: make(map[uint16]struct{}),
+			dataChannelIDsUsed: make(map[uint16]uint32),
 		}
 
 		for i := range ids {
 			id := ids[i]
 			ret.dataChannels = append(ret.dataChannels, &DataChannel{id: &id})
-			ret.dataChannelIDsUsed[id] = struct{}{}
+			ret.dataChannelIDsUsed[id] = 1
 		}
 
 		return ret
@@ -76,7 +76,7 @@ func TestGenerateDataChannelIDRespectsNegotiatedLimitAndParity(t *testing.T) {
 			maxChannels := uint16(4)
 			transport := &SCTPTransport{
 				maxChannels:        &maxChannels,
-				dataChannelIDsUsed: make(map[uint16]struct{}),
+				dataChannelIDsUsed: make(map[uint16]uint32),
 			}
 
 			for _, expected := range testCase.expected {
@@ -96,7 +96,7 @@ func TestGenerateDataChannelIDReusesReleasedID(t *testing.T) {
 	maxChannels := uint16(2)
 	transport := &SCTPTransport{
 		maxChannels:        &maxChannels,
-		dataChannelIDsUsed: make(map[uint16]struct{}),
+		dataChannelIDsUsed: make(map[uint16]uint32),
 	}
 
 	first := new(uint16)
@@ -110,6 +110,25 @@ func TestGenerateDataChannelIDReusesReleasedID(t *testing.T) {
 	reused := new(uint16)
 	require.NoError(t, transport.generateAndSetDataChannelID(DTLSRoleClient, &reused))
 	require.Equal(t, *first, *reused)
+}
+
+func TestReleaseDataChannelIDKeepsOverlappingGenerationReserved(t *testing.T) {
+	const streamID = uint16(0)
+	maxChannels := uint16(2)
+	transport := &SCTPTransport{
+		maxChannels:        &maxChannels,
+		dataChannelIDsUsed: map[uint16]uint32{streamID: 2},
+	}
+
+	transport.releaseDataChannelID(streamID)
+	require.Equal(t, uint32(1), transport.dataChannelIDsUsed[streamID])
+	blocked := new(uint16)
+	require.ErrorIs(t, transport.generateAndSetDataChannelID(DTLSRoleClient, &blocked), ErrMaxDataChannelID)
+
+	transport.releaseDataChannelID(streamID)
+	reused := new(uint16)
+	require.NoError(t, transport.generateAndSetDataChannelID(DTLSRoleClient, &reused))
+	require.Equal(t, streamID, *reused)
 }
 
 func TestSCTPTransportMetadataNotReady(t *testing.T) {

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -317,6 +317,13 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 			wantExtra: 1,
 		},
 		{
+			name: "HandshakeRTOMax",
+			configure: func(se *SettingEngine) {
+				se.sctp.handshakeRTOMax = 150 * time.Millisecond
+			},
+			wantExtra: 1,
+		},
+		{
 			name: "MinCwnd",
 			configure: func(se *SettingEngine) {
 				se.sctp.minCwnd = 11
@@ -345,11 +352,12 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 				se.detach.DataChannels = true
 				se.dataChannelBlockWrite = true
 				se.sctp.rtoMax = time.Second
+				se.sctp.handshakeRTOMax = 150 * time.Millisecond
 				se.sctp.minCwnd = 11
 				se.sctp.fastRtxWnd = 22
 				se.sctp.cwndCAStep = 33
 			},
-			wantExtra: 7,
+			wantExtra: 8,
 		},
 	}
 

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -131,6 +131,22 @@ func TestReleaseDataChannelIDKeepsOverlappingGenerationReserved(t *testing.T) {
 	require.Equal(t, streamID, *reused)
 }
 
+func TestLocalDataChannelGenerationSurvivesDelayedReset(t *testing.T) {
+	const streamID = uint16(0)
+	transport := &SCTPTransport{
+		dataChannelIDsUsed:          map[uint16]uint32{streamID: 2},
+		localDataChannelGenerations: make(map[uint16][]*localDataChannelGeneration),
+	}
+
+	transport.registerLocalDataChannelGeneration(streamID)
+	require.True(t, transport.acceptLocalDataChannelGeneration(streamID))
+	transport.registerLocalDataChannelGeneration(streamID)
+
+	transport.releaseDataChannelID(streamID)
+	require.True(t, transport.acceptLocalDataChannelGeneration(streamID))
+	require.False(t, transport.acceptLocalDataChannelGeneration(streamID))
+}
+
 func TestSCTPTransportMetadataNotReady(t *testing.T) {
 	metadata, ok := (&SCTPTransport{}).Metadata()
 	assert.False(t, ok)

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -112,6 +112,71 @@ func TestGenerateDataChannelIDReusesReleasedID(t *testing.T) {
 	require.Equal(t, *first, *reused)
 }
 
+func TestGenerateDataChannelIDRotatesBeforeReuse(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		role     DTLSRole
+		expected []uint16
+	}{
+		{name: "client", role: DTLSRoleClient, expected: []uint16{0, 2, 4, 0}},
+		{name: "server", role: DTLSRoleServer, expected: []uint16{1, 3, 5, 1}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			maxChannels := uint16(6)
+			transport := &SCTPTransport{
+				maxChannels:        &maxChannels,
+				dataChannelIDsUsed: make(map[uint16]uint32),
+			}
+
+			for _, expected := range testCase.expected {
+				id := new(uint16)
+				require.NoError(t, transport.generateAndSetDataChannelID(testCase.role, &id))
+				require.Equal(t, expected, *id)
+				transport.releaseDataChannelID(*id)
+			}
+		})
+	}
+}
+
+func TestGenerateDataChannelIDRotationSkipsReservedID(t *testing.T) {
+	maxChannels := uint16(6)
+	transport := &SCTPTransport{
+		maxChannels:        &maxChannels,
+		dataChannelIDsUsed: map[uint16]uint32{2: 1},
+		nextDataChannelID:  2,
+	}
+
+	id := new(uint16)
+	require.NoError(t, transport.generateAndSetDataChannelID(DTLSRoleClient, &id))
+	require.Equal(t, uint16(4), *id)
+	transport.releaseDataChannelID(*id)
+
+	require.NoError(t, transport.generateAndSetDataChannelID(DTLSRoleClient, &id))
+	require.Equal(t, uint16(0), *id)
+}
+
+func TestGenerateDataChannelIDRejectsEmptyRoleParity(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		role        DTLSRole
+		maxChannels uint16
+	}{
+		{name: "empty association", role: DTLSRoleClient, maxChannels: 0},
+		{name: "server parity unavailable", role: DTLSRoleServer, maxChannels: 1},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			transport := &SCTPTransport{
+				maxChannels:        &testCase.maxChannels,
+				dataChannelIDsUsed: make(map[uint16]uint32),
+			}
+
+			id := new(uint16)
+			err := transport.generateAndSetDataChannelID(testCase.role, &id)
+			require.ErrorIs(t, err, ErrMaxDataChannelID)
+		})
+	}
+}
+
 func TestSCTPTransportRejectsExplicitDataChannelIDOutsideNegotiatedLimit(t *testing.T) {
 	offerPC, answerPC, err := newPair()
 	require.NoError(t, err)
@@ -235,6 +300,13 @@ func TestSCTPTransportReusesDataChannelIDAfterResetCompletion(t *testing.T) {
 	require.NotNil(t, firstRemote.ID())
 	firstID := *first.ID()
 	require.Equal(t, firstID, *firstRemote.ID())
+	// Constrain the allocator to this single local-parity ID so the test still
+	// proves reuse after reset completion. Wider negotiated ranges are covered
+	// separately and intentionally rotate before returning to firstID.
+	maxChannels := firstID + 1
+	offerPC.SCTP().lock.Lock()
+	offerPC.SCTP().maxChannels = &maxChannels
+	offerPC.SCTP().lock.Unlock()
 
 	require.NoError(t, first.Close())
 	require.Eventually(t, func() bool {

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -208,6 +208,49 @@ func TestSCTPTransportReusesDataChannelIDAfterResetCompletion(t *testing.T) {
 	require.Equal(t, firstID, *secondRemote.ID())
 }
 
+func TestSCTPTransportAcceptsLocalDataChannelCreatedAfterStart(t *testing.T) {
+	offerPC, answerPC, wan := createVNetPair(t, nil)
+	defer func() {
+		require.NoError(t, wan.Stop())
+		closePairNow(t, offerPC, answerPC)
+	}()
+
+	accepted := make(chan *DataChannel, 2)
+	answerPC.OnDataChannel(func(dataChannel *DataChannel) {
+		accepted <- dataChannel
+	})
+
+	first, err := offerPC.CreateDataChannel("first", nil)
+	require.NoError(t, err)
+	firstOpened := make(chan struct{})
+	first.OnOpen(func() { close(firstOpened) })
+	require.NoError(t, signalPairWithOptions(offerPC, answerPC, withDisableInitialDataChannel(true)))
+
+	select {
+	case <-firstOpened:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first DataChannel to open")
+	}
+	waitForAcceptedDataChannel(t, accepted)
+
+	second, err := offerPC.CreateDataChannel("second", nil)
+	require.NoError(t, err)
+	require.NotNil(t, first.ID())
+	require.NotNil(t, second.ID())
+	require.NotEqual(t, *first.ID(), *second.ID())
+	secondOpened := make(chan struct{})
+	second.OnOpen(func() { close(secondOpened) })
+
+	select {
+	case <-secondOpened:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for DataChannel created after SCTP start to open")
+	}
+	secondRemote := waitForAcceptedDataChannel(t, accepted)
+	require.NotNil(t, secondRemote.ID())
+	require.Equal(t, *second.ID(), *secondRemote.ID())
+}
+
 func dataChannelIDInUse(transport *SCTPTransport, id uint16) bool {
 	transport.lock.RLock()
 	defer transport.lock.RUnlock()

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -112,6 +112,40 @@ func TestGenerateDataChannelIDReusesReleasedID(t *testing.T) {
 	require.Equal(t, *first, *reused)
 }
 
+func TestSCTPTransportRejectsExplicitDataChannelIDOutsideNegotiatedLimit(t *testing.T) {
+	offerPC, answerPC, err := newPair()
+	require.NoError(t, err)
+	defer closePairNow(t, offerPC, answerPC)
+
+	_, err = offerPC.CreateDataChannel("initial", nil)
+	require.NoError(t, err)
+	require.NoError(t, signalPairWithOptions(offerPC, answerPC, withDisableInitialDataChannel(true)))
+	require.Eventually(t, func() bool {
+		return offerPC.SCTP().State() == SCTPTransportStateConnected
+	}, 5*time.Second, time.Millisecond)
+
+	const negotiatedLimit = uint16(4)
+	limit := negotiatedLimit
+	offerPC.SCTP().lock.Lock()
+	offerPC.SCTP().maxChannels = &limit
+	dataChannelsBeforeFailure := len(offerPC.SCTP().dataChannels)
+	offerPC.SCTP().lock.Unlock()
+
+	invalidID := negotiatedLimit
+	_, err = offerPC.CreateDataChannel("out-of-range", &DataChannelInit{ID: &invalidID})
+	require.ErrorIs(t, err, ErrMaxDataChannelID)
+	require.False(t, dataChannelIDInUse(offerPC.SCTP(), invalidID))
+	offerPC.SCTP().lock.RLock()
+	dataChannelsAfterFailure := len(offerPC.SCTP().dataChannels)
+	offerPC.SCTP().lock.RUnlock()
+	require.Equal(t, dataChannelsBeforeFailure, dataChannelsAfterFailure)
+
+	validID := negotiatedLimit - 2
+	valid, err := offerPC.CreateDataChannel("in-range", &DataChannelInit{ID: &validID})
+	require.NoError(t, err)
+	require.Equal(t, validID, *valid.ID())
+}
+
 func TestReleaseDataChannelIDKeepsOverlappingGenerationReserved(t *testing.T) {
 	const streamID = uint16(0)
 	maxChannels := uint16(2)

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -251,6 +251,59 @@ func TestSCTPTransportAcceptsLocalDataChannelCreatedAfterStart(t *testing.T) {
 	require.Equal(t, *second.ID(), *secondRemote.ID())
 }
 
+func TestSCTPTransportAcceptsDetachedLocalDataChannelCreatedAfterStart(t *testing.T) {
+	settingEngine := SettingEngine{}
+	settingEngine.DetachDataChannels()
+	offerPC, answerPC, err := NewAPI(WithSettingEngine(settingEngine)).newPair(Configuration{})
+	require.NoError(t, err)
+	defer closePairNow(t, offerPC, answerPC)
+
+	remoteOpened := make(chan struct{}, 2)
+	answerPC.OnDataChannel(func(dataChannel *DataChannel) {
+		dataChannel.OnOpen(func() {
+			_, detachErr := dataChannel.Detach()
+			require.NoError(t, detachErr)
+			remoteOpened <- struct{}{}
+		})
+	})
+
+	first, err := offerPC.CreateDataChannel("first", nil)
+	require.NoError(t, err)
+	firstOpened := make(chan struct{})
+	first.OnOpen(func() {
+		_, detachErr := first.Detach()
+		require.NoError(t, detachErr)
+		close(firstOpened)
+	})
+	require.NoError(t, signalPairWithOptions(offerPC, answerPC, withDisableInitialDataChannel(true)))
+
+	waitForSignal(t, firstOpened, "first detached local DataChannel")
+	waitForSignal(t, remoteOpened, "first detached remote DataChannel")
+
+	second, err := offerPC.CreateDataChannel("second", nil)
+	require.NoError(t, err)
+	secondOpened := make(chan struct{})
+	second.OnOpen(func() {
+		_, detachErr := second.Detach()
+		require.NoError(t, detachErr)
+		close(secondOpened)
+	})
+
+	waitForSignal(t, secondOpened, "second detached local DataChannel")
+	waitForSignal(t, remoteOpened, "second detached remote DataChannel")
+	require.Equal(t, SCTPTransportStateConnected, offerPC.SCTP().State())
+	require.Equal(t, SCTPTransportStateConnected, answerPC.SCTP().State())
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
 func dataChannelIDInUse(transport *SCTPTransport, id uint16) bool {
 	transport.lock.RLock()
 	defer transport.lock.RUnlock()

--- a/settingengine.go
+++ b/settingengine.go
@@ -88,6 +88,7 @@ type SettingEngine struct {
 		maxReceiveBufferSize uint32
 		enableZeroChecksum   bool
 		rtoMax               time.Duration
+		handshakeRTOMax      time.Duration
 		maxMessageSize       uint32
 		minCwnd              uint32
 		fastRtxWnd           uint32
@@ -673,6 +674,13 @@ func (e *SettingEngine) SetDTLSSupportedProtocols(protocols ...string) {
 // Leave this 0 for the default timeout.
 func (e *SettingEngine) SetSCTPRTOMax(rtoMax time.Duration) {
 	e.sctp.rtoMax = rtoMax
+}
+
+// SetSCTPHandshakeRTOMax sets the maximum retransmission timeout for SCTP
+// T1-init and T1-cookie without changing the established association's DATA,
+// reconfiguration, or shutdown timers. Leave this 0 to inherit SCTP RTO max.
+func (e *SettingEngine) SetSCTPHandshakeRTOMax(rtoMax time.Duration) {
+	e.sctp.handshakeRTOMax = rtoMax
 }
 
 // SetSCTPMinCwnd sets the minimum congestion window size. The congestion window

--- a/settingengine.go
+++ b/settingengine.go
@@ -86,6 +86,8 @@ type SettingEngine struct {
 	}
 	sctp struct {
 		maxReceiveBufferSize uint32
+		numInboundStreams    uint16
+		numOutboundStreams   uint16
 		enableZeroChecksum   bool
 		rtoMax               time.Duration
 		handshakeRTOMax      time.Duration
@@ -609,6 +611,13 @@ func (e *SettingEngine) SetDTLSKeyLogWriter(writer io.Writer) {
 // Leave this 0 for the default maxReceiveBufferSize.
 func (e *SettingEngine) SetSCTPMaxReceiveBufferSize(maxReceiveBufferSize uint32) {
 	e.sctp.maxReceiveBufferSize = maxReceiveBufferSize
+}
+
+// SetSCTPNumStreams sets the maximum inbound and outbound stream counts to
+// negotiate. A zero value retains SCTP's default maximum for that direction.
+func (e *SettingEngine) SetSCTPNumStreams(numInbound, numOutbound uint16) {
+	e.sctp.numInboundStreams = numInbound
+	e.sctp.numOutboundStreams = numOutbound
 }
 
 // EnableSCTPZeroChecksum controls the zero checksum feature in SCTP.

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -756,11 +756,13 @@ func TestSettingEngine_SCTPSetters(t *testing.T) {
 	var se SettingEngine
 
 	se.EnableSCTPZeroChecksum(true)
+	se.SetSCTPHandshakeRTOMax(150 * time.Millisecond)
 	se.SetSCTPMinCwnd(11)
 	se.SetSCTPFastRtxWnd(22)
 	se.SetSCTPCwndCAStep(33)
 
 	assert.True(t, se.sctp.enableZeroChecksum)
+	assert.Equal(t, 150*time.Millisecond, se.sctp.handshakeRTOMax)
 	assert.Equal(t, uint32(11), se.sctp.minCwnd)
 	assert.Equal(t, uint32(22), se.sctp.fastRtxWnd)
 	assert.Equal(t, uint32(33), se.sctp.cwndCAStep)

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -756,12 +756,15 @@ func TestSettingEngine_SCTPSetters(t *testing.T) {
 	var se SettingEngine
 
 	se.EnableSCTPZeroChecksum(true)
+	se.SetSCTPNumStreams(7, 9)
 	se.SetSCTPHandshakeRTOMax(150 * time.Millisecond)
 	se.SetSCTPMinCwnd(11)
 	se.SetSCTPFastRtxWnd(22)
 	se.SetSCTPCwndCAStep(33)
 
 	assert.True(t, se.sctp.enableZeroChecksum)
+	assert.Equal(t, uint16(7), se.sctp.numInboundStreams)
+	assert.Equal(t, uint16(9), se.sctp.numOutboundStreams)
 	assert.Equal(t, 150*time.Millisecond, se.sctp.handshakeRTOMax)
 	assert.Equal(t, uint32(11), se.sctp.minCwnd)
 	assert.Equal(t, uint32(22), se.sctp.fastRtxWnd)

--- a/stats.go
+++ b/stats.go
@@ -201,6 +201,12 @@ type SCTPTransportMetadata struct {
 
 	// ZeroChecksumReceivingEnabled indicates whether incoming packets may use zero checksum.
 	ZeroChecksumReceivingEnabled bool `json:"zeroChecksumReceivingEnabled"`
+
+	// NumInboundStreams is the negotiated maximum number of inbound streams.
+	NumInboundStreams uint16 `json:"numInboundStreams"`
+
+	// NumOutboundStreams is the negotiated maximum number of outbound streams.
+	NumOutboundStreams uint16 `json:"numOutboundStreams"`
 }
 
 func newStatsReportCollector() *statsReportCollector {


### PR DESCRIPTION
## What changed

- reuse DataChannel IDs only after SCTP reports reset completion
- keep overlapping and detached DataChannel generations associated with the correct stream ID
- classify locally opened channels even when they are created after SCTP startup
- enforce the negotiated SCTP stream limit for generated and explicit DataChannel IDs
- roll back transport membership and ID reservations when opening a channel fails
- expose a separate SCTP handshake retransmission setting

## Why

DataChannel IDs are SCTP stream IDs. Reusing an ID before both reset directions complete can associate delayed reset or acknowledgement traffic with a new channel generation. Never releasing an ID avoids that race but eventually exhausts the negotiated stream range.

This change tracks local generations through reset completion so IDs can be reused without allowing traffic from an older generation to affect the new channel. It also rejects explicit IDs outside the negotiated range and cleans up failed opens.

## Dependencies and relationship to existing work

This PR depends on pion/sctp#485. The temporary `replace` directive pins the reviewed fork commit containing that SCTP work; it should be replaced with an upstream release after the SCTP change lands.

This is an alternative implementation that covers the goals of #3405 and adds handling for overlapping generations, detached and dynamically created channels, explicit-ID bounds, and failure rollback.

This PR is not intended to invalidate the work in #3405. If maintainers prefer to continue with #3405, please feel free to close this PR and reuse or adapt any tests and fixes that are useful.

## Validation

- `go test ./...`
- affected DataChannel race tests repeated successfully under `go test -race`
- `go vet ./...`
- `go mod tidy -diff`
- `staticcheck -checks 'all,-SA6002,-ST1016' .`

The full race suite also reaches two existing TrackLocal timestamp and sequence-number timing assertions. They fail identically on a clean `upstream/main` checkout and do not produce race-detector reports; the DataChannel-focused race suite passes.
