### PR TITLE
Refresh codec preferences during renegotiation

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1251,6 +1251,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 			}
 			if transceiver != nil {
 				transceiver.setCurrentRemoteDirection(direction)
+				transceiver.updateCodecPreferencesFromRemoteDescription(media)
 			}
 
 			switch {

--- a/peerconnection_renegotiation_test.go
+++ b/peerconnection_renegotiation_test.go
@@ -1369,6 +1369,103 @@ func TestPeerConnection_Regegotiation_AnswerAddsTrack(t *testing.T) {
 	closePairNow(t, pcOffer, pcAnswer)
 }
 
+//nolint:cyclop
+func TestPeerConnection_Renegotiation_CodecPreferences(t *testing.T) {
+	testCases := []struct {
+		name                        string
+		setExplicitPreferences      bool
+		expectedAnswerCodecMimeType string
+	}{
+		{
+			name:                        "update remote-derived preferences",
+			expectedAnswerCodecMimeType: MimeTypeH264,
+		},
+		{
+			name:                        "preserve explicit preferences",
+			setExplicitPreferences:      true,
+			expectedAnswerCodecMimeType: MimeTypeVP8,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			report := test.CheckRoutines(t)
+			defer report()
+
+			pcOffer, pcAnswer, err := newPair()
+			require.NoError(t, err)
+			defer closePairNow(t, pcOffer, pcAnswer)
+
+			offerTransceivers := make([]*RTPTransceiver, 2)
+			for i := range offerTransceivers {
+				offerTransceivers[i], err = pcOffer.AddTransceiverFromKind(RTPCodecTypeVideo)
+				require.NoError(t, err)
+			}
+
+			codecByMimeType := func(mimeType string) RTPCodecParameters {
+				for _, codec := range offerTransceivers[0].api.mediaEngine.getCodecsByKind(RTPCodecTypeVideo) {
+					if strings.EqualFold(codec.MimeType, mimeType) {
+						return codec
+					}
+				}
+
+				require.FailNow(t, "codec is not registered", mimeType)
+
+				return RTPCodecParameters{}
+			}
+
+			vp8Codec := codecByMimeType(MimeTypeVP8)
+			h264Codec := codecByMimeType(MimeTypeH264)
+			for _, transceiver := range offerTransceivers {
+				require.NoError(t, transceiver.SetCodecPreferences([]RTPCodecParameters{vp8Codec}))
+			}
+			require.NoError(t, signalPair(pcOffer, pcAnswer))
+
+			answerTransceivers := pcAnswer.GetTransceivers()
+			require.Len(t, answerTransceivers, 2)
+			for _, transceiver := range answerTransceivers {
+				require.Equal(t, MimeTypeVP8, transceiver.getCodecs()[0].MimeType)
+			}
+			if testCase.setExplicitPreferences {
+				require.NoError(t, answerTransceivers[1].SetCodecPreferences([]RTPCodecParameters{vp8Codec}))
+			}
+
+			pcReoffer, err := NewPeerConnection(Configuration{})
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, pcReoffer.Close())
+			}()
+
+			reofferTransceivers := make([]*RTPTransceiver, 2)
+			for i, codec := range []RTPCodecParameters{vp8Codec, h264Codec} {
+				reofferTransceivers[i], err = pcReoffer.AddTransceiverFromKind(RTPCodecTypeVideo)
+				require.NoError(t, err)
+				require.NoError(t, reofferTransceivers[i].SetCodecPreferences([]RTPCodecParameters{codec}))
+			}
+			offer, err := pcReoffer.CreateOffer(nil)
+			require.NoError(t, err)
+			require.NoError(t, pcAnswer.SetRemoteDescription(offer))
+
+			require.Equal(t, MimeTypeVP8, answerTransceivers[0].getCodecs()[0].MimeType)
+			require.Equal(t, testCase.expectedAnswerCodecMimeType, answerTransceivers[1].getCodecs()[0].MimeType)
+			if !testCase.setExplicitPreferences {
+				answer, err := pcAnswer.CreateAnswer(nil)
+				require.NoError(t, err)
+				parsed, err := answer.Unmarshal()
+				require.NoError(t, err)
+				require.Len(t, parsed.MediaDescriptions, 2)
+				for i, mimeType := range []string{MimeTypeVP8, MimeTypeH264} {
+					require.Equal(t, answerTransceivers[i].Mid(), getMidValue(parsed.MediaDescriptions[i]))
+					codecs, err := codecsFromMediaDescription(parsed.MediaDescriptions[i])
+					require.NoError(t, err)
+					require.NotEmpty(t, codecs)
+					require.Equal(t, mimeType, codecs[0].MimeType)
+				}
+			}
+		})
+	}
+}
+
 func TestNegotiationNeededWithRecvonlyTrack(t *testing.T) {
 	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()

--- a/rtptransceiver.go
+++ b/rtptransceiver.go
@@ -25,7 +25,8 @@ type RTPTransceiver struct {
 	currentDirection       atomic.Value // RTPTransceiverDirection
 	currentRemoteDirection atomic.Value // RTPTransceiverDirection
 
-	codecs []RTPCodecParameters // User provided codecs via SetCodecPreferences
+	codecs                     []RTPCodecParameters
+	codecPreferencesFromRemote bool
 
 	kind RTPCodecType
 
@@ -52,8 +53,19 @@ func newRTPTransceiver(
 // SetCodecPreferences sets preferred list of supported codecs
 // if codecs is empty or nil we reset to default from MediaEngine.
 func (t *RTPTransceiver) SetCodecPreferences(codecs []RTPCodecParameters) error {
+	return t.setCodecPreferences(codecs, false, false)
+}
+
+func (t *RTPTransceiver) setCodecPreferences(
+	codecs []RTPCodecParameters,
+	fromRemoteDescription bool,
+	requireExistingRemotePreferences bool,
+) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if requireExistingRemotePreferences && !t.codecPreferencesFromRemote {
+		return nil
+	}
 
 	for _, codec := range codecs {
 		if _, matchType := codecParametersFuzzySearch(
@@ -64,6 +76,7 @@ func (t *RTPTransceiver) SetCodecPreferences(codecs []RTPCodecParameters) error 
 	}
 
 	t.codecs = filterUnattachedRTX(codecs)
+	t.codecPreferencesFromRemote = fromRemoteDescription
 
 	return nil
 }
@@ -92,9 +105,23 @@ func (t *RTPTransceiver) getCodecs() []RTPCodecParameters {
 	return filterUnattachedRTX(filteredCodecs)
 }
 
-// match codecs from remote description, used when remote is offerer and creating a transceiver
-// from remote description with the aim of keeping order of codecs in remote description.
-func (t *RTPTransceiver) setCodecPreferencesFromRemoteDescription(media *sdp.MediaDescription) { //nolint:cyclop
+// setCodecPreferencesFromRemoteDescription matches codecs from the remote description when
+// creating a transceiver, with the aim of keeping their order from the remote description.
+func (t *RTPTransceiver) setCodecPreferencesFromRemoteDescription(media *sdp.MediaDescription) {
+	t.setCodecPreferencesFromRemoteDescriptionIfNeeded(media, false)
+}
+
+// updateCodecPreferencesFromRemoteDescription refreshes preferences that were previously derived
+// from a remote description, without overwriting preferences provided through SetCodecPreferences.
+func (t *RTPTransceiver) updateCodecPreferencesFromRemoteDescription(media *sdp.MediaDescription) {
+	t.setCodecPreferencesFromRemoteDescriptionIfNeeded(media, true)
+}
+
+//nolint:cyclop
+func (t *RTPTransceiver) setCodecPreferencesFromRemoteDescriptionIfNeeded(
+	media *sdp.MediaDescription,
+	requireExistingRemotePreferences bool,
+) {
 	remoteCodecs, err := codecsFromMediaDescription(media)
 	if err != nil {
 		return
@@ -179,7 +206,7 @@ func (t *RTPTransceiver) setCodecPreferencesFromRemoteDescription(media *sdp.Med
 			}
 		}
 	}
-	_ = t.SetCodecPreferences(filteredCodecs)
+	_ = t.setCodecPreferences(filteredCodecs, true, requireExistingRemotePreferences)
 }
 
 // Sender returns the RTPTransceiver's RTPSender if it has one.


### PR DESCRIPTION
## Summary

- refresh codec preferences derived from remote SDP when `SetRemoteDescription` reuses an existing transceiver during renegotiation
- preserve application-provided preferences set through `SetCodecPreferences`
- add regression coverage for two video MIDs where one changes from VP8 to H264

Fixes #3276

## Testing

- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/main`