### PR TITLE
Add separate SCTP handshake RTO max setting

### DIFF
--- a/sctptransport.go
+++ b/sctptransport.go
@@ -188,7 +188,7 @@ func (r *SCTPTransport) sctpClientOptions(netConn net.Conn, maxMessageSize uint3
 }
 
 func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
-	opts := make([]sctp.ClientOption, 0, 7)
+	opts := make([]sctp.ClientOption, 0, 8)
 
 	if r.api.settingEngine.sctp.maxReceiveBufferSize != 0 {
 		opts = append(opts, sctp.WithMaxReceiveBufferSize(r.api.settingEngine.sctp.maxReceiveBufferSize))
@@ -206,6 +206,15 @@ func (r *SCTPTransport) optionalSCTPClientOptions() []sctp.ClientOption {
 		opts = append(
 			opts,
 			sctp.WithRTOMax(float64(r.api.settingEngine.sctp.rtoMax)/float64(time.Millisecond)),
+		)
+	}
+
+	if r.api.settingEngine.sctp.handshakeRTOMax > 0 {
+		opts = append(
+			opts,
+			sctp.WithHandshakeRTOMax(
+				float64(r.api.settingEngine.sctp.handshakeRTOMax)/float64(time.Millisecond),
+			),
 		)
 	}
 

--- a/sctptransport_test.go
+++ b/sctptransport_test.go
@@ -131,6 +131,13 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 			wantExtra: 1,
 		},
 		{
+			name: "HandshakeRTOMax",
+			configure: func(se *SettingEngine) {
+				se.sctp.handshakeRTOMax = 150 * time.Millisecond
+			},
+			wantExtra: 1,
+		},
+		{
 			name: "MinCwnd",
 			configure: func(se *SettingEngine) {
 				se.sctp.minCwnd = 11
@@ -159,11 +166,12 @@ func TestSCTPTransport_sctpClientOptions_IncludesOptionalOptions(t *testing.T) {
 				se.detach.DataChannels = true
 				se.dataChannelBlockWrite = true
 				se.sctp.rtoMax = time.Second
+				se.sctp.handshakeRTOMax = 150 * time.Millisecond
 				se.sctp.minCwnd = 11
 				se.sctp.fastRtxWnd = 22
 				se.sctp.cwndCAStep = 33
 			},
-			wantExtra: 7,
+			wantExtra: 8,
 		},
 	}
 

--- a/settingengine.go
+++ b/settingengine.go
@@ -88,6 +88,7 @@ type SettingEngine struct {
 		maxReceiveBufferSize uint32
 		enableZeroChecksum   bool
 		rtoMax               time.Duration
+		handshakeRTOMax      time.Duration
 		maxMessageSize       uint32
 		minCwnd              uint32
 		fastRtxWnd           uint32
@@ -673,6 +674,13 @@ func (e *SettingEngine) SetDTLSSupportedProtocols(protocols ...string) {
 // Leave this 0 for the default timeout.
 func (e *SettingEngine) SetSCTPRTOMax(rtoMax time.Duration) {
 	e.sctp.rtoMax = rtoMax
+}
+
+// SetSCTPHandshakeRTOMax sets the maximum retransmission timeout for SCTP
+// T1-init and T1-cookie without changing the established association's DATA,
+// reconfiguration, or shutdown timers. Leave this 0 to inherit SCTP RTO max.
+func (e *SettingEngine) SetSCTPHandshakeRTOMax(rtoMax time.Duration) {
+	e.sctp.handshakeRTOMax = rtoMax
 }
 
 // SetSCTPMinCwnd sets the minimum congestion window size. The congestion window

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -756,11 +756,13 @@ func TestSettingEngine_SCTPSetters(t *testing.T) {
 	var se SettingEngine
 
 	se.EnableSCTPZeroChecksum(true)
+	se.SetSCTPHandshakeRTOMax(150 * time.Millisecond)
 	se.SetSCTPMinCwnd(11)
 	se.SetSCTPFastRtxWnd(22)
 	se.SetSCTPCwndCAStep(33)
 
 	assert.True(t, se.sctp.enableZeroChecksum)
+	assert.Equal(t, 150*time.Millisecond, se.sctp.handshakeRTOMax)
 	assert.Equal(t, uint32(11), se.sctp.minCwnd)
 	assert.Equal(t, uint32(22), se.sctp.fastRtxWnd)
 	assert.Equal(t, uint32(33), se.sctp.cwndCAStep)


### PR DESCRIPTION
## What changed

Add `SettingEngine.SetSCTPHandshakeRTOMax`, which caps the SCTP T1-init and T1-cookie retransmission timeout separately from `SetSCTPRTOMax`. When unset (0), the handshake timers keep inheriting the SCTP RTO max, so existing behavior is unchanged. DATA/T3, reconfiguration and shutdown timers are not affected.

## Why

With a single RTO max, applications have to choose between a large value, which makes association setup slow to retry, and a small value, which makes data retransmission overly aggressive. A separate handshake limit bounds connection setup time without changing data recovery.

## Dependencies

This depends on pion/sctp#496, which adds `WithHandshakeRTOMax`. It will not build against the current `pion/sctp` release, so it is opened as a draft; once #496 is merged and released it only needs the `pion/sctp` version bump.

## Validation

Against the pion/sctp#496 branch:
- `go build ./...`, `go vet .`
- `go test -race -run 'SCTP|SettingEngine|DataChannel' .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
