### PR TITLE
fix(js): preserve ordered ICE candidate delivery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,5 @@ require (
 	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/pion/ice/v4 => github.com/aperturerobotics/pion-ice/v4 v4.0.0-20260812163703-6ad0c439f02a

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/aperturerobotics/pion-ice/v4 v4.0.0-20260812163703-6ad0c439f02a h1:bIPJWMUudSrc59YaAf2DXX4gBMx20jJ1sBLl16JY4mI=
+github.com/aperturerobotics/pion-ice/v4 v4.0.0-20260812163703-6ad0c439f02a/go.mod h1:VqWivYHt+Z7QqpPRSyWUnBHW9NEhIBBrSTgNj5sap1A=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -41,8 +43,6 @@ github.com/pion/datachannel v1.6.2 h1:7EXQ8TH3vTouBUdRWYbcX2edSx9Yj6k5zl5P+qyxEP
 github.com/pion/datachannel v1.6.2/go.mod h1:pzbdAZvyGtXbcHM1hBbsFaOTf40lZizU/dNlvVOak6E=
 github.com/pion/dtls/v3 v3.1.5 h1:9xJtVsHwMYeSjPp5Hh1FTis4DchnQWtnOa5o+6ygqfc=
 github.com/pion/dtls/v3 v3.1.5/go.mod h1:gz1K4jg6c+fq86oQMH4pilpCEOEPwmEr2jY+VcF/mkU=
-github.com/pion/ice/v4 v4.4.0 h1:wvHDDqimaC38Y7MVpD46Y63p246ChvXd87VKoLYS5b4=
-github.com/pion/ice/v4 v4.4.0/go.mod h1:obAyD+J+Hzs7QA7Y8YXHp5uIn6gb7z87pKedXZkrcFU=
 github.com/pion/interceptor v0.1.47 h1:yw8t5pJ2f8t78NgU+8EmxhaqYLXS7uFCC/tAGOaSDBo=
 github.com/pion/interceptor v0.1.47/go.mod h1:7yoRBzaIDETPC6cIN8Zj9EyGqHv1ImOpcTFPha6MuOM=
 github.com/pion/logging v0.2.4 h1:tTew+7cmQ+Mc1pTBLKH2puKsOvhm32dROumOZ655zB8=
@@ -74,6 +74,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/sclevine/agouti v3.0.0+incompatible h1:8IBJS6PWz3uTlMP3YBIR5f+KAldcGuOeFkFbUWfBgK4=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
@@ -111,6 +112,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/icecandidate.go
+++ b/icecandidate.go
@@ -233,11 +233,13 @@ func (c ICECandidate) ToJSON() ICECandidateInit {
 
 	candidate, err := c.ToICE()
 	if err == nil {
-		candidateStr = candidate.Marshal()
+		if marshaled := candidate.Marshal(); marshaled != "" {
+			candidateStr = fmt.Sprintf("candidate:%s", marshaled)
+		}
 	}
 
 	return ICECandidateInit{
-		Candidate:     fmt.Sprintf("candidate:%s", candidateStr),
+		Candidate:     candidateStr,
 		SDPMid:        &c.SDPMid,
 		SDPMLineIndex: &c.SDPMLineIndex,
 	}

--- a/icecandidate.go
+++ b/icecandidate.go
@@ -12,20 +12,21 @@ import (
 
 // ICECandidate represents a ice candidate.
 type ICECandidate struct {
-	statsID        string
-	Foundation     string           `json:"foundation"`
-	Priority       uint32           `json:"priority"`
-	Address        string           `json:"address"`
-	Protocol       ICEProtocol      `json:"protocol"`
-	Port           uint16           `json:"port"`
-	Typ            ICECandidateType `json:"type"`
-	Component      uint16           `json:"component"`
-	RelatedAddress string           `json:"relatedAddress"`
-	RelatedPort    uint16           `json:"relatedPort"`
-	TCPType        string           `json:"tcpType"`
-	SDPMid         string           `json:"sdpMid"`
-	SDPMLineIndex  uint16           `json:"sdpMLineIndex"`
-	extensions     string
+	statsID          string
+	usernameFragment string
+	Foundation       string           `json:"foundation"`
+	Priority         uint32           `json:"priority"`
+	Address          string           `json:"address"`
+	Protocol         ICEProtocol      `json:"protocol"`
+	Port             uint16           `json:"port"`
+	Typ              ICECandidateType `json:"type"`
+	Component        uint16           `json:"component"`
+	RelatedAddress   string           `json:"relatedAddress"`
+	RelatedPort      uint16           `json:"relatedPort"`
+	TCPType          string           `json:"tcpType"`
+	SDPMid           string           `json:"sdpMid"`
+	SDPMLineIndex    uint16           `json:"sdpMLineIndex"`
+	extensions       string
 }
 
 // Conversion for package ice.
@@ -226,6 +227,14 @@ func (c ICECandidate) String() string {
 	return ic.String()
 }
 
+// UsernameFragment returns the ICE username fragment associated with c when
+// the browser or local gathering callback supplied it. It is empty when that
+// identity is unavailable. Conversions from standalone ICE candidates cannot
+// reconstruct the gathering that produced them.
+func (c ICECandidate) UsernameFragment() string {
+	return c.usernameFragment
+}
+
 // ToJSON returns an ICECandidateInit
 // as indicated by the spec https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson
 func (c ICECandidate) ToJSON() ICECandidateInit {
@@ -238,9 +247,15 @@ func (c ICECandidate) ToJSON() ICECandidateInit {
 		}
 	}
 
+	var usernameFragment *string
+	if c.usernameFragment != "" {
+		usernameFragment = &c.usernameFragment
+	}
+
 	return ICECandidateInit{
-		Candidate:     candidateStr,
-		SDPMid:        &c.SDPMid,
-		SDPMLineIndex: &c.SDPMLineIndex,
+		Candidate:        candidateStr,
+		SDPMid:           &c.SDPMid,
+		SDPMLineIndex:    &c.SDPMLineIndex,
+		UsernameFragment: usernameFragment,
 	}
 }

--- a/icecandidate_test.go
+++ b/icecandidate_test.go
@@ -205,18 +205,20 @@ func TestNewIdentifiedICECandidatesFromICE(t *testing.T) {
 
 func TestICECandidate_ToJSON(t *testing.T) {
 	candidate := ICECandidate{
-		Foundation: "foundation",
-		Priority:   128,
-		Address:    "1.0.0.1",
-		Protocol:   ICEProtocolUDP,
-		Port:       1234,
-		Typ:        ICECandidateTypeHost,
-		Component:  1,
+		usernameFragment: "gathering-1",
+		Foundation:       "foundation",
+		Priority:         128,
+		Address:          "1.0.0.1",
+		Protocol:         ICEProtocolUDP,
+		Port:             1234,
+		Typ:              ICECandidateTypeHost,
+		Component:        1,
 	}
 
 	candidateInit := candidate.ToJSON()
 
 	assert.Equal(t, uint16(0), *candidateInit.SDPMLineIndex)
+	assert.Equal(t, "gathering-1", *candidateInit.UsernameFragment)
 	assert.Equal(t, "candidate:foundation 1 udp 128 1.0.0.1 1234 typ host", candidateInit.Candidate)
 }
 

--- a/icecandidate_test.go
+++ b/icecandidate_test.go
@@ -225,6 +225,7 @@ func TestICECandidateZeroSDPid(t *testing.T) {
 
 	assert.Equal(t, candidate.SDPMid, "")
 	assert.Equal(t, candidate.SDPMLineIndex, uint16(0))
+	assert.Empty(t, candidate.ToJSON().Candidate)
 }
 
 func TestICECandidateString(t *testing.T) {

--- a/icecandidateevent.go
+++ b/icecandidateevent.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package webrtc
+
+import "sync"
+
+// ICECandidateEvent describes one local ICE gathering event.
+//
+// Handlers receive accepted events in FIFO order. Replacing a handler or
+// setting it to nil affects only future event acceptance; already accepted
+// events retain the callback that was active when they were accepted. Closing
+// the ICEGatherer or PeerConnection discards accepted events still in the queue.
+type ICECandidateEvent struct {
+	// Candidate is the gathered candidate, or nil at the end of a gathering.
+	Candidate *ICECandidate
+	// UsernameFragment identifies the gathering that produced Candidate. For
+	// an end-of-gathering event, it identifies the exact common gathering of
+	// every current media section, or the common identity of all preceding
+	// candidates when no local description is available. It is empty when the
+	// browser or ICE agent did not provide one exact identity.
+	UsernameFragment string
+}
+
+type queuedICECandidateEvent struct {
+	event    ICECandidateEvent
+	callback func(ICECandidateEvent)
+}
+
+// iceCandidateDispatcher serializes accepted events without holding its lock
+// across callbacks. Each queued event retains the callback active at acceptance.
+type iceCandidateDispatcher struct {
+	mtx sync.Mutex
+
+	events  []queuedICECandidateEvent
+	running bool
+	stopped bool
+}
+
+func (d *iceCandidateDispatcher) enqueue(event ICECandidateEvent, callback func(ICECandidateEvent)) {
+	if d.accept([]queuedICECandidateEvent{{event: event, callback: callback}}) {
+		go d.run()
+	}
+}
+
+func (d *iceCandidateDispatcher) accept(events []queuedICECandidateEvent) bool {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	if d.stopped {
+		return false
+	}
+
+	d.events = append(d.events, events...)
+	if d.running || len(events) == 0 {
+		return false
+	}
+	d.running = true
+
+	return true
+}
+
+func (d *iceCandidateDispatcher) run() {
+	for {
+		d.mtx.Lock()
+		if d.stopped || len(d.events) == 0 {
+			d.running = false
+			d.mtx.Unlock()
+			return
+		}
+
+		event := d.events[0]
+		d.events[0] = queuedICECandidateEvent{}
+		d.events = d.events[1:]
+		d.mtx.Unlock()
+		if event.callback != nil {
+			event.callback(event.event)
+		}
+	}
+}
+
+func (d *iceCandidateDispatcher) stop() {
+	d.mtx.Lock()
+	d.stopped = true
+	d.events = nil
+	d.mtx.Unlock()
+}

--- a/icegatherer.go
+++ b/icegatherer.go
@@ -31,8 +31,9 @@ type ICEGatherer struct {
 
 	agent *ice.Agent
 
-	onLocalCandidateHandler atomic.Value // func(candidate *ICECandidate)
+	onLocalCandidateHandler atomic.Pointer[iceCandidateEventHandler]
 	onStateChangeHandler    atomic.Value // func(state ICEGathererState)
+	candidateEvents         iceCandidateDispatcher
 
 	// Used for GatheringCompletePromise
 	onGatheringCompleteHandler atomic.Value // func()
@@ -46,8 +47,17 @@ type ICEGatherer struct {
 
 	// Used for ICE candidate pooling
 	candidatePoolLock    sync.Mutex
-	candidatePool        []ice.Candidate
+	candidatePool        []iceCandidateSourceEvent
 	iceCandidatePoolSize uint8
+}
+
+type iceCandidateEventHandler struct {
+	callback func(ICECandidateEvent)
+}
+
+type iceCandidateSourceEvent struct {
+	candidate        ice.Candidate
+	usernameFragment string
 }
 
 // ICEAddressRewriteMode controls whether a rule replaces or appends candidates.
@@ -115,7 +125,7 @@ func (api *API) NewICEGatherer(opts ICEGatherOptions) (*ICEGatherer, error) {
 		log:                  api.settingEngine.LoggerFactory.NewLogger("ice"),
 		sdpMid:               atomic.Value{},
 		sdpMLineIndex:        atomic.Uint32{},
-		candidatePool:        make([]ice.Candidate, 0, opts.ICECandidatePoolSize),
+		candidatePool:        make([]iceCandidateSourceEvent, 0, opts.ICECandidatePoolSize),
 		iceCandidatePoolSize: opts.ICECandidatePoolSize,
 	}, nil
 }
@@ -425,63 +435,95 @@ func (g *ICEGatherer) Gather() error { //nolint:cyclop
 	}
 
 	g.setState(ICEGathererStateGathering)
-	if err := agent.OnCandidate(func(candidate ice.Candidate) {
-		onLocalCandidateHandler := func(*ICECandidate) {}
-		if handler, ok := g.onLocalCandidateHandler.Load().(func(candidate *ICECandidate)); ok && handler != nil {
-			onLocalCandidateHandler = handler
-		}
-
-		onGatheringCompleteHandler := func() {}
-		if handler, ok := g.onGatheringCompleteHandler.Load().(func()); ok && handler != nil {
-			onGatheringCompleteHandler = handler
-		}
-
-		sdpMid := ""
-
-		if mid, ok := g.sdpMid.Load().(string); ok {
-			sdpMid = mid
-		}
-
-		sdpMLineIndex := uint16(g.sdpMLineIndex.Load()) //nolint:gosec // G115
-
-		if candidate != nil {
-			g.candidatePoolLock.Lock()
-			if g.iceCandidatePoolSize > 0 && g.candidatePool != nil {
-				g.candidatePool = append(g.candidatePool, candidate)
-				g.candidatePoolLock.Unlock()
-
-				return
-			}
-			g.candidatePoolLock.Unlock()
-
-			c, err := newICECandidateFromICE(candidate, sdpMid, sdpMLineIndex)
-			if err != nil {
-				g.log.Warnf("Failed to convert ice.Candidate: %s", err)
-
-				return
-			}
-			onLocalCandidateHandler(&c)
-		} else {
-			g.setState(ICEGathererStateComplete)
-			onGatheringCompleteHandler()
-
-			// If gathering completes before flushing (i.e., before SetLocalDescription), avoid triggering nil.
-			// Users expect valid candidates to be emitted before the nil completion signal.
-			g.candidatePoolLock.Lock()
-			if g.iceCandidatePoolSize > 0 && g.candidatePool != nil {
-				g.candidatePoolLock.Unlock()
-
-				return
-			}
-			g.candidatePoolLock.Unlock()
-
-			onLocalCandidateHandler(nil)
-		}
-	}); err != nil {
+	g.candidatePoolLock.Lock()
+	err := g.setCandidateSourceHandler(agent, g.onLocalCandidateHandler.Load())
+	g.candidatePoolLock.Unlock()
+	if err != nil {
 		return err
 	}
 
 	return agent.GatherCandidates()
+}
+
+func (g *ICEGatherer) setCandidateSourceHandler(agent *ice.Agent, handler *iceCandidateEventHandler) error {
+	usernameFragment, _, err := agent.GetLocalUserCredentials()
+	if err != nil {
+		usernameFragment = ""
+	}
+
+	return agent.OnCandidate(func(candidate ice.Candidate) {
+		g.onCandidate(usernameFragment, handler, candidate)
+	})
+}
+
+func (g *ICEGatherer) onCandidate(
+	usernameFragment string,
+	handler *iceCandidateEventHandler,
+	candidate ice.Candidate,
+) {
+	if candidate == nil {
+		g.setState(ICEGathererStateComplete)
+		if handler, ok := g.onGatheringCompleteHandler.Load().(func()); ok && handler != nil {
+			handler()
+		}
+	}
+
+	source := iceCandidateSourceEvent{
+		candidate:        candidate,
+		usernameFragment: usernameFragment,
+	}
+
+	// candidatePoolLock orders the transition from pooled events to live events.
+	// Enqueuing the complete pool while holding it prevents a concurrent live
+	// candidate from overtaking the pool's candidates or end marker.
+	g.candidatePoolLock.Lock()
+	if g.iceCandidatePoolSize > 0 && g.candidatePool != nil {
+		g.candidatePool = append(g.candidatePool, source)
+		g.candidatePoolLock.Unlock()
+
+		return
+	}
+	shouldRun := g.acceptCandidateSourceEvents(
+		[]iceCandidateSourceEvent{source},
+		handler,
+	)
+	g.candidatePoolLock.Unlock()
+	if shouldRun {
+		g.candidateEvents.run()
+	}
+}
+
+func (g *ICEGatherer) acceptCandidateSourceEvents(
+	sources []iceCandidateSourceEvent,
+	handler *iceCandidateEventHandler,
+) bool {
+	if handler == nil {
+		return false
+	}
+
+	events := make([]queuedICECandidateEvent, 0, len(sources))
+	for _, source := range sources {
+		event := ICECandidateEvent{UsernameFragment: source.usernameFragment}
+		if source.candidate != nil {
+			sdpMid := ""
+			if mid, ok := g.sdpMid.Load().(string); ok {
+				sdpMid = mid
+			}
+			sdpMLineIndex := uint16(g.sdpMLineIndex.Load()) //nolint:gosec // G115
+
+			candidate, err := newICECandidateFromICE(source.candidate, sdpMid, sdpMLineIndex)
+			if err != nil {
+				g.log.Warnf("Failed to convert ice.Candidate: %s", err)
+
+				continue
+			}
+			candidate.usernameFragment = source.usernameFragment
+			event.Candidate = &candidate
+		}
+		events = append(events, queuedICECandidateEvent{event: event, callback: handler.callback})
+	}
+
+	return g.candidateEvents.accept(events)
 }
 
 // set media stream identification tag and media description index for this gatherer.
@@ -492,45 +534,18 @@ func (g *ICEGatherer) setMediaStreamIdentification(mid string, mLineIndex uint16
 
 func (g *ICEGatherer) flushCandidates() {
 	g.candidatePoolLock.Lock()
-
-	candidates := g.candidatePool
+	sources := g.candidatePool
 	g.candidatePool = nil
 	g.iceCandidatePoolSize = 0
-
+	shouldRun := g.acceptCandidateSourceEvents(sources, g.onLocalCandidateHandler.Load())
 	g.candidatePoolLock.Unlock()
-
-	onLocalCandidateHandler := func(*ICECandidate) {}
-	if handler, ok := g.onLocalCandidateHandler.Load().(func(candidate *ICECandidate)); ok && handler != nil {
-		onLocalCandidateHandler = handler
-	}
-
-	sdpMid := ""
-	if mid, ok := g.sdpMid.Load().(string); ok {
-		sdpMid = mid
-	}
-
-	sdpMLineIndex := uint16(g.sdpMLineIndex.Load()) //nolint:gosec // G115
-
-	currentState := g.State()
-
-	for _, candidate := range candidates {
-		c, err := newICECandidateFromICE(candidate, sdpMid, sdpMLineIndex)
-		if err != nil {
-			g.log.Warnf("Failed to convert pooled ice.Candidate: %s", err)
-
-			continue
-		}
-		onLocalCandidateHandler(&c)
-	}
-
-	// If this is true, gathering completed before flushing,
-	// so trigger nil to notify the user that all candidates have been gathered.
-	if currentState == ICEGathererStateComplete {
-		onLocalCandidateHandler(nil)
+	if shouldRun {
+		g.candidateEvents.run()
 	}
 }
 
-// Close prunes all local candidates, and closes the ports.
+// Close prunes all local candidates, closes the ports, and discards
+// ICECandidateEvent callbacks still queued.
 func (g *ICEGatherer) Close() error {
 	return g.close(false /* shouldGracefullyClose */)
 }
@@ -543,6 +558,7 @@ func (g *ICEGatherer) GracefulClose() error {
 }
 
 func (g *ICEGatherer) close(shouldGracefullyClose bool) error {
+	g.candidateEvents.stop()
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
@@ -623,10 +639,38 @@ func (g *ICEGatherer) GetLocalCandidates() ([]ICECandidate, error) {
 	return newICECandidatesFromICE(iceCandidates, sdpMid, sdpMLineIndex)
 }
 
-// OnLocalCandidate sets an event handler which fires when a new local ICE candidate is available
+// OnLocalCandidate sets an event handler which fires when a new local ICE candidate is available.
 // Take note that the handler will be called with a nil pointer when gathering is finished.
 func (g *ICEGatherer) OnLocalCandidate(f func(*ICECandidate)) {
-	g.onLocalCandidateHandler.Store(f)
+	if f == nil {
+		g.OnLocalCandidateEvent(nil)
+
+		return
+	}
+	g.OnLocalCandidateEvent(func(event ICECandidateEvent) {
+		f(event.Candidate)
+	})
+}
+
+// OnLocalCandidateEvent sets a handler for local ICE candidate events. Events
+// accepted by the gatherer are serialized in FIFO order and retain the handler
+// active at acceptance. Setting f to nil disables only future acceptance; it
+// does not discard queued events. Each event carries the exact ICE username
+// fragment captured for its gathering when available.
+func (g *ICEGatherer) OnLocalCandidateEvent(f func(ICECandidateEvent)) {
+	var handler *iceCandidateEventHandler
+	if f != nil {
+		handler = &iceCandidateEventHandler{callback: f}
+	}
+
+	g.candidatePoolLock.Lock()
+	g.onLocalCandidateHandler.Store(handler)
+	if agent := g.getAgent(); agent != nil {
+		if err := g.setCandidateSourceHandler(agent, handler); err != nil {
+			g.log.Warnf("Failed to set ICE candidate handler: %s", err)
+		}
+	}
+	g.candidatePoolLock.Unlock()
 }
 
 // OnStateChange fires any time the ICEGatherer changes.

--- a/icegatherer_test.go
+++ b/icegatherer_test.go
@@ -66,6 +66,239 @@ func TestNewICEGatherer_Success(t *testing.T) {
 	assert.NoError(t, gatherer.Close())
 }
 
+func TestICEGathererCandidateEventsPreserveOrderAndGeneration(t *testing.T) {
+	se := SettingEngine{}
+	se.SetICECredentials("generation-one", "generation-one-password")
+	gatherer, err := NewAPI(WithSettingEngine(se)).NewICEGatherer(ICEGatherOptions{})
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, gatherer.Close()) }()
+
+	firstCandidate := make(chan struct{})
+	releaseCandidate := make(chan struct{})
+	firstEvents := make(chan ICECandidateEvent, 8)
+	gatherer.OnLocalCandidateEvent(func(event ICECandidateEvent) {
+		firstEvents <- event
+		if event.Candidate != nil {
+			select {
+			case <-firstCandidate:
+			default:
+				close(firstCandidate)
+				<-releaseCandidate
+			}
+		}
+	})
+	require.NoError(t, gatherer.Gather())
+	<-firstCandidate
+	select {
+	case event := <-firstEvents:
+		require.NotNil(t, event.Candidate)
+		assert.Equal(t, "generation-one", event.UsernameFragment)
+		assert.Equal(t, "generation-one", event.Candidate.UsernameFragment())
+		assert.Equal(t, "generation-one", *event.Candidate.ToJSON().UsernameFragment)
+	case <-time.After(5 * time.Second):
+		t.Fatal("first candidate was not delivered")
+	}
+	select {
+	case event := <-firstEvents:
+		t.Fatalf("event overtook blocked candidate: %+v", event)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseCandidate)
+
+	for {
+		event := <-firstEvents
+		assert.Equal(t, "generation-one", event.UsernameFragment)
+		if event.Candidate == nil {
+			break
+		}
+	}
+
+	agent := gatherer.getAgent()
+	require.NotNil(t, agent)
+	require.NoError(t, agent.Restart("generation-two", "generation-two-password"))
+	secondEvents := make(chan ICECandidateEvent, 8)
+	gatherer.OnLocalCandidateEvent(func(event ICECandidateEvent) { secondEvents <- event })
+	require.NoError(t, gatherer.Gather())
+	for {
+		event := <-secondEvents
+		assert.Equal(t, "generation-two", event.UsernameFragment)
+		if event.Candidate == nil {
+			break
+		}
+		assert.Equal(t, "generation-two", event.Candidate.UsernameFragment())
+	}
+}
+
+func TestICEGathererLateSourceEventsKeepGeneration(t *testing.T) {
+	gatherer, err := NewAPI().NewICEGatherer(ICEGatherOptions{})
+	require.NoError(t, err)
+
+	candidate, err := ice.NewCandidateHost(&ice.CandidateHostConfig{
+		Network: "udp", Address: "192.0.2.1", Port: 3478, Component: 1,
+	})
+	require.NoError(t, err)
+
+	events := make(chan ICECandidateEvent, 2)
+	oldCalled := false
+	gatherer.OnLocalCandidateEvent(func(ICECandidateEvent) { oldCalled = true })
+	oldHandler := gatherer.onLocalCandidateHandler.Load()
+	oldSource := func(candidate ice.Candidate) {
+		gatherer.onCandidate("old-generation", oldHandler, candidate)
+	}
+	gatherer.OnLocalCandidateEvent(func(event ICECandidateEvent) { events <- event })
+	oldSource(candidate)
+	oldSource(nil)
+
+	candidateEvent := <-events
+	require.NotNil(t, candidateEvent.Candidate)
+	assert.Equal(t, "old-generation", candidateEvent.UsernameFragment)
+	assert.Equal(t, "old-generation", candidateEvent.Candidate.UsernameFragment())
+	endEvent := <-events
+	assert.False(t, oldCalled)
+	assert.Nil(t, endEvent.Candidate)
+	assert.Equal(t, "old-generation", endEvent.UsernameFragment)
+}
+
+func TestICEGathererPooledAndLiveEventsShareDeliveryOrder(t *testing.T) {
+	gatherer, err := NewAPI().NewICEGatherer(ICEGatherOptions{ICECandidatePoolSize: 1})
+	require.NoError(t, err)
+
+	candidate, err := ice.NewCandidateHost(&ice.CandidateHostConfig{
+		Network: "udp", Address: "192.0.2.1", Port: 3478, Component: 1,
+	})
+	require.NoError(t, err)
+
+	events := make(chan string, 8)
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	gatherer.OnLocalCandidateEvent(func(event ICECandidateEvent) {
+		if event.Candidate != nil {
+			events <- "old-candidate-start"
+			close(firstStarted)
+			<-releaseFirst
+			events <- "old-candidate-complete"
+			return
+		}
+		events <- "old-eoc:" + event.UsernameFragment
+	})
+
+	gatherer.onCandidate("pooled", gatherer.onLocalCandidateHandler.Load(), candidate)
+	gatherer.onCandidate("pooled", gatherer.onLocalCandidateHandler.Load(), nil)
+	go gatherer.flushCandidates()
+	<-firstStarted
+	assert.Equal(t, "old-candidate-start", <-events)
+
+	gatherer.OnLocalCandidateEvent(func(event ICECandidateEvent) {
+		events <- "new:" + event.UsernameFragment
+	})
+	gatherer.onCandidate("live", gatherer.onLocalCandidateHandler.Load(), candidate)
+	select {
+	case event := <-events:
+		t.Fatalf("live event overtook pooled delivery: %s", event)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	assert.Equal(t, "old-candidate-complete", <-events)
+	assert.Equal(t, "old-eoc:pooled", <-events)
+	assert.Equal(t, "new:live", <-events)
+}
+
+func TestICEGathererAcceptedEventsRetainCallbackAcrossReplacement(t *testing.T) {
+	gatherer, err := NewAPI().NewICEGatherer(ICEGatherOptions{})
+	require.NoError(t, err)
+
+	candidate, err := ice.NewCandidateHost(&ice.CandidateHostConfig{
+		Network: "udp", Address: "192.0.2.1", Port: 3478, Component: 1,
+	})
+	require.NoError(t, err)
+
+	events := make(chan string, 4)
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	calls := 0
+	gatherer.OnLocalCandidateEvent(func(ICECandidateEvent) {
+		calls++
+		if calls == 1 {
+			events <- "old-start"
+			close(firstStarted)
+			<-releaseFirst
+			return
+		}
+		events <- "old-queued"
+	})
+	go gatherer.onCandidate("old", gatherer.onLocalCandidateHandler.Load(), candidate)
+	<-firstStarted
+	gatherer.onCandidate("old", gatherer.onLocalCandidateHandler.Load(), candidate)
+	gatherer.OnLocalCandidateEvent(func(ICECandidateEvent) { events <- "new" })
+	gatherer.onCandidate("new", gatherer.onLocalCandidateHandler.Load(), candidate)
+	close(releaseFirst)
+
+	assert.Equal(t, "old-start", <-events)
+	assert.Equal(t, "old-queued", <-events)
+	assert.Equal(t, "new", <-events)
+}
+
+func TestICEGathererReentrantCloseDropsQueuedEvents(t *testing.T) {
+	gatherer, err := NewAPI().NewICEGatherer(ICEGatherOptions{})
+	require.NoError(t, err)
+
+	closed := make(chan struct{})
+	unexpected := make(chan struct{}, 1)
+	gatherer.candidateEvents.events = []queuedICECandidateEvent{
+		{callback: func(ICECandidateEvent) {
+			assert.NoError(t, gatherer.Close())
+			close(closed)
+		}},
+		{callback: func(ICECandidateEvent) { unexpected <- struct{}{} }},
+	}
+	gatherer.candidateEvents.running = true
+	go gatherer.candidateEvents.run()
+	<-closed
+	select {
+	case <-unexpected:
+		t.Fatal("queued callback ran after reentrant Close")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestICEGathererCandidateCallbackCanReplaceHandler(t *testing.T) {
+	gatherer, err := NewAPI().NewICEGatherer(ICEGatherOptions{})
+	require.NoError(t, err)
+
+	candidate, err := ice.NewCandidateHost(&ice.CandidateHostConfig{
+		Network: "udp", Address: "192.0.2.1", Port: 3478, Component: 1,
+	})
+	require.NoError(t, err)
+
+	events := make(chan string, 2)
+	gatherer.OnLocalCandidateEvent(func(event ICECandidateEvent) {
+		gatherer.OnLocalCandidateEvent(func(ICECandidateEvent) { events <- "replacement" })
+		events <- "original"
+	})
+	gatherer.onCandidate("original", gatherer.onLocalCandidateHandler.Load(), candidate)
+	assert.Equal(t, "original", <-events)
+	gatherer.onCandidate("replacement", gatherer.onLocalCandidateHandler.Load(), candidate)
+	assert.Equal(t, "replacement", <-events)
+}
+
+func TestICEGathererNilCandidateHandlers(t *testing.T) {
+	gatherer, err := NewAPI().NewICEGatherer(ICEGatherOptions{})
+	require.NoError(t, err)
+
+	candidate, err := ice.NewCandidateHost(&ice.CandidateHostConfig{
+		Network: "udp", Address: "192.0.2.1", Port: 3478, Component: 1,
+	})
+	require.NoError(t, err)
+
+	gatherer.OnLocalCandidate(nil)
+	gatherer.onCandidate("legacy-nil", gatherer.onLocalCandidateHandler.Load(), candidate)
+	gatherer.onCandidate("legacy-nil", gatherer.onLocalCandidateHandler.Load(), nil)
+	gatherer.OnLocalCandidateEvent(nil)
+	gatherer.onCandidate("event-nil", gatherer.onLocalCandidateHandler.Load(), candidate)
+	gatherer.onCandidate("event-nil", gatherer.onLocalCandidateHandler.Load(), nil)
+}
+
 func TestICEGather_mDNSCandidateGathering(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 20)

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -477,7 +477,22 @@ func (pc *PeerConnection) checkNegotiationNeeded() bool { //nolint:gocognit,cycl
 // Take note that the handler will be called with a nil pointer when
 // gathering is finished.
 func (pc *PeerConnection) OnICECandidate(f func(*ICECandidate)) {
-	pc.iceGatherer.OnLocalCandidate(f)
+	if f == nil {
+		pc.OnICECandidateEvent(nil)
+
+		return
+	}
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) {
+		f(event.Candidate)
+	})
+}
+
+// OnICECandidateEvent sets a handler for local ICE candidate events. Events
+// accepted by the PeerConnection are serialized in FIFO order and retain the
+// handler active at acceptance. Setting f to nil disables only future
+// acceptance; it does not discard queued events.
+func (pc *PeerConnection) OnICECandidateEvent(f func(ICECandidateEvent)) {
+	pc.iceGatherer.OnLocalCandidateEvent(f)
 }
 
 // OnICEGatheringStateChange sets an event handler which is invoked when the
@@ -2486,7 +2501,8 @@ func (pc *PeerConnection) writeRTCP(pkts []rtcp.Packet, _ interceptor.Attributes
 	return pc.dtlsTransport.WriteRTCP(pkts)
 }
 
-// Close ends the PeerConnection.
+// Close ends the PeerConnection and discards ICECandidateEvent callbacks
+// still queued.
 func (pc *PeerConnection) Close() error {
 	return pc.close(false /* shouldGracefullyClose */)
 }

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -8,6 +8,7 @@
 package webrtc
 
 import (
+	"sync"
 	"syscall/js"
 
 	"github.com/pion/ice/v4"
@@ -30,12 +31,66 @@ type PeerConnection struct {
 	onICEConnectionStateChangeHandler *js.Func
 	onICECandidateHandler             *js.Func
 	onICEGatheringStateChangeHandler  *js.Func
+	iceCandidateDispatcher            *iceCandidateDispatcher
 
 	// Used by GatheringCompletePromise
 	onGatherCompleteHandler func()
 
 	// A reference to the associated API state used by this connection
 	api *API
+}
+
+// iceCandidateEvent binds a browser event to the callback active at delivery.
+type iceCandidateEvent struct {
+	candidate *ICECandidate
+	callback  func(*ICECandidate)
+}
+
+// iceCandidateDispatcher serializes accepted events across callback replacements.
+type iceCandidateDispatcher struct {
+	mtx sync.Mutex
+
+	events  []iceCandidateEvent
+	running bool
+	stopped bool
+}
+
+func (d *iceCandidateDispatcher) enqueue(event iceCandidateEvent) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	if d.stopped {
+		return
+	}
+
+	d.events = append(d.events, event)
+	if !d.running {
+		d.running = true
+		go d.run()
+	}
+}
+
+func (d *iceCandidateDispatcher) run() {
+	for {
+		d.mtx.Lock()
+		if d.stopped || len(d.events) == 0 {
+			d.running = false
+			d.mtx.Unlock()
+			return
+		}
+
+		event := d.events[0]
+		d.events[0] = iceCandidateEvent{}
+		d.events = d.events[1:]
+		d.mtx.Unlock()
+		event.callback(event.candidate)
+	}
+}
+
+func (d *iceCandidateDispatcher) stop() {
+	d.mtx.Lock()
+	d.stopped = true
+	d.events = nil
+	d.mtx.Unlock()
 }
 
 // NewPeerConnection creates a peerconnection.
@@ -331,21 +386,31 @@ func (pc *PeerConnection) ICEConnectionState() ICEConnectionState {
 // OnICECandidate sets an event handler which is invoked when a new ICE
 // candidate is found.
 func (pc *PeerConnection) OnICECandidate(f func(candidate *ICECandidate)) {
+	// Detaching the old JavaScript function prevents new events without
+	// discarding events it already placed in the dispatcher.
 	if pc.onICECandidateHandler != nil {
-		oldHandler := pc.onICECandidateHandler
-		defer oldHandler.Release()
+		pc.underlying.Set("onicecandidate", js.Null())
+		pc.onICECandidateHandler.Release()
 	}
-	onICECandidateHandler := js.FuncOf(func(this js.Value, args []js.Value) any {
-		candidate := valueToICECandidate(args[0].Get("candidate"))
-		if candidate == nil && pc.onGatherCompleteHandler != nil {
-			go pc.onGatherCompleteHandler()
-		}
+	if pc.iceCandidateDispatcher == nil {
+		pc.iceCandidateDispatcher = &iceCandidateDispatcher{}
+	}
 
-		go f(candidate)
+	callback := func(candidate *ICECandidate) {
+		if candidate == nil && pc.onGatherCompleteHandler != nil {
+			pc.onGatherCompleteHandler()
+		}
+		f(candidate)
+	}
+	handler := js.FuncOf(func(this js.Value, args []js.Value) any {
+		pc.iceCandidateDispatcher.enqueue(iceCandidateEvent{
+			candidate: valueToICECandidate(args[0].Get("candidate")),
+			callback:  callback,
+		})
 		return js.Undefined()
 	})
-	pc.onICECandidateHandler = &onICECandidateHandler
-	pc.underlying.Set("onicecandidate", onICECandidateHandler)
+	pc.onICECandidateHandler = &handler
+	pc.underlying.Set("onicecandidate", handler)
 }
 
 // OnICEGatheringStateChange sets an event handler which is invoked when the
@@ -424,6 +489,9 @@ func (pc *PeerConnection) Close() (err error) {
 	if pc.onICECandidateHandler != nil {
 		pc.underlying.Set("onicecandidate", js.Null())
 		pc.onICECandidateHandler.Release()
+	}
+	if pc.iceCandidateDispatcher != nil {
+		pc.iceCandidateDispatcher.stop()
 	}
 	if pc.onICEGatheringStateChangeHandler != nil {
 		pc.underlying.Set("onicegatheringstatechange", js.Null())
@@ -684,14 +752,18 @@ func valueToICECandidate(val js.Value) *ICECandidate {
 	if val.IsNull() || val.IsUndefined() {
 		return nil
 	}
-	if val.Get("protocol").IsUndefined() && !val.Get("candidate").IsUndefined() {
-		// Missing some fields, assume it's Firefox and parse SDP candidate.
-		c, err := ice.UnmarshalCandidate(val.Get("candidate").String())
+	sdpMid := valueToStringOrZero(val.Get("sdpMid"))
+	sdpMLineIndex := valueToUint16OrZero(val.Get("sdpMLineIndex"))
+	candidateStr := valueToStringOrZero(val.Get("candidate"))
+	if candidateStr != "" {
+		// The SDP candidate string is authoritative; rebuilding from typed
+		// browser fields can lose fields Chromium still needs on WASM.
+		c, err := ice.UnmarshalCandidate(candidateStr)
 		if err != nil {
 			return nil
 		}
 
-		iceCandidate, err := newICECandidateFromICE(c, "", 0)
+		iceCandidate, err := newICECandidateFromICE(c, sdpMid, sdpMLineIndex)
 		if err != nil {
 			return nil
 		}
@@ -710,6 +782,8 @@ func valueToICECandidate(val js.Value) *ICECandidate {
 		Component:      stringToComponentIDOrZero(val.Get("component").String()),
 		RelatedAddress: val.Get("relatedAddress").String(),
 		RelatedPort:    valueToUint16OrZero(val.Get("relatedPort")),
+		SDPMid:         sdpMid,
+		SDPMLineIndex:  sdpMLineIndex,
 	}
 }
 

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -8,7 +8,7 @@
 package webrtc
 
 import (
-	"sync"
+	"strings"
 	"syscall/js"
 
 	"github.com/pion/ice/v4"
@@ -38,59 +38,6 @@ type PeerConnection struct {
 
 	// A reference to the associated API state used by this connection
 	api *API
-}
-
-// iceCandidateEvent binds a browser event to the callback active at delivery.
-type iceCandidateEvent struct {
-	candidate *ICECandidate
-	callback  func(*ICECandidate)
-}
-
-// iceCandidateDispatcher serializes accepted events across callback replacements.
-type iceCandidateDispatcher struct {
-	mtx sync.Mutex
-
-	events  []iceCandidateEvent
-	running bool
-	stopped bool
-}
-
-func (d *iceCandidateDispatcher) enqueue(event iceCandidateEvent) {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-	if d.stopped {
-		return
-	}
-
-	d.events = append(d.events, event)
-	if !d.running {
-		d.running = true
-		go d.run()
-	}
-}
-
-func (d *iceCandidateDispatcher) run() {
-	for {
-		d.mtx.Lock()
-		if d.stopped || len(d.events) == 0 {
-			d.running = false
-			d.mtx.Unlock()
-			return
-		}
-
-		event := d.events[0]
-		d.events[0] = iceCandidateEvent{}
-		d.events = d.events[1:]
-		d.mtx.Unlock()
-		event.callback(event.candidate)
-	}
-}
-
-func (d *iceCandidateDispatcher) stop() {
-	d.mtx.Lock()
-	d.stopped = true
-	d.events = nil
-	d.mtx.Unlock()
 }
 
 // NewPeerConnection creates a peerconnection.
@@ -386,27 +333,76 @@ func (pc *PeerConnection) ICEConnectionState() ICEConnectionState {
 // OnICECandidate sets an event handler which is invoked when a new ICE
 // candidate is found.
 func (pc *PeerConnection) OnICECandidate(f func(candidate *ICECandidate)) {
+	if f == nil {
+		pc.OnICECandidateEvent(nil)
+
+		return
+	}
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) {
+		f(event.Candidate)
+	})
+}
+
+// OnICECandidateEvent sets a handler for local ICE candidate events. Events
+// accepted from the browser are serialized in FIFO order and retain the handler
+// active at acceptance. Setting f to nil disables only future acceptance; it
+// does not discard queued events.
+func (pc *PeerConnection) OnICECandidateEvent(f func(ICECandidateEvent)) {
 	// Detaching the old JavaScript function prevents new events without
 	// discarding events it already placed in the dispatcher.
 	if pc.onICECandidateHandler != nil {
 		pc.underlying.Set("onicecandidate", js.Null())
 		pc.onICECandidateHandler.Release()
+		pc.onICECandidateHandler = nil
+	}
+	if f == nil {
+		return
 	}
 	if pc.iceCandidateDispatcher == nil {
 		pc.iceCandidateDispatcher = &iceCandidateDispatcher{}
 	}
 
-	callback := func(candidate *ICECandidate) {
-		if candidate == nil && pc.onGatherCompleteHandler != nil {
+	callback := func(event ICECandidateEvent) {
+		if event.Candidate == nil && pc.onGatherCompleteHandler != nil {
 			pc.onGatherCompleteHandler()
 		}
-		f(candidate)
+		f(event)
 	}
+	usernameFragment := ""
+	haveCandidate := false
+	haveExactCandidateIdentity := false
 	handler := js.FuncOf(func(this js.Value, args []js.Value) any {
-		pc.iceCandidateDispatcher.enqueue(iceCandidateEvent{
-			candidate: valueToICECandidate(args[0].Get("candidate")),
-			callback:  callback,
-		})
+		candidateValue := args[0].Get("candidate")
+		candidate := valueToICECandidate(candidateValue)
+		eventUsernameFragment := ""
+		if candidate != nil {
+			eventUsernameFragment = candidate.UsernameFragment()
+			if eventUsernameFragment == "" {
+				eventUsernameFragment = pc.localICEUsernameFragment(candidateValue)
+				candidate.usernameFragment = eventUsernameFragment
+			}
+
+			if !haveCandidate {
+				usernameFragment = eventUsernameFragment
+				haveExactCandidateIdentity = eventUsernameFragment != ""
+			} else if eventUsernameFragment == "" || eventUsernameFragment != usernameFragment {
+				haveExactCandidateIdentity = false
+			}
+			haveCandidate = true
+		} else if exactUsernameFragment, haveLocalDescription := pc.globalICEUsernameFragment(); haveLocalDescription {
+			eventUsernameFragment = exactUsernameFragment
+		} else if haveExactCandidateIdentity {
+			eventUsernameFragment = usernameFragment
+		}
+		pc.iceCandidateDispatcher.enqueue(ICECandidateEvent{
+			Candidate:        candidate,
+			UsernameFragment: eventUsernameFragment,
+		}, callback)
+		if candidate == nil {
+			usernameFragment = ""
+			haveCandidate = false
+			haveExactCandidateIdentity = false
+		}
 		return js.Undefined()
 	})
 	pc.onICECandidateHandler = &handler
@@ -455,7 +451,8 @@ func (pc *PeerConnection) SetIdentityProvider(provider string) (err error) {
 	return nil
 }
 
-// Close ends the PeerConnection
+// Close ends the PeerConnection and discards ICECandidateEvent callbacks
+// still queued.
 func (pc *PeerConnection) Close() (err error) {
 	defer func() {
 		if e := recover(); e != nil {
@@ -748,12 +745,199 @@ func valueToICEServer(iceServerValue js.Value) ICEServer {
 	return s
 }
 
+const (
+	maxLocalDescriptionBytes = 1 << 20
+	maxLocalDescriptionLines = 4096
+	maxLocalMediaSections    = 256
+)
+
+type localICECredentials struct {
+	sessionUsernameFragment string
+	media                   []localICEMediaCredentials
+}
+
+type localICEMediaCredentials struct {
+	mid                 string
+	usernameFragment    string
+	hasUsernameFragment bool
+}
+
+func (pc *PeerConnection) localICEUsernameFragment(candidateValue js.Value) string {
+	credentials, haveLocalDescription := pc.localICECredentials()
+	if !haveLocalDescription {
+		return ""
+	}
+
+	midValue := candidateValue.Get("sdpMid")
+	indexValue := candidateValue.Get("sdpMLineIndex")
+	haveMid := !midValue.IsNull() && !midValue.IsUndefined()
+	haveIndex := !indexValue.IsNull() && !indexValue.IsUndefined()
+	if !haveMid && !haveIndex {
+		return credentials.globalUsernameFragment()
+	}
+
+	mediaIndex := -1
+	if haveMid {
+		if midValue.Type() != js.TypeString || midValue.String() == "" {
+			return ""
+		}
+		for i := range credentials.media {
+			if credentials.media[i].mid != midValue.String() {
+				continue
+			}
+			if mediaIndex != -1 {
+				return ""
+			}
+			mediaIndex = i
+		}
+		if mediaIndex == -1 {
+			return ""
+		}
+	}
+	if haveIndex {
+		if indexValue.Type() != js.TypeNumber {
+			return ""
+		}
+		index := indexValue.Int()
+		if indexValue.Float() != float64(index) || index < 0 || index >= len(credentials.media) ||
+			(mediaIndex != -1 && mediaIndex != index) {
+			return ""
+		}
+		mediaIndex = index
+	}
+
+	return credentials.media[mediaIndex].usernameFragment
+}
+
+// globalICEUsernameFragment returns a username fragment only when every local
+// media section uses that exact fragment. The boolean reports whether a local
+// description was available, including malformed or ambiguous descriptions.
+func (pc *PeerConnection) globalICEUsernameFragment() (string, bool) {
+	credentials, haveLocalDescription := pc.localICECredentials()
+	if !haveLocalDescription {
+		return "", false
+	}
+
+	return credentials.globalUsernameFragment(), true
+}
+
+func (pc *PeerConnection) localICECredentials() (localICECredentials, bool) {
+	localDescription := pc.underlying.Get("localDescription")
+	if localDescription.Type() != js.TypeObject {
+		return localICECredentials{}, false
+	}
+
+	credentials, ok := parseLocalICECredentials(valueToStringOrZero(localDescription.Get("sdp")))
+	if !ok {
+		return localICECredentials{}, true
+	}
+
+	return credentials, true
+}
+
+func (c localICECredentials) globalUsernameFragment() string {
+	if len(c.media) == 0 {
+		return c.sessionUsernameFragment
+	}
+
+	usernameFragment := c.media[0].usernameFragment
+	if usernameFragment == "" {
+		return ""
+	}
+	for i := 1; i < len(c.media); i++ {
+		if c.media[i].usernameFragment != usernameFragment {
+			return ""
+		}
+	}
+
+	return usernameFragment
+}
+
+func parseLocalICECredentials(raw string) (localICECredentials, bool) {
+	if len(raw) == 0 || len(raw) > maxLocalDescriptionBytes {
+		return localICECredentials{}, false
+	}
+
+	credentials := localICECredentials{}
+	mediaIndex := -1
+	lineCount := 0
+	for line := range strings.SplitSeq(raw, "\n") {
+		lineCount++
+		if lineCount > maxLocalDescriptionLines {
+			return localICECredentials{}, false
+		}
+		line = strings.TrimSuffix(line, "\r")
+		if line == "" {
+			continue
+		}
+		if len(line) < 2 || line[1] != '=' {
+			return localICECredentials{}, false
+		}
+
+		switch {
+		case strings.HasPrefix(line, "m="):
+			if len(credentials.media) == maxLocalMediaSections || len(line) == 2 {
+				return localICECredentials{}, false
+			}
+			credentials.media = append(credentials.media, localICEMediaCredentials{
+				usernameFragment: credentials.sessionUsernameFragment,
+			})
+			mediaIndex = len(credentials.media) - 1
+		case strings.HasPrefix(line, "a=mid:"):
+			mid := strings.TrimPrefix(line, "a=mid:")
+			if mediaIndex == -1 || !validSDPToken(mid) || credentials.media[mediaIndex].mid != "" {
+				return localICECredentials{}, false
+			}
+			credentials.media[mediaIndex].mid = mid
+		case strings.HasPrefix(line, "a=ice-ufrag:"):
+			usernameFragment := strings.TrimPrefix(line, "a=ice-ufrag:")
+			if !validICEUsernameFragment(usernameFragment) {
+				return localICECredentials{}, false
+			}
+			if mediaIndex == -1 {
+				if credentials.sessionUsernameFragment != "" {
+					return localICECredentials{}, false
+				}
+				credentials.sessionUsernameFragment = usernameFragment
+				continue
+			}
+			// A media-level credential overrides the inherited session value, but
+			// a second attribute in the same section is malformed.
+			if credentials.media[mediaIndex].hasUsernameFragment {
+				return localICECredentials{}, false
+			}
+			credentials.media[mediaIndex].usernameFragment = usernameFragment
+			credentials.media[mediaIndex].hasUsernameFragment = true
+		}
+	}
+
+	return credentials, true
+}
+
+func validICEUsernameFragment(usernameFragment string) bool {
+	return validSDPToken(usernameFragment)
+}
+
+func validSDPToken(token string) bool {
+	if len(token) == 0 || len(token) > 256 {
+		return false
+	}
+	for _, character := range token {
+		if character <= ' ' || character > '~' {
+			return false
+		}
+	}
+
+	return true
+}
+
 func valueToICECandidate(val js.Value) *ICECandidate {
 	if val.IsNull() || val.IsUndefined() {
 		return nil
 	}
 	sdpMid := valueToStringOrZero(val.Get("sdpMid"))
 	sdpMLineIndex := valueToUint16OrZero(val.Get("sdpMLineIndex"))
+	usernameFragment := valueToStringOrZero(val.Get("usernameFragment"))
 	candidateStr := valueToStringOrZero(val.Get("candidate"))
 	if candidateStr != "" {
 		// The SDP candidate string is authoritative; rebuilding from typed
@@ -768,22 +952,24 @@ func valueToICECandidate(val js.Value) *ICECandidate {
 			return nil
 		}
 
+		iceCandidate.usernameFragment = usernameFragment
 		return &iceCandidate
 	}
 	protocol, _ := NewICEProtocol(val.Get("protocol").String())
 	candidateType, _ := NewICECandidateType(val.Get("type").String())
 	return &ICECandidate{
-		Foundation:     val.Get("foundation").String(),
-		Priority:       valueToUint32OrZero(val.Get("priority")),
-		Address:        val.Get("address").String(),
-		Protocol:       protocol,
-		Port:           valueToUint16OrZero(val.Get("port")),
-		Typ:            candidateType,
-		Component:      stringToComponentIDOrZero(val.Get("component").String()),
-		RelatedAddress: val.Get("relatedAddress").String(),
-		RelatedPort:    valueToUint16OrZero(val.Get("relatedPort")),
-		SDPMid:         sdpMid,
-		SDPMLineIndex:  sdpMLineIndex,
+		usernameFragment: usernameFragment,
+		Foundation:       val.Get("foundation").String(),
+		Priority:         valueToUint32OrZero(val.Get("priority")),
+		Address:          val.Get("address").String(),
+		Protocol:         protocol,
+		Port:             valueToUint16OrZero(val.Get("port")),
+		Typ:              candidateType,
+		Component:        stringToComponentIDOrZero(val.Get("component").String()),
+		RelatedAddress:   val.Get("relatedAddress").String(),
+		RelatedPort:      valueToUint16OrZero(val.Get("relatedPort")),
+		SDPMid:           sdpMid,
+		SDPMLineIndex:    sdpMLineIndex,
 	}
 }
 

--- a/peerconnection_js_test.go
+++ b/peerconnection_js_test.go
@@ -84,15 +84,18 @@ func TestValueToICECandidateFromNativeBrowserCandidate(t *testing.T) {
 	}
 
 	native := constructor.New(js.ValueOf(map[string]any{
-		"candidate":     "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
-		"sdpMid":        "audio",
-		"sdpMLineIndex": 2,
+		"candidate":        "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+		"sdpMid":           "audio",
+		"sdpMLineIndex":    2,
+		"usernameFragment": "browser-ufrag",
 	}))
 	candidate := valueToICECandidate(native)
 	if assert.NotNil(t, candidate) {
 		assert.Equal(t, native.Get("candidate").String(), candidate.ToJSON().Candidate)
 		assert.Equal(t, "audio", candidate.SDPMid)
 		assert.Equal(t, uint16(2), candidate.SDPMLineIndex)
+		assert.Equal(t, "browser-ufrag", candidate.UsernameFragment())
+		assert.Equal(t, "browser-ufrag", *candidate.ToJSON().UsernameFragment)
 	}
 }
 
@@ -105,13 +108,13 @@ func TestOnICECandidatePreservesBrowserEventOrder(t *testing.T) {
 	pc := &PeerConnection{underlying: js.ValueOf(map[string]any{"close": closeFunc})}
 	events := make(chan string, 3)
 	releaseCandidate := make(chan struct{})
-	pc.OnICECandidate(func(candidate *ICECandidate) {
-		if candidate == nil {
-			events <- "gathering-complete"
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) {
+		if event.Candidate == nil {
+			events <- "gathering-complete:" + event.UsernameFragment
 			return
 		}
 
-		events <- "candidate-start"
+		events <- "candidate-start:" + event.UsernameFragment
 		<-releaseCandidate
 		events <- "candidate-complete"
 	})
@@ -122,10 +125,11 @@ func TestOnICECandidatePreservesBrowserEventOrder(t *testing.T) {
 	handler := pc.underlying.Get("onicecandidate")
 	handler.Invoke(js.ValueOf(map[string]any{
 		"candidate": map[string]any{
-			"candidate": "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+			"candidate":        "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+			"usernameFragment": "gathering-1",
 		},
 	}))
-	assert.Equal(t, "candidate-start", <-events)
+	assert.Equal(t, "candidate-start:gathering-1", <-events)
 
 	// The browser delivers the end marker after its candidates. The adapter
 	// must not begin that callback while the preceding candidate is in flight.
@@ -138,66 +142,64 @@ func TestOnICECandidatePreservesBrowserEventOrder(t *testing.T) {
 
 	close(releaseCandidate)
 	assert.Equal(t, "candidate-complete", <-events)
-	assert.Equal(t, "gathering-complete", <-events)
+	assert.Equal(t, "gathering-complete:gathering-1", <-events)
 }
 
 func TestOnICECandidateReplacementDrainsAcceptedEvents(t *testing.T) {
-	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any {
-		return nil
-	})
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any { return nil })
 	defer closeFunc.Release()
 
 	pc := &PeerConnection{underlying: js.ValueOf(map[string]any{"close": closeFunc})}
-	events := make(chan string, 5)
+	events := make(chan string, 6)
 	firstStarted := make(chan struct{})
-	allowReplacement := make(chan struct{})
-	replaced := make(chan struct{})
+	releaseFirst := make(chan struct{})
 	oldCalls := 0
-	pc.OnICECandidate(func(candidate *ICECandidate) {
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) {
 		oldCalls++
-		if oldCalls != 1 {
-			events <- "old-candidate-2"
+		if oldCalls == 1 {
+			events <- "old-start:" + event.UsernameFragment
+			close(firstStarted)
+			<-releaseFirst
+			events <- "old-complete:" + event.UsernameFragment
 			return
 		}
-
-		events <- "old-candidate-1-start"
-		close(firstStarted)
-		<-allowReplacement
-		pc.OnICECandidate(func(candidate *ICECandidate) {
-			if candidate == nil {
-				events <- "new-gathering-complete"
-				return
-			}
-			events <- "new-candidate"
-		})
-		close(replaced)
-		events <- "old-candidate-1-complete"
+		if event.Candidate == nil {
+			events <- "old-eoc:" + event.UsernameFragment
+			return
+		}
+		events <- "old-late:" + event.UsernameFragment
 	})
-	defer func() {
-		assert.NoError(t, pc.Close())
-	}()
+	defer func() { assert.NoError(t, pc.Close()) }()
 
-	candidateEvent := js.ValueOf(map[string]any{
-		"candidate": map[string]any{
-			"candidate": "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
-		},
-	})
+	oldCandidate := js.ValueOf(map[string]any{"candidate": map[string]any{
+		"candidate": "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host", "usernameFragment": "old",
+	}})
 	oldHandler := pc.underlying.Get("onicecandidate")
-	oldHandler.Invoke(candidateEvent)
+	oldHandler.Invoke(oldCandidate)
 	<-firstStarted
-	assert.Equal(t, "old-candidate-1-start", <-events)
+	oldHandler.Invoke(oldCandidate)
+	oldHandler.Invoke(js.ValueOf(map[string]any{"candidate": nil}))
 
-	oldHandler.Invoke(candidateEvent)
-	close(allowReplacement)
-	<-replaced
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) {
+		if event.Candidate == nil {
+			events <- "new-eoc:" + event.UsernameFragment
+			return
+		}
+		events <- "new:" + event.UsernameFragment
+	})
 	newHandler := pc.underlying.Get("onicecandidate")
-	newHandler.Invoke(candidateEvent)
+	newHandler.Invoke(js.ValueOf(map[string]any{"candidate": map[string]any{
+		"candidate": "candidate:2 1 udp 2130706431 192.0.2.2 3478 typ host", "usernameFragment": "new",
+	}}))
 	newHandler.Invoke(js.ValueOf(map[string]any{"candidate": nil}))
+	close(releaseFirst)
 
-	assert.Equal(t, "old-candidate-1-complete", <-events)
-	assert.Equal(t, "old-candidate-2", <-events)
-	assert.Equal(t, "new-candidate", <-events)
-	assert.Equal(t, "new-gathering-complete", <-events)
+	assert.Equal(t, "old-start:old", <-events)
+	assert.Equal(t, "old-complete:old", <-events)
+	assert.Equal(t, "old-late:old", <-events)
+	assert.Equal(t, "old-eoc:old", <-events)
+	assert.Equal(t, "new:new", <-events)
+	assert.Equal(t, "new-eoc:new", <-events)
 }
 
 func TestCloseDropsQueuedICECandidateCallbacks(t *testing.T) {
@@ -238,6 +240,259 @@ func TestCloseDropsQueuedICECandidateCallbacks(t *testing.T) {
 		t.Fatal("queued candidate callback ran after Close")
 	case <-time.After(50 * time.Millisecond):
 	}
+}
+
+func TestOnICECandidateZeroCandidateRestartUsesLocalDescriptionGeneration(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any { return nil })
+	defer closeFunc.Release()
+
+	underlying := js.ValueOf(map[string]any{
+		"close": closeFunc,
+		"localDescription": map[string]any{
+			"sdp": "v=0\r\na=ice-ufrag:first-generation\r\n",
+		},
+	})
+	pc := &PeerConnection{underlying: underlying}
+	defer func() { assert.NoError(t, pc.Close()) }()
+
+	events := make(chan string, 2)
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) { events <- event.UsernameFragment })
+	pc.underlying.Get("onicecandidate").Invoke(js.ValueOf(map[string]any{"candidate": nil}))
+	assert.Equal(t, "first-generation", <-events)
+
+	underlying.Set("localDescription", map[string]any{
+		"sdp": "v=0\r\na=ice-ufrag:second-generation\r\n",
+	})
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) { events <- event.UsernameFragment })
+	pc.underlying.Get("onicecandidate").Invoke(js.ValueOf(map[string]any{"candidate": nil}))
+	assert.Equal(t, "second-generation", <-events)
+}
+
+func TestOnICECandidateEmptyIdentityDoesNotInheritPriorGeneration(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any { return nil })
+	defer closeFunc.Release()
+
+	underlying := js.ValueOf(map[string]any{
+		"close": closeFunc,
+		"localDescription": map[string]any{
+			"sdp": "v=0\r\na=ice-ufrag:known-generation\r\n",
+		},
+	})
+	pc := &PeerConnection{underlying: underlying}
+	defer func() { assert.NoError(t, pc.Close()) }()
+
+	events := make(chan ICECandidateEvent, 4)
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) { events <- event })
+	handler := pc.underlying.Get("onicecandidate")
+	handler.Invoke(js.ValueOf(map[string]any{"candidate": map[string]any{
+		"candidate":        "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+		"usernameFragment": "known-generation",
+	}}))
+	handler.Invoke(js.ValueOf(map[string]any{"candidate": nil}))
+	assert.Equal(t, "known-generation", (<-events).UsernameFragment)
+	assert.Equal(t, "known-generation", (<-events).UsernameFragment)
+
+	underlying.Set("localDescription", js.Null())
+	handler.Invoke(js.ValueOf(map[string]any{"candidate": map[string]any{
+		"candidate":        "candidate:2 1 udp 2130706431 192.0.2.2 3478 typ host",
+		"usernameFragment": "",
+	}}))
+	handler.Invoke(js.ValueOf(map[string]any{"candidate": nil}))
+
+	candidateEvent := <-events
+	if assert.NotNil(t, candidateEvent.Candidate) {
+		assert.Empty(t, candidateEvent.Candidate.UsernameFragment())
+	}
+	assert.Empty(t, candidateEvent.UsernameFragment)
+	endEvent := <-events
+	assert.Nil(t, endEvent.Candidate)
+	assert.Empty(t, endEvent.UsernameFragment)
+}
+
+func TestOnICECandidateUsesSelectedMediaUsernameFragment(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any { return nil })
+	defer closeFunc.Release()
+
+	pc := &PeerConnection{underlying: js.ValueOf(map[string]any{
+		"close": closeFunc,
+		"localDescription": map[string]any{"sdp": "v=0\r\n" +
+			"a=ice-ufrag:session-generation\r\n" +
+			"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+			"a=mid:audio\r\n" +
+			"a=ice-ufrag:audio-generation\r\n" +
+			"m=video 9 UDP/TLS/RTP/SAVPF 96\r\n" +
+			"a=mid:video\r\n" +
+			"a=ice-ufrag:video-generation\r\n"},
+	})}
+	defer func() { assert.NoError(t, pc.Close()) }()
+
+	events := make(chan ICECandidateEvent, 2)
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) { events <- event })
+	handler := pc.underlying.Get("onicecandidate")
+	handler.Invoke(js.ValueOf(map[string]any{"candidate": map[string]any{
+		"candidate":     "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+		"sdpMid":        "video",
+		"sdpMLineIndex": 1,
+	}}))
+	handler.Invoke(js.ValueOf(map[string]any{"candidate": nil}))
+
+	candidateEvent := <-events
+	if assert.NotNil(t, candidateEvent.Candidate) {
+		assert.Equal(t, "video-generation", candidateEvent.Candidate.UsernameFragment())
+		assert.Equal(t, "video-generation", *candidateEvent.Candidate.ToJSON().UsernameFragment)
+	}
+	assert.Equal(t, "video-generation", candidateEvent.UsernameFragment)
+
+	endEvent := <-events
+	assert.Nil(t, endEvent.Candidate)
+	assert.Empty(t, endEvent.UsernameFragment, "global end marker cannot select one of multiple ICE transports")
+}
+
+func TestLocalICEUsernameFragmentSelection(t *testing.T) {
+	const distinctMedia = "v=0\r\n" +
+		"a=ice-ufrag:session-generation\r\n" +
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+		"a=mid:audio\r\n" +
+		"a=ice-ufrag:audio-generation\r\n" +
+		"m=video 9 UDP/TLS/RTP/SAVPF 96\r\n" +
+		"a=mid:video\r\n" +
+		"a=ice-ufrag:video-generation\r\n"
+
+	testCases := []struct {
+		name      string
+		sdp       string
+		candidate map[string]any
+		expect    string
+	}{
+		{
+			name: "session credential inherited",
+			sdp: "v=0\r\na=ice-ufrag:session-generation\r\n" +
+				"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=mid:audio\r\n",
+			candidate: map[string]any{"sdpMid": "audio", "sdpMLineIndex": 0},
+			expect:    "session-generation",
+		},
+		{
+			name:      "media index selects override",
+			sdp:       distinctMedia,
+			candidate: map[string]any{"sdpMLineIndex": 1},
+			expect:    "video-generation",
+		},
+		{
+			name:      "selectors absent in multi transport description",
+			sdp:       distinctMedia,
+			candidate: map[string]any{},
+		},
+		{
+			name: "candidate mid absent from description",
+			sdp: "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+				"a=ice-ufrag:audio-generation\r\n",
+			candidate: map[string]any{"sdpMid": "audio", "sdpMLineIndex": 0},
+		},
+		{
+			name: "malformed mid is rejected",
+			sdp: "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+				"a=mid:bad mid\r\na=ice-ufrag:audio-generation\r\n",
+			candidate: map[string]any{"sdpMid": "bad mid", "sdpMLineIndex": 0},
+		},
+		{
+			name: "duplicate mid is ambiguous",
+			sdp: "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+				"a=mid:duplicate\r\na=ice-ufrag:first\r\n" +
+				"m=video 9 UDP/TLS/RTP/SAVPF 96\r\n" +
+				"a=mid:duplicate\r\na=ice-ufrag:second\r\n",
+			candidate: map[string]any{"sdpMid": "duplicate", "sdpMLineIndex": 1},
+		},
+		{
+			name:      "mid and index disagree",
+			sdp:       distinctMedia,
+			candidate: map[string]any{"sdpMid": "audio", "sdpMLineIndex": 1},
+		},
+		{
+			name:      "malformed SDP",
+			sdp:       "v=0\r\nnot-an-sdp-line\r\na=ice-ufrag:first\r\n",
+			candidate: map[string]any{},
+		},
+		{
+			name: "duplicate media credential",
+			sdp: "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=mid:audio\r\n" +
+				"a=ice-ufrag:first\r\na=ice-ufrag:second\r\n",
+			candidate: map[string]any{"sdpMid": "audio", "sdpMLineIndex": 0},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			pc := &PeerConnection{underlying: js.ValueOf(map[string]any{
+				"localDescription": map[string]any{"sdp": testCase.sdp},
+			})}
+			assert.Equal(t, testCase.expect, pc.localICEUsernameFragment(js.ValueOf(testCase.candidate)))
+		})
+	}
+}
+
+func TestOnICECandidateReentrantReplacementRetainsAcceptedCallback(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any { return nil })
+	defer closeFunc.Release()
+
+	pc := &PeerConnection{underlying: js.ValueOf(map[string]any{"close": closeFunc})}
+	defer func() { assert.NoError(t, pc.Close()) }()
+
+	events := make(chan string, 4)
+	calls := 0
+	pc.OnICECandidateEvent(func(event ICECandidateEvent) {
+		calls++
+		events <- "old"
+		if calls == 1 {
+			pc.OnICECandidateEvent(func(ICECandidateEvent) { events <- "new" })
+		}
+	})
+	candidate := js.ValueOf(map[string]any{"candidate": map[string]any{
+		"candidate": "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+	}})
+	pc.underlying.Get("onicecandidate").Invoke(candidate)
+	assert.Equal(t, "old", <-events)
+
+	pc.underlying.Get("onicecandidate").Invoke(candidate)
+	assert.Equal(t, "new", <-events)
+}
+
+func TestOnICECandidateReentrantCloseDropsQueuedCallbacks(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any { return nil })
+	defer closeFunc.Release()
+
+	dispatcher := &iceCandidateDispatcher{running: true}
+	pc := &PeerConnection{
+		underlying:             js.ValueOf(map[string]any{"close": closeFunc}),
+		iceCandidateDispatcher: dispatcher,
+	}
+	closed := make(chan struct{})
+	unexpected := make(chan struct{}, 1)
+	dispatcher.events = []queuedICECandidateEvent{
+		{callback: func(ICECandidateEvent) {
+			assert.NoError(t, pc.Close())
+			close(closed)
+		}},
+		{callback: func(ICECandidateEvent) { unexpected <- struct{}{} }},
+	}
+	go dispatcher.run()
+	<-closed
+	select {
+	case <-unexpected:
+		t.Fatal("queued callback ran after reentrant Close")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestOnICECandidateNilHandlers(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any { return nil })
+	defer closeFunc.Release()
+
+	pc := &PeerConnection{underlying: js.ValueOf(map[string]any{"close": closeFunc})}
+	defer func() { assert.NoError(t, pc.Close()) }()
+	pc.OnICECandidate(nil)
+	assert.Equal(t, js.TypeUndefined, pc.underlying.Get("onicecandidate").Type())
+	pc.OnICECandidateEvent(nil)
+	assert.Equal(t, js.TypeUndefined, pc.underlying.Get("onicecandidate").Type())
 }
 
 func TestValueToICEServer(t *testing.T) {

--- a/peerconnection_js_test.go
+++ b/peerconnection_js_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"syscall/js"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -45,18 +46,21 @@ func TestValueToICECandidate(t *testing.T) {
 				RelatedPort:    0,
 			},
 		}, {
-			// Both are present, Chrome/Webkit-style takes precedent:
-			`{"candidate":"1966762133 1 udp 2122260222 192.168.20.128 47298 typ srflx raddr 203.0.113.1 rport 5000", "foundation":"1966762134", "component":"rtp", "protocol":"udp", "priority":2122260223, "address":"192.168.20.129", "port":47299, "type":"host", "relatedAddress":null}`,
+			// Both are present; the SDP candidate string is the browser's
+			// authoritative candidate payload.
+			`{"candidate":"1966762133 1 udp 2122260222 192.168.20.128 47298 typ srflx raddr 203.0.113.1 rport 5000", "foundation":"1966762134", "component":"rtp", "protocol":"udp", "priority":2122260223, "address":"192.168.20.129", "port":47299, "type":"host", "relatedAddress":null, "sdpMid":"0", "sdpMLineIndex":2}`,
 			ICECandidate{
-				Foundation:     "1966762134",
-				Priority:       2122260223,
-				Address:        "192.168.20.129",
+				Foundation:     "1966762133",
+				Priority:       2122260222,
+				Address:        "192.168.20.128",
 				Protocol:       ICEProtocolUDP,
-				Port:           47299,
-				Typ:            ICECandidateTypeHost,
+				Port:           47298,
+				Typ:            ICECandidateTypeSrflx,
 				Component:      1,
-				RelatedAddress: "<null>",
-				RelatedPort:    0,
+				RelatedAddress: "203.0.113.1",
+				RelatedPort:    5000,
+				SDPMid:         "0",
+				SDPMLineIndex:  2,
 			},
 		},
 	}
@@ -70,6 +74,169 @@ func TestValueToICECandidate(t *testing.T) {
 		val := *valueToICECandidate(js.ValueOf(v))
 		val.statsID = ""
 		assert.Equal(t, testCase.expect, val)
+	}
+}
+
+func TestValueToICECandidateFromNativeBrowserCandidate(t *testing.T) {
+	constructor := js.Global().Get("RTCIceCandidate")
+	if constructor.IsUndefined() {
+		t.Skip("RTCIceCandidate constructor is not available")
+	}
+
+	native := constructor.New(js.ValueOf(map[string]any{
+		"candidate":     "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+		"sdpMid":        "audio",
+		"sdpMLineIndex": 2,
+	}))
+	candidate := valueToICECandidate(native)
+	if assert.NotNil(t, candidate) {
+		assert.Equal(t, native.Get("candidate").String(), candidate.ToJSON().Candidate)
+		assert.Equal(t, "audio", candidate.SDPMid)
+		assert.Equal(t, uint16(2), candidate.SDPMLineIndex)
+	}
+}
+
+func TestOnICECandidatePreservesBrowserEventOrder(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return nil
+	})
+	defer closeFunc.Release()
+
+	pc := &PeerConnection{underlying: js.ValueOf(map[string]any{"close": closeFunc})}
+	events := make(chan string, 3)
+	releaseCandidate := make(chan struct{})
+	pc.OnICECandidate(func(candidate *ICECandidate) {
+		if candidate == nil {
+			events <- "gathering-complete"
+			return
+		}
+
+		events <- "candidate-start"
+		<-releaseCandidate
+		events <- "candidate-complete"
+	})
+	defer func() {
+		assert.NoError(t, pc.Close())
+	}()
+
+	handler := pc.underlying.Get("onicecandidate")
+	handler.Invoke(js.ValueOf(map[string]any{
+		"candidate": map[string]any{
+			"candidate": "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+		},
+	}))
+	assert.Equal(t, "candidate-start", <-events)
+
+	// The browser delivers the end marker after its candidates. The adapter
+	// must not begin that callback while the preceding candidate is in flight.
+	handler.Invoke(js.ValueOf(map[string]any{"candidate": nil}))
+	select {
+	case event := <-events:
+		t.Fatalf("callback order violated: got %q before candidate completion", event)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseCandidate)
+	assert.Equal(t, "candidate-complete", <-events)
+	assert.Equal(t, "gathering-complete", <-events)
+}
+
+func TestOnICECandidateReplacementDrainsAcceptedEvents(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return nil
+	})
+	defer closeFunc.Release()
+
+	pc := &PeerConnection{underlying: js.ValueOf(map[string]any{"close": closeFunc})}
+	events := make(chan string, 5)
+	firstStarted := make(chan struct{})
+	allowReplacement := make(chan struct{})
+	replaced := make(chan struct{})
+	oldCalls := 0
+	pc.OnICECandidate(func(candidate *ICECandidate) {
+		oldCalls++
+		if oldCalls != 1 {
+			events <- "old-candidate-2"
+			return
+		}
+
+		events <- "old-candidate-1-start"
+		close(firstStarted)
+		<-allowReplacement
+		pc.OnICECandidate(func(candidate *ICECandidate) {
+			if candidate == nil {
+				events <- "new-gathering-complete"
+				return
+			}
+			events <- "new-candidate"
+		})
+		close(replaced)
+		events <- "old-candidate-1-complete"
+	})
+	defer func() {
+		assert.NoError(t, pc.Close())
+	}()
+
+	candidateEvent := js.ValueOf(map[string]any{
+		"candidate": map[string]any{
+			"candidate": "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+		},
+	})
+	oldHandler := pc.underlying.Get("onicecandidate")
+	oldHandler.Invoke(candidateEvent)
+	<-firstStarted
+	assert.Equal(t, "old-candidate-1-start", <-events)
+
+	oldHandler.Invoke(candidateEvent)
+	close(allowReplacement)
+	<-replaced
+	newHandler := pc.underlying.Get("onicecandidate")
+	newHandler.Invoke(candidateEvent)
+	newHandler.Invoke(js.ValueOf(map[string]any{"candidate": nil}))
+
+	assert.Equal(t, "old-candidate-1-complete", <-events)
+	assert.Equal(t, "old-candidate-2", <-events)
+	assert.Equal(t, "new-candidate", <-events)
+	assert.Equal(t, "new-gathering-complete", <-events)
+}
+
+func TestCloseDropsQueuedICECandidateCallbacks(t *testing.T) {
+	closeFunc := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return nil
+	})
+	defer closeFunc.Release()
+
+	pc := &PeerConnection{underlying: js.ValueOf(map[string]any{"close": closeFunc})}
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	unexpected := make(chan struct{}, 1)
+	calls := 0
+	pc.OnICECandidate(func(candidate *ICECandidate) {
+		calls++
+		if calls == 1 {
+			close(firstStarted)
+			<-releaseFirst
+			return
+		}
+		unexpected <- struct{}{}
+	})
+
+	handler := pc.underlying.Get("onicecandidate")
+	event := js.ValueOf(map[string]any{
+		"candidate": map[string]any{
+			"candidate": "candidate:1 1 udp 2130706431 192.0.2.1 3478 typ host",
+		},
+	})
+	handler.Invoke(event)
+	<-firstStarted
+	handler.Invoke(event)
+	assert.NoError(t, pc.Close())
+	close(releaseFirst)
+
+	select {
+	case <-unexpected:
+		t.Fatal("queued candidate callback ran after Close")
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 


### PR DESCRIPTION
The WASM browser adapter rebuilt Chromium ICE candidates from typed fields, losing the browser's authoritative candidate string and SDP location. It also started each callback in an independent goroutine, so an end-of-candidates marker could overtake a candidate still being applied.

Parse the native candidate string when available and preserve sdpMid and sdpMLineIndex. A PeerConnection-local dispatcher now serializes browser events without blocking JavaScript delivery. Each accepted event retains the callback active when it arrived, so handler replacement drains prior work before events for the new handler.

Closing the PeerConnection detaches the JavaScript callback and discards queued work while allowing an active user callback to return. The worker exits whenever its queue empties, avoiding an idle goroutine for connections with no candidate work.

This changes WASM candidate callbacks from concurrent to ordered delivery and keeps the nil completion marker behind preceding candidates. Native PeerConnection behavior and public types remain unchanged.
