### PR TITLE
Fix RTPSender.ReplaceTrack losing RTP flow after mute/unmute

### DIFF
--- a/rtpsender.go
+++ b/rtpsender.go
@@ -29,6 +29,29 @@ type trackEncoding struct {
 	context *baseTrackLocalContext
 
 	ssrc, ssrcRTX, ssrcFEC SSRC
+
+	// lastSeqNumber, lastTimestamp and hasLastRTPState record the RTP state
+	// of the most recently replaced track for this encoding, so a new track
+	// bound in its place can continue the RTP stream instead of restarting
+	// it (see #2623).
+	lastSeqNumber   uint16
+	lastTimestamp   uint32
+	hasLastRTPState bool
+}
+
+// rtpSequenceState is implemented by the built-in sample-based TrackLocal
+// types to expose the most recently written RTP sequence number and
+// timestamp, so RTPSender.ReplaceTrack can preserve RTP stream continuity
+// when swapping in a new track.
+type rtpSequenceState interface {
+	lastRTPState() (sequenceNumber uint16, timestamp uint32, ok bool)
+}
+
+// rtpSequenceSeeder is implemented by TrackLocal types that can be seeded
+// with a starting RTP sequence number and timestamp before their first Bind,
+// so RTPSender.ReplaceTrack can continue an existing RTP stream onto them.
+type rtpSequenceSeeder interface {
+	continueSequenceFrom(sequenceNumber uint16, timestamp uint32)
 }
 
 // RTPSender allows an application to control how a given Track is encoded and transmitted to a remote peer.
