### PR TITLE
Fix data race in TrackRemote.read

### DIFF
--- a/track_remote.go
+++ b/track_remote.go
@@ -130,14 +130,14 @@ func (t *TrackRemote) Read(b []byte) (n int, attributes interceptor.Attributes, 
 }
 
 func (t *TrackRemote) read(b []byte) (n int, attributes interceptor.Attributes, err error) {
-	t.mu.RLock()
+	t.mu.Lock()
 	receiver := t.receiver
 	var peekedPkt *peekedPacket
 	if len(t.peekedPackets) != 0 {
 		peekedPkt = t.peekedPackets[0]
 		t.peekedPackets = t.peekedPackets[1:]
 	}
-	t.mu.RUnlock()
+	t.mu.Unlock()
 
 	if receiver.haveClosed() {
 		return 0, nil, io.EOF


### PR DESCRIPTION
## Problem

`TrackRemote.read` consumed `t.peekedPackets` while holding only a read lock:

```go
t.mu.RLock()
if len(t.peekedPackets) != 0 {
    peekedPkt = t.peekedPackets[0]
    t.peekedPackets = t.peekedPackets[1:] // write: advances the slice header
}
t.mu.RUnlock()
```

Popping is a write, so a read lock is the wrong boundary: `RLock` holders do
not exclude each other, and two readers can take the same head element while
the header only advances once.

## Scope

This is not a regression, and it is not reachable through the `peek` path.
As pointed out in review, `peek` completes before `OnTrack` fires and does not
overlap user reads, and simulcast does not by itself produce concurrent reads
on a single `TrackRemote`. `Read` is exported API, so the guard still matters
for callers that read one track from more than one goroutine.

## Fix

Take the full lock while consuming the slice. No test is added.

## Verification

- `go build ./...` and `go vet ./...` clean
- `go test -race .` passes
- `golangci-lint` v2.10.1 (the version CI pins): 0 issues
- both changed lines are already covered by the existing suite, so patch
  coverage stays at 100%
