### PR TITLE
Skip DTLS HelloVerifyRequest by default

### DIFF
--- a/dtlstransport.go
+++ b/dtlstransport.go
@@ -517,10 +517,18 @@ func (t *DTLSTransport) toDTLSServerOptions(sharedOpts []dtls.Option) []dtls.Ser
 		clientAuth = *t.api.settingEngine.dtls.clientAuth
 	}
 
+	// The HelloVerifyRequest cookie exchange only validates the remote
+	// address, which the ICE connectivity checks have already done, so it
+	// is skipped unless explicitly requested via the SettingEngine.
+	skipHelloVerify := true
+	if skip := t.api.settingEngine.dtls.insecureSkipHelloVerify; skip != nil {
+		skipHelloVerify = *skip
+	}
+
 	serverOpts = append(serverOpts,
 		dtls.WithClientAuth(clientAuth),
 		dtls.WithClientCAs(t.api.settingEngine.dtls.clientCAs),
-		dtls.WithInsecureSkipVerifyHello(t.api.settingEngine.dtls.insecureSkipHelloVerify),
+		dtls.WithInsecureSkipVerifyHello(skipHelloVerify),
 	)
 
 	if t.api.settingEngine.dtls.serverHelloMessageHook != nil {

--- a/settingengine.go
+++ b/settingengine.go
@@ -67,7 +67,7 @@ type SettingEngine struct {
 		SRTCP *uint
 	}
 	dtls struct {
-		insecureSkipHelloVerify       bool
+		insecureSkipHelloVerify       *bool
 		disableInsecureSkipVerify     bool
 		retransmissionInterval        time.Duration
 		ellipticCurves                []dtlsElliptic.Curve
@@ -549,11 +549,14 @@ func (e *SettingEngine) SetDTLSRetransmissionInterval(interval time.Duration) {
 }
 
 // SetDTLSInsecureSkipHelloVerify sets the skip HelloVerify flag for DTLS.
-// If true and when acting as DTLS server, will allow client to skip hello verify phase and
-// receive ServerHello after initial ClientHello. This will mean faster connect times,
-// but will have lower DoS attack resistance.
+//
+// Deprecated: the HelloVerifyRequest cookie exchange only validates the
+// remote address, which the ICE connectivity checks have already done, so it
+// is skipped by default. This setter is retained for backward compatibility;
+// pass false to restore the cookie exchange when acting as DTLS server. It
+// will be removed in v5.
 func (e *SettingEngine) SetDTLSInsecureSkipHelloVerify(skip bool) {
-	e.dtls.insecureSkipHelloVerify = skip
+	e.dtls.insecureSkipHelloVerify = &skip
 }
 
 // SetDTLSDisableInsecureSkipVerify sets the disable skip insecure verify flag for DTLS.

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -734,7 +734,11 @@ func TestSettingEngine_DTLSSetters(t *testing.T) {
 		return nil
 	})
 
-	assert.True(t, se.dtls.insecureSkipHelloVerify)
+	assert.True(t, *se.dtls.insecureSkipHelloVerify)
+	se.SetDTLSInsecureSkipHelloVerify(false)
+	assert.False(t, *se.dtls.insecureSkipHelloVerify)
+	se.SetDTLSInsecureSkipHelloVerify(true)
+	assert.True(t, *se.dtls.insecureSkipHelloVerify)
 	assert.True(t, se.dtls.disableInsecureSkipVerify)
 	assert.Equal(t, dtls.RequireExtendedMasterSecret, se.dtls.extendedMasterSecret)
 	assert.NotNil(t, se.dtls.clientAuth)


### PR DESCRIPTION
The HelloVerifyRequest cookie exchange only validates the remote address, which the ICE connectivity checks have already done in the context of WebRTC so disable this by default.