### PR TITLE
Fix panic in RTX repair reader for malformed packets

### DIFF
--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -667,7 +667,7 @@ func (r *RTPReceiver) receiveForRtxInternal(
 }
 
 // maybeStartRepairStreamReader starts repair processing when needed. The caller must hold r.mu.
-func (r *RTPReceiver) maybeStartRepairStreamReader(track *trackStreams) { //nolint:cyclop
+func (r *RTPReceiver) maybeStartRepairStreamReader(track *trackStreams) { //nolint:cyclop,gocognit
 	if track.repairReaderStarted || track.repairInterceptor == nil {
 		return
 	}
@@ -689,22 +689,41 @@ func (r *RTPReceiver) maybeStartRepairStreamReader(track *trackStreams) { //noli
 				return
 			}
 
+			if i == 0 {
+				// Zero-length read: there is nothing to parse, and reading
+				// b[0]/b[i-1] below could either parse stale pool contents
+				// or panic (b[-1]). Skip the packet.
+				r.rtxPool.Put(b) // nolint:staticcheck
+
+				continue
+			}
+
 			// RTX packets have a different payload format. Move the OSN in the payload to the RTP header and rewrite the
 			// payload type and SSRC, so that we can return RTX packets to the caller 'transparently' i.e. in the same format
 			// as non-RTX RTP packets
 			hasExtension := b[0]&0b10000 > 0
 			hasPadding := b[0]&0b100000 > 0
 			csrcCount := b[0] & 0b1111
-			headerLength := uint16(12 + (4 * csrcCount))
+			// headerLength is kept as an int to avoid uint16 wraparound when
+			// a malformed extension length field is large.
+			headerLength := 12 + (4 * int(csrcCount))
 			paddingLength := 0
+			if hasExtension && i < headerLength+4 {
+				// The packet is truncated before the extension header:
+				// the extension length field would be read from bytes
+				// beyond the packet.
+				r.rtxPool.Put(b) // nolint:staticcheck
+
+				continue
+			}
 			if hasExtension {
-				headerLength += 4 * (1 + binary.BigEndian.Uint16(b[headerLength+2:headerLength+4]))
+				headerLength += 4 * (1 + int(binary.BigEndian.Uint16(b[headerLength+2:headerLength+4])))
 			}
 			if hasPadding {
 				paddingLength = int(b[i-1])
 			}
 
-			if i-int(headerLength)-paddingLength < 2 {
+			if i-headerLength-paddingLength < 2 {
 				// BWE probe packet, ignore
 				r.rtxPool.Put(b) // nolint:staticcheck
 

--- a/rtpreceiver_test.go
+++ b/rtpreceiver_test.go
@@ -983,3 +983,56 @@ func TestRTPReceiver_CollectStats_RID(t *testing.T) {
 
 	assert.Equal(t, rid, inbound.Rid)
 }
+
+func TestRTPReceiverRepairReaderMalformedPacketNoPanic(t *testing.T) {
+	receiver, track := newRepairReaderPolicyTestReceiver(t, false, 2222, nil)
+
+	var reads atomic.Int32
+	repairReader := interceptor.RTPReaderFunc(
+		func(b []byte, attributes interceptor.Attributes) (int, interceptor.Attributes, error) {
+			switch reads.Add(1) {
+			case 1:
+				// Zero-length read whose buffer holds garbage (as if recycled
+				// from a prior packet). Without an i == 0 guard the padding
+				// length read b[i-1] is b[-1] -> panic.
+				b[0] = 0xA0 // padding + extension bits set
+
+				return 0, attributes, nil
+			case 2:
+				// Truncated packet: extension bit set (0x90) but only 12 bytes,
+				// shorter than the fixed header + extension header. Without a
+				// length guard the extension length field is parsed from bytes
+				// beyond the packet.
+				return copy(b, []byte{
+					0x90, 97, 0, 1, 0, 0, 0, 0, 0, 0, 0x04, 0x57,
+				}), attributes, nil
+			case 3:
+				// Valid RTX packet: OSN 0x04D2 -> sequence number 1234, payload 0xA1.
+				return copy(b, []byte{
+					0x80, 97, 0x13, 0x88, 0, 0, 0, 0, 0, 0, 0x08, 0xAE,
+					0x04, 0xD2, 0xA1,
+				}), attributes, nil
+			default:
+				// Stop the repair reader once the valid packet was forwarded.
+				return 0, attributes, io.EOF
+			}
+		},
+	)
+	require.NoError(t, receiver.receiveForRtx(
+		2222, "", &interceptor.StreamInfo{SSRC: 2222}, nil, repairReader, true, nil, nil,
+	))
+
+	// The malformed packets must be skipped and the valid packet still forwarded.
+	require.Eventually(t, func() bool {
+		receiver.mu.RLock()
+		defer receiver.mu.RUnlock()
+
+		return len(receiver.tracks[0].repairStreamChannel) == 1
+	}, time.Second, time.Millisecond)
+
+	packet, _, err := track.ReadRTP()
+	require.NoError(t, err)
+	require.NotNil(t, packet)
+	assert.Equal(t, uint16(1234), packet.SequenceNumber)
+	assert.Equal(t, []byte{0xA1}, packet.Payload)
+}


### PR DESCRIPTION
## Summary

Fix a panic in the RTX repair reader (`maybeStartRepairStreamReader`) when the repair interceptor returns malformed data:

- A zero-length read (`i == 0`) made the padding length read `b[i-1]` index `b[-1]`, panicking the process.
- A truncated packet with the extension bit set caused the extension length field to be parsed from stale bytes beyond the packet.
- The header length was tracked in a `uint16`, so a large extension length field wrapped around and let malformed packets bypass the probe check and be forwarded as bogus RTX packets.

## Changes

- Skip zero-length reads and packets truncated before the extension header, returning the buffer to the pool.
- Track the header length as an `int` to avoid `uint16` wraparound.

## Verification

- New test `TestRTPReceiverRepairReaderMalformedPacketNoPanic` feeds a zero-length read, a truncated packet and a valid RTX packet through the repair reader and asserts the valid packet is still forwarded correctly. It panics on `main` and passes with this change.
- Full repo test suite with `-race` passes.
- golangci-lint clean for the changed lines.