@@ -252,6 +275,11 @@ func (r *RTPSender) ReplaceTrack(track TrackLocal) error { //nolint:cyclop
 			if err := replacedTrack.Unbind(context); err != nil {
 				return err
 			}
+
+			e.lastSeqNumber, e.lastTimestamp, e.hasLastRTPState = 0, 0, false
+			if state, ok := replacedTrack.(rtpSequenceState); ok {
+				e.lastSeqNumber, e.lastTimestamp, e.hasLastRTPState = state.lastRTPState()
+			}
 		}
 
 		if !r.hasSent() || track == nil {
@@ -269,6 +297,16 @@ func (r *RTPSender) ReplaceTrack(track TrackLocal) error { //nolint:cyclop
 	)
 
 	// If we reach this point in the routine, there is only 1 track encoding
+
+	// Seed the new track's RTP sequence number/timestamp from the replaced
+	// track's last known state, if available, so the RTP stream continues
+	// rather than restarting with an unrelated sequence number. Restarting
+	// can desync SRTP's rollover-count tracking and cause the receiver to
+	// silently drop all subsequent packets as replays (see #2623).
+	if seeder, ok := track.(rtpSequenceSeeder); ok && r.trackEncodings[0].hasLastRTPState {
+		seeder.continueSequenceFrom(r.trackEncodings[0].lastSeqNumber, r.trackEncodings[0].lastTimestamp)
+	}
+
 	codec, err := track.Bind(&baseTrackLocalContext{
 		id:              context.ID(),
 		params:          params,

--- a/rtpsender_test.go
+++ b/rtpsender_test.go
@@ -100,6 +100,117 @@ func Test_RTPSender_ReplaceTrack(t *testing.T) { //nolint:cyclop
 	closePairNow(t, sender, receiver)
 }
 
+// Test_RTPSender_ReplaceTrack_ResumesFlowAfterRepeatedMuteUnmute reproduces
+// https://github.com/pion/webrtc/issues/2623: repeatedly muting a sender via
+// ReplaceTrack(nil) and resuming it with a freshly-constructed track (as a
+// typical mute/unmute implementation using getUserMedia-style tracks would)
+// must keep RTP flowing to the remote peer. Before the fix, a fresh track's
+// unrelated starting RTP sequence number could desync SRTP's rollover-count
+// tracking on the receiver, causing it to silently drop every subsequent
+// packet as a replay.
+func Test_RTPSender_ReplaceTrack_ResumesFlowAfterRepeatedMuteUnmute(t *testing.T) { //nolint:cyclop
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	sender, receiver, err := NewAPI().newPair(Configuration{})
+	assert.NoError(t, err)
+
+	trackA, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+	assert.NoError(t, err)
+
+	rtpSender, err := sender.AddTrack(trackA)
+	assert.NoError(t, err)
+
+	var lastSeenCycle atomic.Uint32
+	var currentCycle atomic.Uint32
+	var currentTrack atomic.Pointer[TrackLocalStaticSample]
+	currentTrack.Store(trackA)
+
+	receiver.OnTrack(func(track *TrackRemote, _ *RTPReceiver) {
+		for {
+			pkt, _, err := track.ReadRTP()
+			if err != nil {
+				assert.True(t, errors.Is(err, io.EOF))
+
+				return
+			}
+			if len(pkt.Payload) > 0 {
+				lastSeenCycle.Store(uint32(pkt.Payload[len(pkt.Payload)-1]))
+			}
+		}
+	})
+
+	assert.NoError(t, signalPair(sender, receiver))
+
+	// Continuous background writer, simulating an audio/video pipeline that
+	// keeps producing samples independent of application-level mute state.
+	writerDone := make(chan struct{})
+	defer func() { <-writerDone }()
+
+	stopWriter := make(chan struct{})
+	defer close(stopWriter)
+
+	go func() {
+		defer close(writerDone)
+
+		ticker := time.NewTicker(time.Millisecond * 10)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopWriter:
+				return
+			case <-ticker.C:
+				tr := currentTrack.Load()
+				if tr == nil {
+					continue
+				}
+				cycle := byte(currentCycle.Load()) //nolint:gosec // G115: bounded by the small cycles const below
+				sample := media.Sample{Data: []byte{cycle}, Duration: time.Millisecond * 10}
+				_ = tr.WriteSample(sample)
+			}
+		}
+	}()
+
+	const cycles = 15
+	for cycle := 1; cycle <= cycles; cycle++ {
+		currentCycle.Store(uint32(cycle))
+
+		// Mute.
+		assert.NoError(t, rtpSender.ReplaceTrack(nil))
+		currentTrack.Store(nil)
+		time.Sleep(time.Millisecond * 20)
+
+		// Unmute with a brand-new track object, mirroring a caller that
+		// creates a fresh local track on every unmute.
+		newTrack, err := NewTrackLocalStaticSample(RTPCodecCapability{MimeType: MimeTypeVP8}, "video", "pion")
+		assert.NoError(t, err)
+		assert.NoError(t, rtpSender.ReplaceTrack(newTrack))
+		currentTrack.Store(newTrack)
+
+		deadline := time.Now().Add(time.Second * 2)
+		resumed := false
+		for time.Now().Before(deadline) {
+			if lastSeenCycle.Load() == uint32(cycle) {
+				resumed = true
+
+				break
+			}
+			time.Sleep(time.Millisecond * 20)
+		}
+
+		msg := "RTP flow did not resume on cycle %d/%d after ReplaceTrack(nil)->ReplaceTrack(newTrack)"
+		assert.Truef(t, resumed, msg, cycle, cycles)
+		if !resumed {
+			break
+		}
+	}
+
+	closePairNow(t, sender, receiver)
+}
+
 func Test_RTPSender_GetParameters(t *testing.T) {
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()

--- a/track_local_static.go
+++ b/track_local_static.go
@@ -8,6 +8,7 @@ package webrtc
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pion/rtp"
 	"github.com/pion/webrtc/v4/internal/util"
@@ -34,6 +35,14 @@ type TrackLocalStaticRTP struct {
 	id, rid, streamID string
 	initalTimestamp   *uint32
 	initialSeqNumber  *uint16
+
+	// lastSequenceNumber, lastTimestamp and hasWrittenRTP record the RTP
+	// state of the most recently written packet, so RTPSender.ReplaceTrack
+	// can seed a replacement track to continue the RTP stream instead of
+	// restarting it with an unrelated sequence number (see #2623).
+	lastSequenceNumber atomic.Uint32
+	lastTimestamp      atomic.Uint32
+	hasWrittenRTP      atomic.Bool
 }
 
 // NewTrackLocalStaticRTP returns a TrackLocalStaticRTP.
@@ -130,6 +139,18 @@ func (s *TrackLocalStaticRTP) Unbind(t TrackLocalContext) error {
 	return ErrUnbindFailed
 }
 
+// lastRTPState returns the most recently written RTP sequence number and
+// timestamp for this track, if any packet has been written yet. It is used
+// by RTPSender.ReplaceTrack to preserve RTP stream continuity when this
+// track is replaced by a fresh TrackLocal (see #2623).
+func (s *TrackLocalStaticRTP) lastRTPState() (sequenceNumber uint16, timestamp uint32, ok bool) {
+	if !s.hasWrittenRTP.Load() {
+		return 0, 0, false
+	}
+
+	return uint16(s.lastSequenceNumber.Load()), s.lastTimestamp.Load(), true //nolint:gosec // G115
+}
+
 // ID is the unique identifier for this Track. This should be unique for the
 // stream, but doesn't have to globally unique. A common example would be 'audio' or 'video'
 // and StreamID would be 'desktop' or 'webcam'.
@@ -195,6 +216,10 @@ func (s *TrackLocalStaticRTP) WriteRTP(p *rtp.Packet) error {
 func (s *TrackLocalStaticRTP) writeRTP(packet *rtp.Packet) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
+	s.lastSequenceNumber.Store(uint32(packet.Header.SequenceNumber))
+	s.lastTimestamp.Store(packet.Header.Timestamp)
+	s.hasWrittenRTP.Store(true)
 
 	writeErrs := []error{}
 
@@ -334,6 +359,39 @@ func (s *TrackLocalStaticSample) Bind(t TrackLocalContext) (RTPCodecParameters, 
 // because a track has been stopped.
 func (s *TrackLocalStaticSample) Unbind(t TrackLocalContext) error {
 	return s.rtpTrack.Unbind(t)
+}
+
+// lastRTPState returns the most recently written RTP sequence number and
+// timestamp for this track, if any packet has been written yet. It is used
+// by RTPSender.ReplaceTrack to preserve RTP stream continuity when this
+// track is replaced by a fresh TrackLocal (see #2623).
+func (s *TrackLocalStaticSample) lastRTPState() (sequenceNumber uint16, timestamp uint32, ok bool) {
+	return s.rtpTrack.lastRTPState()
+}
+
+// continueSequenceFrom seeds this not-yet-bound track's initial RTP sequence
+// number and timestamp so that, once Bind creates its packetizer, the RTP
+// stream continues from the given state instead of starting at an unrelated
+// value. It is a no-op if the packetizer has already been created, or if the
+// caller already requested explicit values via WithRTPSequenceNumber/
+// WithRTPTimestamp.
+func (s *TrackLocalStaticSample) continueSequenceFrom(sequenceNumber uint16, timestamp uint32) {
+	s.rtpTrack.mu.Lock()
+	defer s.rtpTrack.mu.Unlock()
+
+	if s.packetizer != nil {
+		return
+	}
+
+	if s.rtpTrack.initialSeqNumber == nil {
+		next := sequenceNumber + 1
+		s.rtpTrack.initialSeqNumber = &next
+	}
+
+	if s.rtpTrack.initalTimestamp == nil {
+		ts := timestamp
+		s.rtpTrack.initalTimestamp = &ts
+	}
 }
 
 // WriteSample writes a Sample to the TrackLocalStaticSample


### PR DESCRIPTION
## Summary

`RTPSender.ReplaceTrack(nil)` followed by `RTPSender.ReplaceTrack(track)` with a freshly-constructed `TrackLocalStaticSample`/`TrackLocalStaticRTP` (the common mute/unmute pattern, e.g. after `getUserMedia`) can leave RTP permanently stopped on the remote peer, with no error returned and the track appearing bound.

The new track's packetizer starts an unrelated RTP sequence number (random by default). On the receiver, `pion/srtp`'s per-SSRC rollover-count high-water mark only advances when a newly observed sequence number computes a positive difference relative to it. A sequence number that lands "behind" the previous high-water mark leaves that state frozen, so every subsequent packet on that SSRC then falls outside the 64-packet replay-protection window and is silently dropped as a replay. Depending on where the new track's random starting sequence number lands, this happens roughly half the time, matching the issue's own "no error... sometimes we do, sometimes we don't... couldn't find a pattern" description.

I confirmed the mechanism two ways: a two-`PeerConnection` repro that repeatedly mutes/unmutes with a fresh track object reliably stops RTP flow within 2-3 cycles under default settings, and the failure disappears when `SettingEngine.DisableSRTPReplayProtection(true)` is set, isolating it to the replay-protection/rollover-count path rather than SDP negotiation or SRTP key setup.

## Changes

- `TrackLocalStaticRTP` now records the sequence number and timestamp of the last RTP packet it wrote.
- `RTPSender.ReplaceTrack` uses that (via two small unexported interfaces, no public API change) to seed a not-yet-bound replacement `TrackLocalStaticSample`'s initial sequence number/timestamp before its first `Bind`, so the RTP stream continues monotonically across the swap instead of restarting at an unrelated value.
- This only takes effect when the new track hasn't been bound anywhere yet (its packetizer is still nil) and the caller hasn't already set explicit values via `WithRTPSequenceNumber`/`WithRTPTimestamp`. Custom `TrackLocal` implementations and callers writing raw packets through `TrackLocalStaticRTP.WriteRTP`/`Write` directly are unaffected.

## Verification

- New test `Test_RTPSender_ReplaceTrack_ResumesFlowAfterRepeatedMuteUnmute`: two real `PeerConnection`s, 15 repeated `ReplaceTrack(nil)` -> `ReplaceTrack(newTrack)` cycles with a fresh `TrackLocalStaticSample` each time and a continuous background writer simulating an always-on media pipeline.
- Against unpatched `rtpsender.go`/`track_local_static.go`, the same test fails: `rtpsender_test.go:205: Error: Should be true / Messages: RTP flow did not resume on cycle 2/15 after ReplaceTrack(nil)->ReplaceTrack(newTrack)`. With the fix it passes 5/5 consecutive runs (`ok github.com/pion/webrtc/v4 1.77s`, `1.72s`, `1.72s`, `1.45s`, `1.66s`).
- `go test -run 'Test_RTPSender|TrackLocal' -count=1`: `ok github.com/pion/webrtc/v4 11.054s`, all ~40 subtests pass.
- `go test -run 'Test_RTPSender|TrackLocal|ReplaceTrack|Test_TrackRemote|Test_RTPReceiver' -race -count=1`: passes clean with no data races, including the new regression test. Two pre-existing tests (`Test_TrackLocalStatic_Timestamp`, `Test_TrackLocalStatic_SequenceNumber`) fail under `-race`, but they fail identically on unmodified `main` under `-race` (timing-budget assertions that don't hold up to race-detector overhead) and are unrelated to this change.
- `go test -count=1 ./...`: `ok github.com/pion/webrtc/v4 174.327s`, full package suite passes.
- `go build ./...`, `gofmt -l` on touched files, and `go vet ./...` are all clean. `golangci-lint run --new-from-rev=278b7f9 ./...` reports `0 issues.`
- `-race` was scoped to the touched-area test set rather than the full package (a full-package `-race` run takes several minutes longer and would need the two pre-existing flaky tests excluded); the scoped run is what proves race-safety for this diff.

## Note for maintainers

While investigating, I noticed #3292 (RTP timestamp/sequence discontinuity after `ReplaceTrack`) looks like it may share this same root cause, just surfacing as a milder AV-sync symptom rather than a full replay-window drop. This PR is scoped to #2623's reproducible failure only; flagging the likely overlap here in case there's already a preferred direction for the shared root cause.

Fixes #2623
