### PR TITLE
Fix ivfwriter panic on VP8 descriptor-only packet

### DIFF
--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -212,6 +212,11 @@ func (i *IVFWriter) writeVP8(packet *rtp.Packet, timestamp uint64) error {
 		return err
 	}
 
+	// a payload that carries only the VP8 descriptor has nothing to write.
+	if len(vp8Packet.Payload) == 0 {
+		return nil
+	}
+
 	isKeyFrame := (vp8Packet.Payload[0] & 0x01) == 0
 	switch {
 	case !i.seenKeyFrame && !isKeyFrame:

--- a/pkg/media/ivfwriter/ivfwriter_test.go
+++ b/pkg/media/ivfwriter/ivfwriter_test.go
@@ -246,6 +246,27 @@ func TestIVFWriter_EmptyPayload(t *testing.T) {
 	assert.NoError(t, writer.WriteRTP(&rtp.Packet{Payload: []byte{}}))
 }
 
+func TestIVFWriter_VP8DescriptorOnlyPayload(t *testing.T) {
+	// a VP8 payload can legally consist of the descriptor alone, which leaves
+	// the depacketized payload empty.
+	for _, payload := range [][]byte{
+		{0x10},
+		{0x90, 0x00},
+		{0x90, 0x80, 0x05},
+	} {
+		buffer := &bytes.Buffer{}
+
+		writer, err := NewWith(buffer)
+		assert.NoError(t, err)
+
+		assert.NoError(t, writer.WriteRTP(&rtp.Packet{
+			Header:  rtp.Header{Marker: true},
+			Payload: payload,
+		}))
+		assert.Equal(t, 32, buffer.Len()) // only the IVF file header
+	}
+}
+
 func TestIVFWriter_Errors(t *testing.T) {
 	// Creating a Writer with AV1 and VP8
 	_, err := NewWith(&bytes.Buffer{}, WithCodec(mimeTypeAV1), WithCodec(mimeTypeAV1))


### PR DESCRIPTION
`VP8Packet.Unmarshal` returns successfully with an empty payload when the RTP payload carries only the VP8 descriptor, which RFC 7741 section 4.2 allows. `writeVP8` then reads `Payload[0]` to check the keyframe bit and panics with `index out of range [0] with length 0`.

The existing guard only skips packets whose RTP payload is empty, so a descriptor-only packet gets through. Since the codec payload comes from the remote peer, and SRTP authenticates it but does not validate it, anything feeding `TrackRemote.ReadRTP` into `IVFWriter.WriteRTP` (the save-to-disk example, recording servers) can be crashed by a peer.

The fix skips the packet, the same way the AV1 branch already handles an empty payload. Test covers the three descriptor shapes (`{0x10}`, `{0x90, 0x00}`, `{0x90, 0x80, 0x05}`) and asserts nothing beyond the IVF file header is written; it panics without the change.

Same class as #3507.