### PR TITLE
Do not block DataChannel accept on a stuck OPEN

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -20,6 +20,10 @@ import (
 
 const sctpMaxChannels = uint16(65535)
 
+// defaultSCTPDataChannelOpenTimeout bounds how long an accepted SCTP stream may
+// wait for its DCEP DATA_CHANNEL_OPEN before the stream is closed.
+const defaultSCTPDataChannelOpenTimeout = 10 * time.Second
+
 func newSCTPTransportMetadata(metadata sctp.AssociationMetadata) SCTPTransportMetadata {
 	partialReliabilityMode := SCTPTransportPartialReliabilityModeNone
 	switch metadata.PartialReliabilityMode {
@@ -240,37 +244,31 @@ func (r *SCTPTransport) Stop() error {
 	return nil
 }
 
-//nolint:cyclop
+// acceptDataChannels accepts incoming SCTP streams and opens a DataChannel
+// for each of them. It only returns when the association stops producing
+// streams; a failure on a single stream never ends the loop.
 func (r *SCTPTransport) acceptDataChannels(
 	assoc *sctp.Association,
 	existingDataChannels []*DataChannel,
 ) {
-	dataChannels := make([]*datachannel.DataChannel, 0, len(existingDataChannels))
+	existingIDs := make(map[uint16]struct{}, len(existingDataChannels))
 	for _, dc := range existingDataChannels {
 		dc.mu.Lock()
-		isNil := dc.dataChannel == nil
-		dc.mu.Unlock()
-		if isNil {
-			continue
+		if dc.dataChannel != nil {
+			existingIDs[dc.dataChannel.StreamIdentifier()] = struct{}{}
 		}
-		dataChannels = append(dataChannels, dc.dataChannel)
+		dc.mu.Unlock()
 	}
-ACCEPT:
+
 	for {
 		// check if the association has been stopped before calling accept.
-		r.lock.RLock()
-		currentAssoc := r.sctpAssociation
-		shouldStop := currentAssoc == nil || currentAssoc != assoc
-		r.lock.RUnlock()
-		if shouldStop {
+		if !r.isCurrentAssociation(assoc) {
 			r.onClose(nil)
 
 			return
 		}
 
-		dc, err := datachannel.Accept(assoc, &datachannel.Config{
-			LoggerFactory: r.api.settingEngine.LoggerFactory,
-		}, dataChannels...)
+		stream, err := assoc.AcceptStream()
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
 				r.log.Errorf("Failed to accept data channel: %v", err)
@@ -282,72 +280,125 @@ ACCEPT:
 
 			return
 		}
-		for _, ch := range dataChannels {
-			if ch.StreamIdentifier() == dc.StreamIdentifier() {
-				continue ACCEPT
-			}
+
+		stream.SetDefaultPayloadType(sctp.PayloadTypeWebRTCBinary)
+		if _, ok := existingIDs[stream.StreamIdentifier()]; ok {
+			continue
 		}
 
-		var (
-			maxRetransmits    *uint16
-			maxPacketLifeTime *uint16
-		)
-		val := uint16(dc.Config.ReliabilityParameter) //nolint:gosec //G115
-		ordered := true
-
-		switch dc.Config.ChannelType {
-		case datachannel.ChannelTypeReliable:
-			ordered = true
-		case datachannel.ChannelTypeReliableUnordered:
-			ordered = false
-		case datachannel.ChannelTypePartialReliableRexmit:
-			ordered = true
-			maxRetransmits = &val
-		case datachannel.ChannelTypePartialReliableRexmitUnordered:
-			ordered = false
-			maxRetransmits = &val
-		case datachannel.ChannelTypePartialReliableTimed:
-			ordered = true
-			maxPacketLifeTime = &val
-		case datachannel.ChannelTypePartialReliableTimedUnordered:
-			ordered = false
-			maxPacketLifeTime = &val
-		default:
-		}
-
-		sid := dc.StreamIdentifier()
-		rtcDC, err := r.api.newDataChannel(&DataChannelParameters{
-			ID:                &sid,
-			Label:             dc.Config.Label,
-			Protocol:          dc.Config.Protocol,
-			Negotiated:        dc.Config.Negotiated,
-			Ordered:           ordered,
-			MaxPacketLifeTime: maxPacketLifeTime,
-			MaxRetransmits:    maxRetransmits,
-		}, r, r.api.settingEngine.LoggerFactory.NewLogger("ortc"))
-		if err != nil {
-			// This data channel is invalid. Close it and log an error.
-			if err1 := dc.Close(); err1 != nil {
-				r.log.Errorf("Failed to close invalid data channel: %v", err1)
-			}
-			r.log.Errorf("Failed to accept data channel: %v", err)
-			r.onError(err)
-			// We've received a datachannel with invalid configuration. We can still receive other datachannels.
-			continue ACCEPT
-		}
-
-		<-r.onDataChannel(rtcDC)
-		rtcDC.handleOpen(dc, true, dc.Config.Negotiated)
-
-		r.lock.Lock()
-		r.dataChannelsOpened++
-		handler := r.onDataChannelOpenedHandler
-		r.lock.Unlock()
-
-		if handler != nil {
-			handler(rtcDC)
-		}
+		// Wait for the DCEP OPEN off the accept loop, so a stream whose OPEN is
+		// delayed or lost cannot block every stream accepted after it.
+		go r.openAcceptedDataChannel(assoc, stream)
 	}
+}
+
+// openAcceptedDataChannel waits, bounded by the DataChannel open timeout, for
+// the DCEP OPEN on an accepted stream and then announces the DataChannel.
+// Any failure closes just this stream.
+//
+//nolint:cyclop
+func (r *SCTPTransport) openAcceptedDataChannel(assoc *sctp.Association, stream *sctp.Stream) {
+	sid := stream.StreamIdentifier()
+
+	timeout := r.api.settingEngine.sctp.dataChannelOpenTimeout
+	if timeout <= 0 {
+		timeout = defaultSCTPDataChannelOpenTimeout
+	}
+
+	dc, err := func() (*datachannel.DataChannel, error) {
+		if err := stream.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+			return nil, err
+		}
+
+		dc, err := datachannel.Server(stream, &datachannel.Config{
+			LoggerFactory: r.api.settingEngine.LoggerFactory,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return dc, stream.SetReadDeadline(time.Time{})
+	}()
+	if err != nil {
+		r.log.Warnf("Failed to open incoming data channel on stream %d: %v", sid, err)
+		if closeErr := stream.Close(); closeErr != nil {
+			r.log.Debugf("Failed to close stream %d: %v", sid, closeErr)
+		}
+
+		return
+	}
+
+	if !r.isCurrentAssociation(assoc) {
+		_ = dc.Close()
+
+		return
+	}
+
+	var (
+		maxRetransmits    *uint16
+		maxPacketLifeTime *uint16
+	)
+	val := uint16(dc.Config.ReliabilityParameter) //nolint:gosec //G115
+	ordered := true
+
+	switch dc.Config.ChannelType {
+	case datachannel.ChannelTypeReliable:
+		ordered = true
+	case datachannel.ChannelTypeReliableUnordered:
+		ordered = false
+	case datachannel.ChannelTypePartialReliableRexmit:
+		ordered = true
+		maxRetransmits = &val
+	case datachannel.ChannelTypePartialReliableRexmitUnordered:
+		ordered = false
+		maxRetransmits = &val
+	case datachannel.ChannelTypePartialReliableTimed:
+		ordered = true
+		maxPacketLifeTime = &val
+	case datachannel.ChannelTypePartialReliableTimedUnordered:
+		ordered = false
+		maxPacketLifeTime = &val
+	default:
+	}
+
+	rtcDC, err := r.api.newDataChannel(&DataChannelParameters{
+		ID:                &sid,
+		Label:             dc.Config.Label,
+		Protocol:          dc.Config.Protocol,
+		Negotiated:        dc.Config.Negotiated,
+		Ordered:           ordered,
+		MaxPacketLifeTime: maxPacketLifeTime,
+		MaxRetransmits:    maxRetransmits,
+	}, r, r.api.settingEngine.LoggerFactory.NewLogger("ortc"))
+	if err != nil {
+		// This data channel is invalid. Close it and log an error.
+		if err1 := dc.Close(); err1 != nil {
+			r.log.Errorf("Failed to close invalid data channel: %v", err1)
+		}
+		r.log.Errorf("Failed to accept data channel: %v", err)
+		r.onError(err)
+
+		return
+	}
+
+	<-r.onDataChannel(rtcDC)
+	rtcDC.handleOpen(dc, true, dc.Config.Negotiated)
+
+	r.lock.Lock()
+	r.dataChannelsOpened++
+	handler := r.onDataChannelOpenedHandler
+	r.lock.Unlock()
+
+	if handler != nil {
+		handler(rtcDC)
+	}
+}
+
+func (r *SCTPTransport) isCurrentAssociation(assoc *sctp.Association) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	return r.sctpAssociation != nil && r.sctpAssociation == assoc
 }
 
 // OnError sets an event handler which is invoked when the SCTP Association errors.

--- a/sctptransport_accept_test.go
+++ b/sctptransport_accept_test.go
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package webrtc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/datachannel"
+	"github.com/pion/logging"
+	"github.com/pion/sctp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sctpCommonHeaderLen = 12
+	sctpChunkTypeData   = 0
+	sctpChunkTypeIData  = 64
+	sctpDataFlagBegin   = 0x02
+)
+
+var castagnoliTable = crc32.MakeTable(crc32.Castagnoli) //nolint:gochecknoglobals
+
+// fragmentDroppingConn forwards SCTP packets but strips every DATA/I-DATA chunk of
+// dropSID that is not the first fragment of a message. The receiver therefore
+// admits the stream but never gets a complete, readable message on it.
+type fragmentDroppingConn struct {
+	net.Conn
+	dropSID uint16
+
+	firstFragments atomic.Int32
+	dropped        atomic.Int32
+}
+
+//nolint:cyclop
+func (c *fragmentDroppingConn) Write(pkt []byte) (int, error) {
+	if len(pkt) < sctpCommonHeaderLen {
+		return c.Conn.Write(pkt)
+	}
+
+	out := append([]byte{}, pkt[:sctpCommonHeaderLen]...)
+	kept, stripped := 0, false
+	for offset := sctpCommonHeaderLen; offset+4 <= len(pkt); {
+		chunkLen := int(binary.BigEndian.Uint16(pkt[offset+2:]))
+		if chunkLen < 4 || offset+chunkLen > len(pkt) {
+			return c.Conn.Write(pkt)
+		}
+		next := min(offset+(chunkLen+3)&^3, len(pkt))
+		chunk := pkt[offset:next]
+		offset = next
+
+		// DATA and I-DATA both carry the stream identifier at offset 8.
+		isData := chunk[0] == sctpChunkTypeData || chunk[0] == sctpChunkTypeIData
+		if isData && chunkLen >= 16 && binary.BigEndian.Uint16(chunk[8:]) == c.dropSID {
+			if chunk[1]&sctpDataFlagBegin == 0 {
+				c.dropped.Add(1)
+				stripped = true
+
+				continue
+			}
+			c.firstFragments.Add(1)
+		}
+		out = append(out, chunk...)
+		kept++
+	}
+
+	if !stripped {
+		return c.Conn.Write(pkt)
+	}
+	if kept == 0 {
+		return len(pkt), nil
+	}
+
+	binary.LittleEndian.PutUint32(out[8:], 0)
+	binary.LittleEndian.PutUint32(out[8:], crc32.Checksum(out, castagnoliTable))
+	if _, err := c.Conn.Write(out); err != nil {
+		return 0, err
+	}
+
+	return len(pkt), nil
+}
+
+type acceptTestPeer struct {
+	client    *sctp.Association
+	transport *SCTPTransport
+	filter    *fragmentDroppingConn
+	opened    chan string
+	closed    chan error
+}
+
+// newAcceptTestPeer connects a raw client association to an SCTPTransport
+// running acceptDataChannels, with fragments of stuckSID dropped on the way.
+func newAcceptTestPeer(t *testing.T, stuckSID uint16, openTimeout time.Duration) *acceptTestPeer {
+	t.Helper()
+
+	clientConn, serverConn := net.Pipe()
+	filter := &fragmentDroppingConn{Conn: clientConn, dropSID: stuckSID}
+	loggerFactory := logging.NewDefaultLoggerFactory()
+
+	type result struct {
+		assoc *sctp.Association
+		err   error
+	}
+	serverRes := make(chan result, 1)
+	go func() {
+		assoc, err := sctp.ServerWithOptions(sctp.WithNetConn(serverConn), sctp.WithLoggerFactory(loggerFactory))
+		serverRes <- result{assoc, err}
+	}()
+	client, err := sctp.ClientWithOptions(sctp.WithNetConn(filter), sctp.WithLoggerFactory(loggerFactory))
+	require.NoError(t, err)
+	res := <-serverRes
+	require.NoError(t, res.err)
+
+	settingEngine := SettingEngine{}
+	settingEngine.SetSCTPDataChannelOpenTimeout(openTimeout)
+	api := NewAPI(WithSettingEngine(settingEngine))
+
+	transport := api.NewSCTPTransport(nil)
+	transport.lock.Lock()
+	transport.sctpAssociation = res.assoc
+	transport.state = SCTPTransportStateConnected
+	transport.lock.Unlock()
+
+	peer := &acceptTestPeer{
+		client:    client,
+		transport: transport,
+		filter:    filter,
+		opened:    make(chan string, 16),
+		closed:    make(chan error, 1),
+	}
+	transport.OnDataChannel(func(dc *DataChannel) {
+		peer.opened <- dc.Label()
+	})
+	transport.OnClose(func(err error) {
+		peer.closed <- err
+	})
+	go transport.acceptDataChannels(res.assoc, nil)
+
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = transport.Stop()
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+
+	return peer
+}
+
+// openStuckStream starts a message on sid whose tail never reaches the
+// server, and waits until the head has been forwarded so the server has
+// admitted the stream.
+func (p *acceptTestPeer) openStuckStream(
+	t *testing.T,
+	sid uint16,
+	ppi sctp.PayloadProtocolIdentifier,
+	configure func(*sctp.Stream),
+) *sctp.Stream {
+	t.Helper()
+
+	stream, err := p.client.OpenStream(sid, ppi)
+	require.NoError(t, err)
+	if configure != nil {
+		configure(stream)
+	}
+	_, err = stream.WriteSCTP(make([]byte, 1300), ppi)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return p.filter.firstFragments.Load() > 0 && p.filter.dropped.Load() > 0
+	}, 5*time.Second, 5*time.Millisecond, "stuck stream never reached the server")
+
+	return stream
+}
+
+func (p *acceptTestPeer) dial(t *testing.T, sid uint16) string {
+	t.Helper()
+
+	label := fmt.Sprintf("dc-%d", sid)
+	_, err := datachannel.Dial(p.client, sid, &datachannel.Config{
+		ChannelType:   datachannel.ChannelTypeReliable,
+		Label:         label,
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	require.NoError(t, err)
+
+	return label
+}
+
+func (p *acceptTestPeer) expectOpened(t *testing.T, labels []string, timeout time.Duration) {
+	t.Helper()
+
+	want := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		want[l] = struct{}{}
+	}
+	deadline := time.After(timeout)
+	for len(want) > 0 {
+		select {
+		case l := <-p.opened:
+			delete(want, l)
+		case err := <-p.closed:
+			require.FailNowf(t, "accept loop exited", "err=%v, still waiting for %v", err, want)
+		case <-deadline:
+			require.FailNowf(t, "data channels were not accepted", "still waiting for %v", want)
+		}
+	}
+}
+
+// waitForReset waits until the server resets the client's stream.
+func waitForReset(t *testing.T, stream *sctp.Stream, timeout time.Duration) {
+	t.Helper()
+
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 2048)
+		for {
+			if _, _, err := stream.ReadSCTP(buf); err != nil {
+				readErr <- err
+
+				return
+			}
+		}
+	}()
+
+	select {
+	case err := <-readErr:
+		assert.ErrorIs(t, err, io.EOF)
+	case <-time.After(timeout):
+		require.FailNow(t, "server never closed the stuck stream")
+	}
+}
+
+// A stream whose DCEP OPEN never arrives must neither block DataChannels
+// accepted after it nor stop the accept loop once its open times out.
+func TestSCTPTransportAcceptDataChannelsStuckOpen(t *testing.T) {
+	const (
+		stuckSID    = 1
+		openTimeout = 2 * time.Second
+	)
+	peer := newAcceptTestPeer(t, stuckSID, openTimeout)
+
+	start := time.Now()
+	stuck := peer.openStuckStream(t, stuckSID, sctp.PayloadTypeWebRTCDCEP, nil)
+
+	peer.expectOpened(t, []string{peer.dial(t, 3), peer.dial(t, 5), peer.dial(t, 7)}, openTimeout/2)
+	assert.Less(t, time.Since(start), openTimeout, "later channels were blocked behind the stuck open")
+
+	waitForReset(t, stuck, 5*openTimeout)
+
+	peer.expectOpened(t, []string{peer.dial(t, 9)}, 5*time.Second)
+}
+
+// A per-stream io.EOF while waiting for the DCEP OPEN (the peer reset the
+// stream) must close that stream only, not end the accept loop.
+func TestSCTPTransportAcceptDataChannelsStreamEOF(t *testing.T) {
+	const stuckSID = 1
+	// Long enough that only io.EOF, not the timeout, can end the open.
+	peer := newAcceptTestPeer(t, stuckSID, time.Minute)
+
+	// Partially reliable so the dropped tail is abandoned and the peer's
+	// stream reset below is not held back by the TSN gap.
+	stream := peer.openStuckStream(t, stuckSID, sctp.PayloadTypeWebRTCBinary, func(s *sctp.Stream) {
+		s.SetReliabilityParams(false, sctp.ReliabilityTypeRexmit, 1)
+	})
+
+	require.NoError(t, stream.Close())
+	// The server answers the peer's reset by resetting its own side, which
+	// only happens if it handled the io.EOF by closing the stream.
+	waitForReset(t, stream, 15*time.Second)
+
+	peer.expectOpened(t, []string{peer.dial(t, 3), peer.dial(t, 5)}, 5*time.Second)
+
+	select {
+	case err := <-peer.closed:
+		assert.Fail(t, "accept loop exited", "err=%v", err)
+	default:
+	}
+}

--- a/settingengine.go
+++ b/settingengine.go
@@ -85,14 +85,15 @@ type SettingEngine struct {
 		supportedProtocols            []string
 	}
 	sctp struct {
-		maxReceiveBufferSize uint32
-		enableZeroChecksum   bool
-		rtoMax               time.Duration
-		maxMessageSize       uint32
-		minCwnd              uint32
-		fastRtxWnd           uint32
-		cwndCAStep           uint32
-		enableSnap           bool
+		maxReceiveBufferSize   uint32
+		enableZeroChecksum     bool
+		rtoMax                 time.Duration
+		maxMessageSize         uint32
+		minCwnd                uint32
+		fastRtxWnd             uint32
+		cwndCAStep             uint32
+		enableSnap             bool
+		dataChannelOpenTimeout time.Duration
 	}
 	sdpMediaLevelFingerprints                 bool
 	answeringDTLSRole                         DTLSRole
@@ -673,6 +674,13 @@ func (e *SettingEngine) SetDTLSSupportedProtocols(protocols ...string) {
 // Leave this 0 for the default timeout.
 func (e *SettingEngine) SetSCTPRTOMax(rtoMax time.Duration) {
 	e.sctp.rtoMax = rtoMax
+}
+
+// SetSCTPDataChannelOpenTimeout sets how long an incoming SCTP stream may wait
+// for its DCEP DATA_CHANNEL_OPEN message before the stream is closed.
+// Leave this 0 for the default timeout.
+func (e *SettingEngine) SetSCTPDataChannelOpenTimeout(timeout time.Duration) {
+	e.sctp.dataChannelOpenTimeout = timeout
 }
 
 // SetSCTPMinCwnd sets the minimum congestion window size. The congestion window

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -398,6 +398,14 @@ func TestSetSCTPRTOMax(t *testing.T) {
 	assert.Equal(t, expSize, s.sctp.rtoMax)
 }
 
+func TestSetSCTPDataChannelOpenTimeout(t *testing.T) {
+	s := SettingEngine{}
+	assert.Equal(t, time.Duration(0), s.sctp.dataChannelOpenTimeout)
+
+	s.SetSCTPDataChannelOpenTimeout(3 * time.Second)
+	assert.Equal(t, 3*time.Second, s.sctp.dataChannelOpenTimeout)
+}
+
 func TestSetICEUseCandidateCheckPriority(t *testing.T) {
 	settingEngine := SettingEngine{}
 	assert.False(t, settingEngine.iceUseCandidateCheckPriority)


### PR DESCRIPTION
This replaces #3533, moved to a dedicated branch and rebased on current `main`.

#### Description

`SCTPTransport.acceptDataChannels` handles incoming streams one at a time: each iteration calls `datachannel.Accept`, which runs `datachannel.Server` and blocks on `stream.ReadSCTP` with no deadline until the DCEP DATA_CHANNEL_OPEN arrives. If one stream's OPEN never becomes readable, the loop stops and no further DataChannel is accepted. ICE and existing channels keep working, so the connection looks healthy but can no longer open channels.

This can happen under a burst of incoming channels:

1. The receive window is `maxReceiveBufferSize` minus the unread bytes in every stream's reassembly queue.
2. The peer opens many channels and sends data right after each OPEN (which RFC 8832 allows).
3. Streams waiting behind the blocked accept have no reader yet, so their data keeps the window full.
4. Once the window is full, `acceptPayloadData` drops incoming DATA. The stream is still created and queued on `acceptCh` before the drop. If the dropped chunk is a stream's OPEN, the accept loop waits on that stream.
5. The retransmitted OPEN can only be accepted once the window drains, and the window only drains when the streams queued behind the stuck accept are read. Neither can happen, so the loop waits forever.

Separately, an `io.EOF` from a single stream's OPEN read (the peer reset that stream) was treated as the association running out of streams, and the accept loop exited.

#### Changes

- `acceptDataChannels` now only calls `AcceptStream` and starts a goroutine per new stream. It exits only when `AcceptStream` fails.
- Each goroutine reads the OPEN with a read deadline, then clears the deadline. On any failure (timeout, `io.EOF`, invalid OPEN) it closes just that stream, so the peer sees a reset.
- The deadline defaults to 10s and can be changed with the new `SettingEngine.SetSCTPDataChannelOpenTimeout`.

Concurrency is what breaks the deadlock: streams behind a stuck one get their DataChannel and reader, the window drains, and the retransmitted OPEN is accepted. The deadline is a backstop for an OPEN that never arrives.

Behaviour changes:
- `OnDataChannel` can fire in a different order from the order the OPENs arrived.
- A malformed OPEN or a failed ACK write now closes only that stream. Before, it fired `OnError`/`OnClose` and stopped accepting.

#### Tests

`sctptransport_accept_test.go` connects two raw SCTP associations over `net.Pipe`. A wrapper on the client's connection strips every non-first DATA/I-DATA fragment on one stream, so the server accepts that stream but never gets a complete OPEN.

- `TestSCTPTransportAcceptDataChannelsStuckOpen`: later channels are accepted while the stuck stream is pending, the stuck stream is reset after the timeout, and accepting still works afterwards.
- `TestSCTPTransportAcceptDataChannelsStreamEOF`: the peer resets the stuck stream, the server closes only that stream, and later channels are still accepted.

Both tests fail on current `main`: in the first, later channels are never accepted; in the second, the server never closes the stuck stream. Both pass with this change under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
