### PR TITLE
Parse apt when finding RTX payload type

### DIFF
--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -3007,3 +3007,47 @@ func BenchmarkPeerConnection_Media_WriteRead(b *testing.B) {
 
 	b.StopTimer()
 }
+
+func TestPeerConnection_RTXWithExtraFmtpParameters(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	// RFC 4588 gives "apt=96;rtx-time=3000" as an example of an RTX fmtp
+	// line, so the association must be read from the apt parameter and not
+	// from the whole line.
+	for _, fmtpLine := range []string{"apt=96", "apt=96;rtx-time=3000", "rtx-time=3000;apt=96"} {
+		pc, err := NewPeerConnection(Configuration{})
+		assert.NoError(t, err)
+
+		offer := "v=0\r\n" +
+			"o=- 0 0 IN IP4 127.0.0.1\r\n" +
+			"s=-\r\n" +
+			"t=0 0\r\n" +
+			"a=group:BUNDLE 0\r\n" +
+			"m=video 9 UDP/TLS/RTP/SAVPF 96 97\r\n" +
+			"c=IN IP4 0.0.0.0\r\n" +
+			"a=ice-ufrag:abcd\r\n" +
+			"a=ice-pwd:abcdefghijklmnopqrstuvwx\r\n" +
+			"a=fingerprint:sha-256 " +
+			"11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:" +
+			"11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00\r\n" +
+			"a=setup:actpass\r\n" +
+			"a=mid:0\r\n" +
+			"a=sendonly\r\n" +
+			"a=rtcp-mux\r\n" +
+			"a=rtpmap:96 VP8/90000\r\n" +
+			"a=rtpmap:97 rtx/90000\r\n" +
+			"a=fmtp:97 " + fmtpLine + "\r\n"
+
+		assert.NoError(t, pc.SetRemoteDescription(SessionDescription{Type: SDPTypeOffer, SDP: offer}))
+
+		answer, err := pc.CreateAnswer(nil)
+		assert.NoError(t, err)
+		assert.Contains(t, answer.SDP, "rtx/90000", fmtpLine)
+
+		assert.NoError(t, pc.Close())
+	}
+}

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -3020,7 +3020,7 @@ func TestPeerConnection_RTXWithExtraFmtpParameters(t *testing.T) {
 	// from the whole line.
 	for _, fmtpLine := range []string{"apt=96", "apt=96;rtx-time=3000", "rtx-time=3000;apt=96"} {
 		pc, err := NewPeerConnection(Configuration{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		offer := "v=0\r\n" +
 			"o=- 0 0 IN IP4 127.0.0.1\r\n" +

--- a/rtpcodec.go
+++ b/rtpcodec.go
@@ -4,7 +4,6 @@
 package webrtc
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -144,11 +143,32 @@ func codecParametersFuzzySearch(
 	return RTPCodecParameters{}, codecMatchNone
 }
 
+// Given an RTX CodecParameters, return the payload type of the codec it
+// repairs, taken from the apt parameter defined by RFC 4588.
+func rtxAssociatedPayloadType(codec RTPCodecParameters) (PayloadType, bool) {
+	if !strings.EqualFold(codec.MimeType, MimeTypeRTX) {
+		return 0, false
+	}
+
+	parsed := fmtp.Parse(codec.MimeType, codec.ClockRate, codec.Channels, codec.SDPFmtpLine)
+
+	aptPayload, ok := parsed.Parameter("apt")
+	if !ok {
+		return 0, false
+	}
+
+	payloadType, err := strconv.Atoi(aptPayload)
+	if err != nil || payloadType < 0 || payloadType > 255 {
+		return 0, false
+	}
+
+	return PayloadType(payloadType), true
+}
+
 // Given a CodecParameters find the RTX CodecParameters if one exists.
 func findRTXPayloadType(needle PayloadType, haystack []RTPCodecParameters) PayloadType {
-	aptStr := fmt.Sprintf("apt=%d", needle)
 	for _, c := range haystack {
-		if aptStr == c.SDPFmtpLine {
+		if associated, ok := rtxAssociatedPayloadType(c); ok && associated == needle {
 			return c.PayloadType
 		}
 	}
@@ -166,19 +186,14 @@ func primaryPayloadTypeForRTXExists(needle RTPCodecParameters, haystack []RTPCod
 	}
 
 	isRTX = true
-	parsed := fmtp.Parse(needle.MimeType, needle.ClockRate, needle.Channels, needle.SDPFmtpLine)
-	aptPayload, ok := parsed.Parameter("apt")
+
+	primaryPayloadType, ok := rtxAssociatedPayloadType(needle)
 	if !ok {
 		return
 	}
 
-	primaryPayloadType, err := strconv.Atoi(aptPayload)
-	if err != nil || primaryPayloadType < 0 || primaryPayloadType > 255 {
-		return
-	}
-
 	for _, c := range haystack {
-		if c.PayloadType == PayloadType(primaryPayloadType) {
+		if c.PayloadType == primaryPayloadType {
 			primaryExists = true
 
 			return

--- a/rtpcodec_test.go
+++ b/rtpcodec_test.go
@@ -276,3 +276,39 @@ func TestFindFECPayloadType(t *testing.T) {
 		assert.Equal(t, test.ResultPayloadType, findFECPayloadType(test.Haystack))
 	}
 }
+
+func TestFindRTXPayloadType(t *testing.T) {
+	haystack := []RTPCodecParameters{
+		{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP8, 90000, 0, "", nil},
+			PayloadType:        96,
+		},
+		{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeRTX, 90000, 0, "apt=96;rtx-time=3000", nil},
+			PayloadType:        97,
+		},
+		{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeVP9, 90000, 0, "", nil},
+			PayloadType:        98,
+		},
+		{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeRTX, 90000, 0, "rtx-time=3000;apt=98", nil},
+			PayloadType:        99,
+		},
+		{
+			RTPCodecCapability: RTPCodecCapability{MimeTypeH264, 90000, 0, "apt=100", nil},
+			PayloadType:        101,
+		},
+	}
+
+	// the fmtp line of an RTX codec can carry parameters other than apt,
+	// rtx-time being the one given as an example by RFC 4588.
+	assert.Equal(t, PayloadType(97), findRTXPayloadType(96, haystack))
+	assert.Equal(t, PayloadType(99), findRTXPayloadType(98, haystack))
+
+	// a non-RTX codec that happens to carry apt must not be matched.
+	assert.Equal(t, PayloadType(0), findRTXPayloadType(100, haystack))
+
+	// no RTX codec for this payload type.
+	assert.Equal(t, PayloadType(0), findRTXPayloadType(123, haystack))
+}


### PR DESCRIPTION
`findRTXPayloadType` compared the whole fmtp line against `"apt=N"`, so an RTX codec whose fmtp carries any other parameter was never matched. RFC 4588 section 8.1 gives `apt=96;rtx-time=3000` as its own example, and the negotiated RTX codec keeps the remote peer's fmtp line verbatim, so this triggers with any peer that sends `rtx-time`.

RTX is then lost in both directions:

- answering, `setCodecPreferencesFromRemoteDescription` gets 0 back and skips the codec, so the answer drops the rtx payload type entirely. I checked this end to end: an offer with `a=fmtp:97 apt=96;rtx-time=3000` gets `m=video 9 UDP/TLS/RTP/SAVPF 96` back, while the same offer with `apt=96` keeps 97.
- sending, the stream is set up with a retransmission payload type of 0, so the nack responder in pion/interceptor takes its non-RTX path and NACK retransmissions go out as plain duplicates on the primary SSRC, even though the answer advertised `a=ssrc-group:FID`.

The payload type is now read from the parsed `apt` parameter. `primaryPayloadTypeForRTXExists` already did exactly this, so I pulled it into a small shared helper and used it in both places rather than writing the parsing twice. That also fixes a second case: a non-RTX codec whose fmtp happens to be `apt=N` was previously returned as an RTX codec.

Browsers send a bare `apt=`, so this mostly shows up against non-browser peers and media servers.

Note #3051 and #3157 both touch these lines without changing the comparison, so there is a textual conflict with either. Happy to rebase on whichever lands first.