### PR TITLE
Accept non-bundled offers in generated answer

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -3091,7 +3091,7 @@ func (pc *PeerConnection) generateMatchedSDP(
 	pc.sctpTransport.lock.Lock()
 	defer pc.sctpTransport.lock.Unlock()
 
-	var bundleGroup *string
+	var bundleGroup *remoteBundleGroup
 	// If we are offering also include unmatched local transceivers
 	if includeUnmatched { //nolint:nestif
 		if !detectedPlanB {
@@ -3119,9 +3119,22 @@ func (pc *PeerConnection) generateMatchedSDP(
 			}
 		}
 	} else if remoteDescription != nil {
-		groupValue, _ := remoteDescription.parsed.Attribute(sdp.AttrKeyGroup)
-		groupValue = strings.TrimLeft(groupValue, "BUNDLE")
-		bundleGroup = &groupValue
+		bundleGroup = &remoteBundleGroup{}
+
+		// a description can carry several groups with different semantics
+		// (RFC 5888), so look for the BUNDLE one instead of taking the first.
+		for _, attribute := range remoteDescription.parsed.Attributes {
+			if attribute.Key != sdp.AttrKeyGroup {
+				continue
+			}
+
+			if semantics, mids, _ := strings.Cut(attribute.Value, " "); semantics == "BUNDLE" {
+				bundleGroup.mids = mids
+				bundleGroup.present = true
+
+				break
+			}
+		}
 	}
 
 	if pc.configuration.SDPSemantics == SDPSemanticsUnifiedPlanWithFallback && detectedPlanB {

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -2959,6 +2959,7 @@ func (pc *PeerConnection) generateUnmatchedSDP(
 		mediaSections,
 		pc.ICEGatheringState(),
 		nil,
+		pc.configuration.BundlePolicy,
 		pc.api.settingEngine.getSCTPMaxMessageSize(),
 		false,
 	)
@@ -3160,6 +3161,7 @@ func (pc *PeerConnection) generateMatchedSDP(
 		mediaSections,
 		pc.ICEGatheringState(),
 		bundleGroup,
+		pc.configuration.BundlePolicy,
 		pc.api.settingEngine.getSCTPMaxMessageSize(),
 		ignoreRidPauseForRecv,
 	)

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -968,3 +968,77 @@ func TestICETrickleCapabilityString(t *testing.T) {
 		assert.Equal(t, tt.expected, tt.value.String())
 	}
 }
+
+func TestPeerConnection_AnswerNonBundledOffer(t *testing.T) {
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	const offerHead = "v=0\r\n" +
+		"o=- 0 0 IN IP4 127.0.0.1\r\n" +
+		"s=-\r\n" +
+		"t=0 0\r\n"
+
+	const audioSection = "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+		"c=IN IP4 0.0.0.0\r\n" +
+		"a=ice-ufrag:abcd\r\n" +
+		"a=ice-pwd:abcdefghijklmnopqrstuvwx\r\n" +
+		"a=fingerprint:sha-256 " +
+		"11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:" +
+		"11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00\r\n" +
+		"a=setup:actpass\r\n" +
+		"a=mid:0\r\n" +
+		"a=sendonly\r\n" +
+		"a=rtcp-mux\r\n" +
+		"a=rtpmap:111 opus/48000/2\r\n"
+
+	t.Run("without a bundle group", func(t *testing.T) {
+		pc, err := NewPeerConnection(Configuration{})
+		assert.NoError(t, err)
+
+		assert.NoError(t, pc.SetRemoteDescription(SessionDescription{
+			Type: SDPTypeOffer,
+			SDP:  offerHead + audioSection,
+		}))
+
+		answer, err := pc.CreateAnswer(nil)
+		assert.NoError(t, err)
+
+		parsed, err := answer.Unmarshal()
+		assert.NoError(t, err)
+		assert.Len(t, parsed.MediaDescriptions, 1)
+
+		// the media section must not be rejected...
+		assert.NotEqual(t, 0, parsed.MediaDescriptions[0].MediaName.Port.Value)
+
+		// ...and the answer must not carry a group the offer did not have.
+		_, ok := parsed.Attribute(sdp.AttrKeyGroup)
+		assert.False(t, ok)
+
+		assert.NoError(t, pc.Close())
+	})
+
+	t.Run("with a non-bundle group", func(t *testing.T) {
+		pc, err := NewPeerConnection(Configuration{})
+		assert.NoError(t, err)
+
+		assert.NoError(t, pc.SetRemoteDescription(SessionDescription{
+			Type: SDPTypeOffer,
+			SDP:  offerHead + "a=group:LS 0\r\n" + audioSection,
+		}))
+
+		answer, err := pc.CreateAnswer(nil)
+		assert.NoError(t, err)
+
+		parsed, err := answer.Unmarshal()
+		assert.NoError(t, err)
+
+		// an LS group is not a BUNDLE group.
+		_, ok := parsed.Attribute(sdp.AttrKeyGroup)
+		assert.False(t, ok)
+
+		assert.NoError(t, pc.Close())
+	})
+}

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -994,8 +994,10 @@ func TestPeerConnection_AnswerNonBundledOffer(t *testing.T) {
 		"a=rtcp-mux\r\n" +
 		"a=rtpmap:111 opus/48000/2\r\n"
 
-	t.Run("without a bundle group", func(t *testing.T) {
-		pc, err := NewPeerConnection(Configuration{})
+	t.Run("without a bundle group, under max-bundle", func(t *testing.T) {
+		// Accepting a non-bundled offer is opt-in behind max-bundle, whose
+		// spec behavior for a non-bundle-aware remote is a single media track.
+		pc, err := NewPeerConnection(Configuration{BundlePolicy: BundlePolicyMaxBundle})
 		assert.NoError(t, err)
 
 		assert.NoError(t, pc.SetRemoteDescription(SessionDescription{

--- a/sdp.go
+++ b/sdp.go
@@ -721,6 +721,7 @@ func populateSDP(
 	mediaSections []mediaSection,
 	iceGatheringState ICEGatheringState,
 	matchBundleGroup *remoteBundleGroup,
+	bundlePolicy BundlePolicy,
 	sctpMaxMessageSize uint32,
 	ignoreRidPauseForRecv bool,
 ) (*sdp.SessionDescription, error) {
@@ -786,10 +787,14 @@ func populateSDP(
 
 		if shouldAddID {
 			switch {
-			case matchBundleGroup != nil && !matchBundleGroup.present:
-				// the remote description has no BUNDLE group. Only one
-				// transport is available, so every media section after the
-				// first one is rejected.
+			case matchBundleGroup != nil && !matchBundleGroup.present &&
+				bundlePolicy == BundlePolicyMaxBundle:
+				// The remote description has no BUNDLE group. Under max-bundle
+				// pion negotiates a single media track, so keep the first
+				// section and reject the rest. Other policies fall through to
+				// the normal path (which, with no group to match, rejects every
+				// section) to avoid changing spec behavior for balanced and
+				// max-compat, where pion cannot yet offer separate transports.
 				if i != 0 {
 					descr.MediaDescriptions[len(descr.MediaDescriptions)-1].MediaName.Port = sdp.RangedPort{Value: 0}
 				}

--- a/sdp.go
+++ b/sdp.go
@@ -678,13 +678,26 @@ type mediaSection struct {
 	rids            []*simulcastRid
 }
 
-func bundleMatchFromRemote(matchBundleGroup *string) func(mid string) bool {
+// remoteBundleGroup describes the BUNDLE group of the remote description
+// that an answer is being generated for.
+type remoteBundleGroup struct {
+	// mids listed in the remote BUNDLE group.
+	mids string
+
+	// whether the remote description carries a BUNDLE group at all. An
+	// answer may only bundle media sections that the offer bundled
+	// (RFC 8843, section 7.3), so an offer without a group gets an answer
+	// without one.
+	present bool
+}
+
+func bundleMatchFromRemote(matchBundleGroup *remoteBundleGroup) func(mid string) bool {
 	if matchBundleGroup == nil {
 		return func(string) bool {
 			return true
 		}
 	}
-	bundleTags := strings.Split(*matchBundleGroup, " ")
+	bundleTags := strings.Split(matchBundleGroup.mids, " ")
 
 	return func(midValue string) bool {
 		return slices.Contains(bundleTags, midValue)
@@ -693,7 +706,7 @@ func bundleMatchFromRemote(matchBundleGroup *string) func(mid string) bool {
 
 // populateSDP serializes a PeerConnections state into an SDP.
 //
-//nolint:cyclop
+//nolint:cyclop,gocognit
 func populateSDP(
 	descr *sdp.SessionDescription,
 	isPlanB bool,
@@ -707,7 +720,7 @@ func populateSDP(
 	iceParams ICEParameters,
 	mediaSections []mediaSection,
 	iceGatheringState ICEGatheringState,
-	matchBundleGroup *string,
+	matchBundleGroup *remoteBundleGroup,
 	sctpMaxMessageSize uint32,
 	ignoreRidPauseForRecv bool,
 ) (*sdp.SessionDescription, error) {
@@ -772,9 +785,17 @@ func populateSDP(
 		}
 
 		if shouldAddID {
-			if bundleMatch(section.id) {
+			switch {
+			case matchBundleGroup != nil && !matchBundleGroup.present:
+				// the remote description has no BUNDLE group. Only one
+				// transport is available, so every media section after the
+				// first one is rejected.
+				if i != 0 {
+					descr.MediaDescriptions[len(descr.MediaDescriptions)-1].MediaName.Port = sdp.RangedPort{Value: 0}
+				}
+			case bundleMatch(section.id):
 				appendBundle(section.id)
-			} else {
+			default:
 				descr.MediaDescriptions[len(descr.MediaDescriptions)-1].MediaName.Port = sdp.RangedPort{Value: 0}
 			}
 		}

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -1172,7 +1172,6 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 
 		d := &sdp.SessionDescription{}
 
-		matchedBundle := "audio"
 		offerSdp, err := populateSDP(
 			d,
 			false,
@@ -1186,7 +1185,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			ICEParameters{},
 			mediaSections,
 			ICEGatheringStateComplete,
-			&matchedBundle,
+			&remoteBundleGroup{mids: "audio", present: true},
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -1215,7 +1214,6 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 
 		d := &sdp.SessionDescription{}
 
-		matchedBundle := ""
 		offerSdp, err := populateSDP(
 			d,
 			false,
@@ -1229,11 +1227,56 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			ICEParameters{},
 			mediaSections,
 			ICEGatheringStateComplete,
-			&matchedBundle,
+			&remoteBundleGroup{present: true},
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
 		assert.Nil(t, err)
+
+		_, ok := offerSdp.Attribute(sdp.AttrKeyGroup)
+		assert.False(t, ok)
+	})
+	t.Run("remote without bundle group", func(t *testing.T) {
+		se := SettingEngine{}
+
+		me := &MediaEngine{}
+		assert.NoError(t, me.RegisterDefaultCodecs())
+		api := NewAPI(WithMediaEngine(me))
+
+		tra := &RTPTransceiver{kind: RTPCodecTypeVideo, api: api, codecs: me.videoCodecs}
+		tra.setDirection(RTPTransceiverDirectionRecvonly)
+		trb := &RTPTransceiver{kind: RTPCodecTypeAudio, api: api, codecs: me.audioCodecs}
+		trb.setDirection(RTPTransceiverDirectionRecvonly)
+		mediaSections := []mediaSection{
+			{id: "video", transceivers: []*RTPTransceiver{tra}},
+			{id: "audio", transceivers: []*RTPTransceiver{trb}},
+		}
+
+		d := &sdp.SessionDescription{}
+
+		offerSdp, err := populateSDP(
+			d,
+			false,
+			[]DTLSFingerprint{},
+			se.sdpMediaLevelFingerprints,
+			se.candidates.ICELite,
+			true,
+			me,
+			connectionRoleFromDtlsRole(defaultDtlsRoleOffer),
+			[]ICECandidate{},
+			ICEParameters{},
+			mediaSections,
+			ICEGatheringStateComplete,
+			&remoteBundleGroup{},
+			se.getSCTPMaxMessageSize(),
+			false,
+		)
+		assert.Nil(t, err)
+
+		// only one transport is available, so the first media section is
+		// kept and the others are rejected.
+		assert.NotEqual(t, 0, offerSdp.MediaDescriptions[0].MediaName.Port.Value)
+		assert.Equal(t, 0, offerSdp.MediaDescriptions[1].MediaName.Port.Value)
 
 		_, ok := offerSdp.Attribute(sdp.AttrKeyGroup)
 		assert.False(t, ok)

--- a/sdp_test.go
+++ b/sdp_test.go
@@ -759,6 +759,7 @@ func TestMediaDescriptionFingerprints(t *testing.T) {
 				media,
 				ICEGatheringStateNew,
 				nil,
+				BundlePolicyBalanced,
 				0,
 				false,
 			)
@@ -814,6 +815,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			se.ignoreRidPauseForRecv,
 		)
@@ -876,6 +878,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			se.ignoreRidPauseForRecv,
 		)
@@ -936,6 +939,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -977,6 +981,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			[]mediaSection{},
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -1036,6 +1041,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -1070,6 +1076,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			[]mediaSection{},
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -1101,6 +1108,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			[]mediaSection{},
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -1146,6 +1154,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -1186,6 +1195,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			&remoteBundleGroup{mids: "audio", present: true},
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -1228,6 +1238,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			&remoteBundleGroup{present: true},
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
@@ -1236,7 +1247,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		_, ok := offerSdp.Attribute(sdp.AttrKeyGroup)
 		assert.False(t, ok)
 	})
-	t.Run("remote without bundle group", func(t *testing.T) {
+	t.Run("remote without bundle group, max-bundle keeps only the first section", func(t *testing.T) {
 		se := SettingEngine{}
 
 		me := &MediaEngine{}
@@ -1268,14 +1279,62 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			&remoteBundleGroup{},
+			BundlePolicyMaxBundle,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)
 		assert.Nil(t, err)
 
-		// only one transport is available, so the first media section is
-		// kept and the others are rejected.
+		// under max-bundle only one media track is negotiated, so the first
+		// section is kept and the others are rejected.
 		assert.NotEqual(t, 0, offerSdp.MediaDescriptions[0].MediaName.Port.Value)
+		assert.Equal(t, 0, offerSdp.MediaDescriptions[1].MediaName.Port.Value)
+
+		_, ok := offerSdp.Attribute(sdp.AttrKeyGroup)
+		assert.False(t, ok)
+	})
+	t.Run("remote without bundle group, non-max-bundle keeps spec behavior", func(t *testing.T) {
+		se := SettingEngine{}
+
+		me := &MediaEngine{}
+		assert.NoError(t, me.RegisterDefaultCodecs())
+		api := NewAPI(WithMediaEngine(me))
+
+		tra := &RTPTransceiver{kind: RTPCodecTypeVideo, api: api, codecs: me.videoCodecs}
+		tra.setDirection(RTPTransceiverDirectionRecvonly)
+		trb := &RTPTransceiver{kind: RTPCodecTypeAudio, api: api, codecs: me.audioCodecs}
+		trb.setDirection(RTPTransceiverDirectionRecvonly)
+		mediaSections := []mediaSection{
+			{id: "video", transceivers: []*RTPTransceiver{tra}},
+			{id: "audio", transceivers: []*RTPTransceiver{trb}},
+		}
+
+		d := &sdp.SessionDescription{}
+
+		offerSdp, err := populateSDP(
+			d,
+			false,
+			[]DTLSFingerprint{},
+			se.sdpMediaLevelFingerprints,
+			se.candidates.ICELite,
+			true,
+			me,
+			connectionRoleFromDtlsRole(defaultDtlsRoleOffer),
+			[]ICECandidate{},
+			ICEParameters{},
+			mediaSections,
+			ICEGatheringStateComplete,
+			&remoteBundleGroup{},
+			BundlePolicyBalanced,
+			se.getSCTPMaxMessageSize(),
+			false,
+		)
+		assert.Nil(t, err)
+
+		// balanced and max-compat require separate transports for a non-bundle
+		// remote, which pion does not provide, so the keep-one-section fallback
+		// stays opt-in behind max-bundle and the spec behavior is unchanged.
+		assert.Equal(t, 0, offerSdp.MediaDescriptions[0].MediaName.Port.Value)
 		assert.Equal(t, 0, offerSdp.MediaDescriptions[1].MediaName.Port.Value)
 
 		_, ok := offerSdp.Attribute(sdp.AttrKeyGroup)
@@ -1307,6 +1366,7 @@ func TestPopulateSDP(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			mediaSections,
 			ICEGatheringStateComplete,
 			nil,
+			BundlePolicyBalanced,
 			se.getSCTPMaxMessageSize(),
 			false,
 		)


### PR DESCRIPTION
`generateMatchedSDP` discards the ok value of `Attribute(sdp.AttrKeyGroup)`, so an offer with no `a=group:BUNDLE` becomes an empty bundle group rather than no group at all. No mid then matches, and every media section in the answer is rejected with port 0. The application gets a well-formed answer and no error, but the session is dead.

Repro is a plain single-m-line audio offer with mid, ice, fingerprint and setup but no `a=group`: the answer comes back as `m=audio 0 UDP/TLS/RTP/SAVPF 111`. With `a=group:BUNDLE 0` added to the same offer it is `m=audio 9 ...`.

This came in with #2563, which needed the group to drop mids the offerer had removed; the absent-group case was not considered. #2950 notes that non-bundled offers are valid input. Browsers always bundle, so it mostly shows up with GStreamer's webrtcbin, whose `bundle-policy` defaults to `none`, and with SIP gateways.

There is one design decision in here that you may want to make differently. When the offer has no BUNDLE group the answer now keeps the first media section and rejects the rest, because only one ICE and DTLS transport exists (candidates are only added to section 0), and it emits no group of its own, since RFC 8843 section 7.3 says an answerer may only include a BUNDLE group the offerer requested. Simply passing nil would accept every section and put a BUNDLE group in the answer that the offer never asked for, which is what happened before #2563.

While in there: the group was read with a cutset `TrimLeft(value, "BUNDLE")` over the first `a=group` attribute only, so an offer carrying `a=group:LS 0 1` produced `a=group:BUNDLE 0 1` in the answer. Groups are now matched on their semantics field, since RFC 5888 allows several of them.

Tests cover the answer for an offer with no group, an offer with an LS group, and populateSDP with two sections and no remote group. All three fail without the change, and the existing bundle tests are untouched.